### PR TITLE
SLT-121 more tests

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -8,29 +8,55 @@ release: {{ .Release.Name }}
 {{ regexReplaceAll "[^[:alnum:]]" .Values.branchname "-" | lower }}.{{ .Release.Namespace }}.{{ .Values.clusterDomain }}
 {{- end -}}
 
+{{- define "drupal.php-container" }}
+image: {{ .Values.drupal.image | quote }}
+env: {{ include "drupal.env" . }}
+ports:
+  - containerPort: 9000
+    name: drupal
+volumeMounts:
+  - name: drupal-public-files
+    mountPath: /var/www/html/web/sites/default/files
+  {{- if .Values.drupal.privateFiles.enabled }}
+  - name: drupal-private-files
+    mountPath: /var/www/html/private
+  {{- end }}
+{{- end }}
+
+{{- define "drupal.volumes" }}
+- name: drupal-public-files
+  persistentVolumeClaim:
+    claimName: {{ .Release.Name }}-public-files
+{{- if .Values.drupal.privateFiles.enabled }}
+- name: drupal-private-files
+  persistentVolumeClaim:
+    claimName: {{ .Release.Name }}-private-files
+{{- end }}
+{{- end }}
+
 {{- define "drupal.env" }}
-    - name: DB_USER
-      value: "{{ .Values.mariadb.db.user }}"
-    - name: DB_NAME
-      value: "{{ .Values.mariadb.db.name }}"
-    - name: DB_HOST
-      value: {{ .Release.Name }}-mariadb
-    - name: DB_PASS
-      valueFrom:
-        secretKeyRef:
-          name: {{ .Release.Name }}-mariadb
-          key: mariadb-password
-    - name: HASH_SALT
-      valueFrom:
-        secretKeyRef:
-          name: {{ .Release.Name }}-secrets-drupal
-          key: hashsalt
-    {{- range $key, $val := .Values.drupal.env }}
-    - name: {{ $key }}
-      value: {{ $val | quote }}
-    {{- end }}
-    {{- if .Values.drupal.privateFiles.enabled }}
-    - name: PRIVATE_FILES_PATH
-      value: '/var/www/html/private'
-    {{- end }}
+- name: DB_USER
+  value: "{{ .Values.mariadb.db.user }}"
+- name: DB_NAME
+  value: "{{ .Values.mariadb.db.name }}"
+- name: DB_HOST
+  value: {{ .Release.Name }}-mariadb
+- name: DB_PASS
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Release.Name }}-mariadb
+      key: mariadb-password
+- name: HASH_SALT
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Release.Name }}-secrets-drupal
+      key: hashsalt
+{{- range $key, $val := .Values.drupal.env }}
+- name: {{ $key }}
+  value: {{ $val | quote }}
+{{- end }}
+{{- if .Values.drupal.privateFiles.enabled }}
+- name: PRIVATE_FILES_PATH
+  value: '/var/www/html/private'
+{{- end }}
 {{- end }}

--- a/chart/templates/drupal-cron.yaml
+++ b/chart/templates/drupal-cron.yaml
@@ -12,10 +12,10 @@ spec:
         spec:
           containers:
           - name: drupal-cron
-            image: "{{ .Values.drupal.image }}"
+            {{ include "drupal.php-container" . | indent 12 }}
             command:
             - drush
             - cron
-            env:
-            {{ include "drupal.env" . | indent 8 }}
           restartPolicy: OnFailure
+          volumes:
+            {{ include "drupal.volumes" . | indent 12 }}

--- a/chart/templates/drupal-deployment.yaml
+++ b/chart/templates/drupal-deployment.yaml
@@ -21,19 +21,7 @@ spec:
       containers:
       # php-fpm container.
       - name: drupal
-        image: {{ .Values.drupal.image | quote }}
-        env:
-        {{ include "drupal.env" . | indent 4 }}
-        ports:
-        - containerPort: 9000
-          name: drupal
-        volumeMounts:
-        - name: drupal-public-files
-          mountPath: /var/www/html/web/sites/default/files
-        {{- if .Values.drupal.privateFiles.enabled }}
-        - name: drupal-private-files
-          mountPath: /var/www/html/private
-        {{- end }}
+        {{ include "drupal.php-container" . | indent 8}}
 
       # Nginx container
       - name: nginx
@@ -60,11 +48,4 @@ spec:
       imagePullSecrets:
       - name: gcr
       volumes:
-      - name: drupal-public-files
-        persistentVolumeClaim:
-          claimName: {{ .Release.Name }}-public-files
-      {{- if .Values.drupal.privateFiles.enabled }}
-      - name: drupal-private-files
-        persistentVolumeClaim:
-          claimName: {{ .Release.Name }}-private-files
-      {{- end }}
+        {{ include "drupal.volumes" . | indent 8}}

--- a/chart/templates/postinstall.yaml
+++ b/chart/templates/postinstall.yaml
@@ -17,21 +17,14 @@ spec:
       restartPolicy: Never
       containers:
       - name: postinstall
