### PR TITLE
SLT-136: Trimming release name to comply with releasename 52 char length limitation.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,9 +66,14 @@ jobs:
       - checkout
 
       # Set the release name for later reuse.
+      # Release name length is 37 chars long, which leaves max 16 chars for kubernetes resource name.
+      # Release name is prefixed with w because  it _HAS_ to start with alphabetic character. w 4 wunder.
       - run: |
           LOWERCASE_BRANCH=${CIRCLE_BRANCH,,}
-          echo "export RELEASE_NAME='$CIRCLE_PROJECT_REPONAME--${LOWERCASE_BRANCH//[^[:alnum:]]/-}'" >> $BASH_ENV
+          REPONAME_HASH=$(echo $CIRCLE_PROJECT_REPONAME | shasum -a 256 | cut -c 1-8 )
+          BRANCHNAME_HASH=$(echo $LOWERCASE_BRANCH | shasum -a 256 | cut -c 1-8 )
+          BRANCHNAME_TRUNCATED=$(echo ${LOWERCASE_BRANCH//[^[:alnum:]]/-} | cut -c 1-20 )
+          echo "export RELEASE_NAME='w$REPONAME_HASH-$BRANCHNAME_HASH-$BRANCHNAME_TRUNCATED'" >> $BASH_ENV
 
       - run: |
           echo $GCLOUD_KEY_JSON > ${HOME}/gcloud-service-key.json
@@ -81,6 +86,7 @@ jobs:
           helm dependency build ./chart
 
           helm upgrade --install $RELEASE_NAME ./chart \
+            --set branchname=$CIRCLE_BRANCH \
             --set drupal.image=$DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/$CIRCLE_PROJECT_REPONAME-drupal:$CIRCLE_SHA1 \
             --set nginx.image=$DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/$CIRCLE_PROJECT_REPONAME-nginx:$CIRCLE_SHA1 \
             --set mariadb.rootUser.password=$DB_ROOT_PASS \

--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -22,7 +22,7 @@ spec:
             backend:
               serviceName: {{ .Release.Name }}-drupal
               servicePort: 80
-    - host: {{ .Release.Name }}.{{ .Release.Namespace }}.silta.wdr.io
+    - host: {{ regexReplaceAll "[^[:alnum:]]" .Values.branchname "-" | lower }}.{{ .Release.Namespace }}.silta.wdr.io
       http:
         paths:
           - path: /


### PR DESCRIPTION
Story:
https://wunder.atlassian.net/browse/SLT-136

Description:
- Changes release name to `w[projectname | sha256 | cut 8]-[branchname | sha256 | cut 8][normalized-branchname | cut 20]`. Sample release name: `w68f3d122-764d8b51-feature-slt-136-trim`
- Adds a `lowercase_branch` variable to `helm update` command so that ingress resource can still set nice name for domain (this can be removed once we centralize ingress). Sample domain: `feature-slt-136-trim-release-name-to-comply-with-length-limitations.drupal-project-k8s.silta.wdr.io`.