### PR TITLE
SLT-116 deploy each release in a project namespaces

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,8 @@ jobs:
       # Set environment variables for Helm.
       - run: |
           generate-kontena-config >> $BASH_ENV
-          echo 'export RELEASE_NAME="${CIRCLE_BRANCH//[^[:alnum:]]/-}"' >> $BASH_ENV
+          LOWERCASE_BRANCH=${CIRCLE_BRANCH,,}
+          echo "export RELEASE_NAME='${LOWERCASE_BRANCH//[^[:alnum:]]/-}'" >> $BASH_ENV
 
       - run: |
           echo $GCLOUD_KEY_JSON > ${HOME}/gcloud-service-key.json


### PR DESCRIPTION
To provide better isolation between projects and better visibility in the administrative backend, we can deploy each project in a dedicated namespace. 