### PR TITLE
Feature/slt 112 mvcreds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,6 @@ jobs:
       #     kubectl create secret generic $RELEASE_NAME-drupal-secrets \ 
       #     --namespace=$CIRCLE_PROJECT_REPONAME $ARGS
 
-
       - run: |
           helm dependency build ./chart
 
@@ -115,14 +114,8 @@ workflows:
     jobs:
       - phpcs
       - build:
-          context: 
-            - dev_wdr_io
-            - global_all
-            - global_nonprod
+          context: global_nonprod
       - deploy:
-          context: 
-            - dev_wdr_io
-            - global_all
-            - global_nonprod
+          context: global_nonprod
           requires:
             - build


### PR DESCRIPTION
now context created (`global_nonprod`) and assigned to build and deploy jobs (was `dev_wdr_io`)

In circle CI created context "`global_nonprod`" added following vars
```
DOCKER_PASSWORD	
DOCKER_REPO_HOST
DOCKER_REPO_ORG	
DOCKER_USER	
GCLOUD_EMAIL	
GCLOUD_KEY
GCLOUD_KEY_JSON
```

Kontena related vars that were in `dev_wdr_io` (`KONTENA_DOCKER_PASSWORD; ...`) abandoned

`DB_ROOT_PASS`, `DB_USER_PASS` : moved from context to project environment variables
`DOCKER_REPO_PROJ` : left in project environment variables

`EXTERNALREGISTRYENDPOINT=eu.gcr.io/silta-204108` - in project environment variables: deleted