-        image: {{ .Values.drupal.image | quote }}
+        {{ include "drupal.php-container" . | indent 8 }}
         command: ["/bin/sh", "-c"]
         args:
         - cd web;
           bootstrapped=$(drush status --field=bootstrap);
           if [[ $bootstrapped = *'Success'* ]]; then drush updatedb -n; drush config-import -n; drush entity-updates -n;
           else drush site-install -n config_installer; conf_count=$(ls ../config/sync/ | wc -l); if [ $conf_count -lt 2 ]; then drush site-install minimal -y; fi; fi;
-        env:
-        {{ include "drupal.env" . | indent 4 }}
-        volumeMounts:
-          - name: drupal-files-volume
-            mountPath: /var/www/html/web/sites/default/files
       imagePullSecrets:
       - name: gcr
       volumes:
-      - name: drupal-files-volume
-        persistentVolumeClaim:
-          claimName: {{ .Release.Name }}-public-files
+        {{ include "drupal.volumes" . | indent 8 }}

--- a/chart/tests/drupal_cron_test.yaml
+++ b/chart/tests/drupal_cron_test.yaml
@@ -2,6 +2,11 @@ suite: drupal cron jobs
 templates:
   - drupal-cron.yaml
 tests:
+  - it: is a cron job
+    asserts:
+      - isKind:
+          of: CronJob
+
   - it: uses the right docker image
     set:
       drupal.image: 'drupal-12345'

--- a/chart/tests/drupal_cron_test.yaml
+++ b/chart/tests/drupal_cron_test.yaml
@@ -1,0 +1,31 @@
+suite: drupal cron jobs
+templates:
+  - drupal-cron.yaml
+tests:
+  - it: uses the right docker image
+    set:
+      drupal.image: 'drupal-12345'
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].image
+          value: 'drupal-12345'
+
+  - it: sets environment variables correctly
+    set:
+      drupal.env:
+        foo: bar
+    asserts:
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].env
+          content:
+            name: foo
+            value: bar
+
+  - it: has public files mounted
+    asserts:
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.volumes
+          content:
+            name: "drupal-public-files"
+            persistentVolumeClaim:
+              claimName: RELEASE-NAME-public-files

--- a/chart/tests/drupal_deployment_test.yaml
+++ b/chart/tests/drupal_deployment_test.yaml
@@ -2,6 +2,11 @@ suite: drupal deployment
 templates:
   - drupal-deployment.yaml
 tests:
+  - it: is a deployment
+    asserts:
+      - isKind:
+          of: Deployment
+
   - it: uses the right docker images
     set:
       drupal.image: 'drupal-12345'

--- a/chart/tests/drupal_postinstall_test.yaml
+++ b/chart/tests/drupal_postinstall_test.yaml
@@ -1,0 +1,31 @@
+suite: drupal post-install hook
+templates:
+  - postinstall.yaml
+tests:
+  - it: uses the right docker image
+    set:
+      drupal.image: 'drupal-12345'
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: 'drupal-12345'
+
+  - it: sets environment variables correctly
+    set:
+      drupal.env:
+        foo: bar
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: foo
+            value: bar
+
+  - it: has public files mounted
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: "drupal-public-files"
+            persistentVolumeClaim:
+              claimName: RELEASE-NAME-public-files

--- a/chart/tests/drupal_postinstall_test.yaml
+++ b/chart/tests/drupal_postinstall_test.yaml
@@ -2,6 +2,11 @@ suite: drupal post-install hook
 templates:
   - postinstall.yaml
 tests:
+  - it: is a helm hook
+    asserts:
+      - isKind:
+          of: Job
+
   - it: uses the right docker image
     set:
       drupal.image: 'drupal-12345'

--- a/chart/tests/private_files_test.yaml
+++ b/chart/tests/private_files_test.yaml
@@ -2,6 +2,8 @@ suite: drupal private files
 templates:
   - drupal-deployment.yaml
   - drupal-volumes.yaml
+  - postinstall.yaml
+  - drupal-cron.yaml
 tests:
   - it: private files should be disabled by default
     asserts:
@@ -37,7 +39,25 @@ tests:
             value: '/var/www/html/private'
 
       # There are two volumes defined.
-      - hasDocuments:
+      - template: drupal-volumes.yaml
+        hasDocuments:
           count: 2
-        template: drupal-volumes.yaml
+
+      # Private files are available for cron jobs.
+      - template: drupal-cron.yaml
+        contains:
+          path: spec.jobTemplate.spec.template.spec.volumes
+          content:
+            name: "drupal-private-files"
+            persistentVolumeClaim:
+              claimName: RELEASE-NAME-private-files
+
+      # Private files are available for in the post-install hooks.
+      - template: postinstall.yaml
+        contains:
+          path: spec.template.spec.volumes
+          content:
+            name: "drupal-private-files"
+            persistentVolumeClaim:
+              claimName: RELEASE-NAME-private-files
 


### PR DESCRIPTION
Adding some additional tests pointed out that some things were missing in a few places: cron was missing volumes, postinstall was missing private files. Fixing these issues was done by defining the php container as a template, similar to what was done in https://github.com/wunderio/charts/pull/8/files. 