### PR TITLE
Feature/slt 134 postupgrade split

### DIFF
--- a/chart/templates/postinstall.yaml
+++ b/chart/templates/postinstall.yaml
@@ -20,7 +20,7 @@ spec:
         {{ include "drupal.php-container" . | indent 8 }}
         command: ["/bin/sh", "-c"]
         args:
-        - {{ .Values.postinstall.commands | quote }}
+        - {{ .Values.drupal.postinstall.command | quote }}
       imagePullSecrets:
       - name: gcr
       volumes:

--- a/chart/templates/postupgrade.yaml
+++ b/chart/templates/postupgrade.yaml
@@ -20,7 +20,7 @@ spec:
         {{ include "drupal.php-container" . | indent 8 }}
         command: ["/bin/sh", "-c"]
         args:
-        - {{ .Values.postupgrade.commands | quote }}
+        - {{ .Values.drupal.postupgrade.command | quote }}
       imagePullSecrets:
       - name: gcr
       volumes:

--- a/chart/templates/postupgrade.yaml
+++ b/chart/templates/postupgrade.yaml
@@ -1,26 +1,26 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "{{ .Release.Name }}-postinstall"
+  name: "{{ .Release.Name }}-postupgrade"
   labels:
-    app: postinstall
+    app: postupgrade
     release: {{ .Release.Name }}
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
-    "helm.sh/hook": post-install
+    "helm.sh/hook": post-upgrade
     "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
 spec:
   template:
     spec:
       restartPolicy: Never
       containers:
-      - name: postinstall
+      - name: postupgrade
         {{ include "drupal.php-container" . | indent 8 }}
         command: ["/bin/sh", "-c"]
         args:
-        - {{ .Values.postinstall.commands | quote }}
+        - {{ .Values.postupgrade.commands | quote }}
       imagePullSecrets:
       - name: gcr
       volumes:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -15,6 +15,21 @@ drupal:
   privateFiles:
     enabled: false
 
+  postinstall:
+    command: |
+      cd web;
+      conf_count=$(ls ../config/sync/ | wc -l);
+      if [ $conf_count -gt 1 ]; then drush site-install -n config_installer;
+      else drush site-install minimal -y;
+      fi;
+
+  postupgrade:
+    command: |
+      cd web;
+      conf_count=$(ls ../config/sync/ | wc -l);
+      if [ $conf_count -gt 1 ]; then drush updatedb -n; drush config-import -n; drush entity-updates -n;
+      fi;
+
 mariadb:
   replication:
     enabled: false
@@ -27,18 +42,3 @@ mariadb:
 
 clusterDomain: "silta.wdr.io"
 branchname: "default"
-
-postinstall:
-  commands: |
-    cd web;
-    conf_count=$(ls ../config/sync/ | wc -l);
-    if [ $conf_count -gt 1 ]; then drush site-install -n config_installer;
-    else drush site-install minimal -y;
-    fi;
-
-postupgrade:
-  commands: |
-    cd web;
-    conf_count=$(ls ../config/sync/ | wc -l);
-    if [ $conf_count -gt 1 ]; then drush updatedb -n; drush config-import -n; drush entity-updates -n;
-    fi;

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -27,3 +27,18 @@ mariadb:
 
 clusterDomain: "silta.wdr.io"
 branchname: "default"
+
+postinstall:
+  commands: |
+    cd web;
+    conf_count=$(ls ../config/sync/ | wc -l);
+    if [ $conf_count -gt 1 ]; then drush site-install -n config_installer;
+    else drush site-install minimal -y;
+    fi;
+
+postupgrade:
+  commands: |
+    cd web;
+    conf_count=$(ls ../config/sync/ | wc -l);
+    if [ $conf_count -gt 1 ]; then drush updatedb -n; drush config-import -n; drush entity-updates -n;
+    fi;


### PR DESCRIPTION
**Story:**
https://wunder.atlassian.net/browse/SLT-134

**Description:**
splits post-install resource into two - one that gets triggered after new helm deployment install and another that is run after deployment update.

- Install checks for config files in sync folder. If they exist, installs site with a `config_installer` profile and imports said configuration. ~imports database dump from (shared) mounted location `/var/backups/db`. Shared NFS location must be deployed beforehand.~
 - Update imports config files, updates entitity configs and runs database updates.

---

Shared persistent volume resource for project
```
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: {{ .Release.Namespace }}-dbdump
  namespace: {{ .Release.Namespace }}
spec:
  storageClassName: nfs
  accessModes:
  - ReadWriteOnce
  resources:
    requests:
      storage: 10Gi
```