### PR TITLE
SLT-147: make pull secrets for docker images configurable

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -34,6 +34,13 @@ volumeMounts:
 {{- end }}
 {{- end }}
 
+{{- define "drupal.imagePullSecrets" }}
+{{- if .Values.imagePullSecrets }}
+imagePullSecrets:
+{{ .Values.imagePullSecrets | toYaml }}
+{{- end }}
+{{- end }}
+
 {{- define "drupal.env" }}
 - name: DB_USER
   value: "{{ .Values.mariadb.db.user }}"

--- a/chart/templates/drupal-cron.yaml
+++ b/chart/templates/drupal-cron.yaml
@@ -19,3 +19,5 @@ spec:
           restartPolicy: OnFailure
           volumes:
             {{ include "drupal.volumes" . | indent 12 }}
+
+          {{ include "drupal.imagePullSecrets" . | indent 10 }}

--- a/chart/templates/drupal-deployment.yaml
+++ b/chart/templates/drupal-deployment.yaml
@@ -45,7 +45,7 @@ spec:
         - name: drupal-public-files
           mountPath: /var/www/html/web/sites/default/files
 
-      imagePullSecrets:
-      - name: gcr
       volumes:
         {{ include "drupal.volumes" . | indent 8}}
+
+      {{ include "drupal.imagePullSecrets" . | indent 6 }}

--- a/chart/templates/postinstall.yaml
+++ b/chart/templates/postinstall.yaml
@@ -24,7 +24,8 @@ spec:
           bootstrapped=$(drush status --field=bootstrap);
           if [[ $bootstrapped = *'Success'* ]]; then drush updatedb -n; drush config-import -n; drush entity-updates -n;
           else drush site-install -n config_installer; conf_count=$(ls ../config/sync/ | wc -l); if [ $conf_count -lt 2 ]; then drush site-install minimal -y; fi; fi;
-      imagePullSecrets:
-      - name: gcr
+
+      {{ include "drupal.imagePullSecrets" . | indent 6 }}
+
       volumes:
         {{ include "drupal.volumes" . | indent 8 }}

--- a/chart/tests/private_docker_image_test.yaml
+++ b/chart/tests/private_docker_image_test.yaml
@@ -1,0 +1,34 @@
+suite: private docker image
+templates:
+  - drupal-deployment.yaml
+  - drupal-cron.yaml
+  - postinstall.yaml
+tests:
+  - it: has no image pull secret by default
+    asserts:
+      - isNull:
+          path: spec.template.spec.imagePullSecrets
+
+  - it: sets the image pull secret
+    set:
+      imagePullSecrets:
+        - name: gcr
+
+    asserts:
+     - contains:
+         path: spec.template.spec.imagePullSecrets
+         content:
+           name: gcr
+
+     - template: drupal-cron.yaml
+       contains:
+         path: spec.jobTemplate.spec.template.spec.imagePullSecrets
+         content:
+           name: gcr
+
+     - template: postinstall.yaml
+       contains:
+         path: spec.template.spec.imagePullSecrets
+         content:
+           name: gcr
+

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -25,5 +25,11 @@ mariadb:
     user: drupal
     password: "{{ randAlphaNum 10 }}" # pass in a value to your helm chart to override this
 
+# Cluster configuration.
 clusterDomain: "silta.wdr.io"
+
+# Configure image pull secrets for the containers. This is not needed on GKE.
+# See https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+imagePullSecrets: []
+
 branchname: "default"


### PR DESCRIPTION
Based on https://github.com/wunderio/charts/pull/7

We do not actually need to have pull secrets configured on GKE. When we do, these should be based on a single configuration entry.