### PR TITLE
SLT-99 configurable cron

### DIFF
--- a/chart/templates/drupal-cron.yaml
+++ b/chart/templates/drupal-cron.yaml
@@ -19,8 +19,8 @@ spec:
               - {{ $job.command | quote }}
           restartPolicy: OnFailure
           volumes:
-            {{ include "drupal.volumes" . | indent 12 }}
+            {{ include "drupal.volumes" $ | indent 12 }}
 
-          {{ include "drupal.imagePullSecrets" . | indent 10 }}
+          {{ include "drupal.imagePullSecrets" $ | indent 10 }}
 ---
 {{- end }}

--- a/chart/templates/drupal-cron.yaml
+++ b/chart/templates/drupal-cron.yaml
@@ -1,9 +1,10 @@
+{{- range $index, $job := .Values.drupal.cron }}
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  name: {{ .Release.Name }}-cron
+  name: {{ $.Release.Name }}-cron-{{ $index }}
 spec:
-  schedule: "0 * * * *"
+  schedule: {{ $job.schedule | quote }}
   concurrencyPolicy: Forbid
   backOffLimit: 3
   jobTemplate:
@@ -12,10 +13,12 @@ spec:
         spec:
           containers:
           - name: drupal-cron
-            {{ include "drupal.php-container" . | indent 12 }}
-            command:
-            - drush
-            - cron
+            {{ include "drupal.php-container" $ | indent 12 }}
+            command: ["/bin/sh", "-c"]
+            args:
+              - {{ $job.command | quote }}
           restartPolicy: OnFailure
           volumes:
-            {{ include "drupal.volumes" . | indent 12 }}
+            {{ include "drupal.volumes" $ | indent 12 }}
+---
+{{- end }}

--- a/chart/tests/drupal_cron_test.yaml
+++ b/chart/tests/drupal_cron_test.yaml
@@ -34,3 +34,30 @@ tests:
             name: "drupal-public-files"
             persistentVolumeClaim:
               claimName: RELEASE-NAME-public-files
+
+  - it: runs multiple jobs
+    set:
+      drupal.cron:
+        - command: foo
+          schedule: "0 * * * *"
+        - command: bar
+          schedule: "30 * * * *"
+    asserts:
+      - hasDocuments:
+          count: 2
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].args[0]
+          value: 'foo'
+        documentIndex: 0
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].args[0]
+          value: 'bar'
+        documentIndex: 1
+      - equal:
+          path: spec.schedule
+          value: "0 * * * *"
+        documentIndex: 0
+      - equal:
+          path: spec.schedule
+          value: "30 * * * *"
+        documentIndex: 1

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -4,6 +4,11 @@ nginx:
   image: 'you need to pass in a value for nginx.image to your helm chart'
 drupal:
   image: 'you need to pass in a value for drupal.image to your helm chart'
+
+  cron:
+    - schedule: '0 * * * *'
+      command: 'drush cron'
+
   # will be generated random hashsalt if not provided here
   # need to be base64 encoded
   hashsalt: "template-hash-salt" 


### PR DESCRIPTION
Based on the work done by Agnis in https://github.com/wunderio/drupal-project-k8s/tree/feature/SLT-99-cron and by Jonathan in https://github.com/wunderio/charts/pull/3/files

We want to enable multiple cron jobs, for example, one for `drush cron`, and one for a dedicated queue. The use of the root scope `$` greatly simplifies the use of global variables in a loop.