### PR TITLE
Feature/configmaps (SLT-148; SLT-144)

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -21,6 +21,18 @@ volumeMounts:
   - name: drupal-private-files
     mountPath: /var/www/html/private
   {{- end }}
+  - name: php-conf
+    mountPath: /etc/php7/php.ini
+    readOnly: true
+    subPath: php.ini
+  - name: php-conf
+    mountPath: /etc/php7/php-fpm.conf
+    readOnly: true
+    subPath: php-fpm.conf
+  - name: php-conf
+    mountPath: /etc/php7/php-fpm.d/www.conf
+    readOnly: true
+    subPath: php-fpm.d/www.conf
 {{- end }}
 
 {{- define "drupal.volumes" }}
@@ -32,6 +44,16 @@ volumeMounts:
   persistentVolumeClaim:
     claimName: {{ .Release.Name }}-private-files
 {{- end }}
+- name: php-conf
+  configMap:
+    name: {{ .Release.Name }}-php-conf
+    items:
+      - key: php.ini
+        path: php.ini
+      - key: php-fpm.conf
+        path: php-fpm.conf
+      - key: www.conf
+        path: php-fpm.d/www.conf
 {{- end }}
 
 {{- define "drupal.imagePullSecrets" }}

--- a/chart/templates/drupal-configmap-nginx.yaml
+++ b/chart/templates/drupal-configmap-nginx.yaml
@@ -1,0 +1,391 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-conf
+data:
+  nginx.conf: |
+    user                            nginx;                                                 
+    worker_processes                auto;                                                  
+    error_log                       /proc/self/fd/2 {{ .Values.nginx.loglevel }};                                 
+                                                                                          
+    events {                                                                               
+        worker_connections          1024;                                                  
+        multi_accept                on;                                                    
+    }                                                                                      
+                                                                                          
+    http {                                                                                 
+        include                     /etc/nginx/mime.types;                                 
+        default_type                application/octet-stream;                              
+                                                                                          
+        log_format                  real_ip '$http_x_real_ip - $remote_user [$time_local] '
+                                            '"$request" $status $body_bytes_sent '
+                                            '"$http_referer" "$http_user_agent"';
+                                                            
+                                                                                                              
+        access_log                  /proc/self/fd/1 combined;
+                                              
+        send_timeout                60s;       
+        sendfile                    on;        
+        client_body_timeout         60s;       
+        client_header_timeout       60s;                                                                                                                   
+        client_max_body_size        32m;                                                                                                                   
+        client_body_buffer_size     16k;                                                                                                                   
+        client_header_buffer_size   4k;                                                                                                                    
+        large_client_header_buffers 8 16K;                                                                                                                 
+        keepalive_timeout           75s;                                                                                                                   
+        keepalive_requests          100;                                                                                                                   
+        reset_timedout_connection   off;                                                                                                                   
+        tcp_nodelay                 on;                                                                                                                    
+        tcp_nopush                  on;                                                                                                                    
+        server_tokens               off;                                                                                                                   
+                                                                                                                                                          
+        ## upload_progress             uploads 1m;          
+                                              
+        gzip                        on;                      
+        gzip_buffers                16 8k;     
+        gzip_comp_level             1;         
+        gzip_http_version           1.1;       
+        gzip_min_length             20;        
+        gzip_types                  text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascrip
+        gzip_vary                   on;                                                                                                                    
+        gzip_proxied                any;       
+        gzip_disable                msie6;                                                                                                                 
+                                                                                                                                                          
+        ## https://www.owasp.org/index.php/List_of_useful_HTTP_headers.                                                                                                                                                   
+        add_header                  X-XSS-Protection '1; mode=block';                                                                                      
+        add_header                  X-Frame-Options SAMEORIGIN;                                                                                            
+        add_header                  X-Content-Type-Options nosniff;
+        add_header                  Strict-Transport-Security max-age=31536000;
+        add_header                  X-XSS-Protection '1; mode=block';                                                                                                                                              
+                                                                    
+        map $uri $no_slash_uri {                                                                                                                           
+            ~^/(?<no_slash>.*)$ $no_slash;                                                                                                                 
+        }                                                            
+                                                                                                                                                          
+        include conf.d/*.conf;                                                                                                                             
+    }     
+
+  drupal.conf: |
+    upstream php {                                                  
+        server localhost:9000;                   
+    }                            
+                                              
+    map $http_x_forwarded_proto $fastcgi_https {                                                        
+        default $https;                                            
+        http '';                          
+        https on;                          
+    }                                      
+                                          
+    server {                               
+        server_name drupal;                          
+        listen 80;          
+                                        
+        root /var/www/html/web;                                     
+        index index.php;
+                                                                              
+        include fastcgi.conf;
+                                          
+                                              
+        location / {                                                        
+                                                    
+            location ~* /system/files/ {
+                include fastcgi.conf;                                                                                                                      
+                fastcgi_param QUERY_STRING q=$uri&$args;
+                fastcgi_param SCRIPT_NAME /index.php;
+                fastcgi_param SCRIPT_FILENAME $document_root/index.php;     
+                fastcgi_pass php;  
+                log_not_found off;         
+            }                    
+                                            
+            location ~* /sites/.+/files/private/ {
+                internal;                                          
+            }                              
+
+            location ~* /sites/.+/files/.+\.txt {    
+                access_log off;                                        
+                expires 30d;                            
+                tcp_nodelay off;                                                                        
+                open_file_cache off;                                   
+                open_file_cache_valid 45s;                             
+                open_file_cache_min_uses 2;                            
+                open_file_cache_errors off;                            
+            }                                                                                                   
+                                                                              
+            location ~* /admin/reports/hacked/.+/diff/ {                    
+                try_files $uri @drupal;                                        
+            }                                                                  
+                                                                              
+            location ~* /rss.xml {                                             
+                try_files $uri @drupal-no-args;                                
+            }  
+
+            location ~* /sitemap.xml {                                      
+                try_files $uri @drupal;                                        
+            }                                                                                                                             
+                                                                                                        
+            location ~* ^.+\.(?:pdf|pptx?)$ {                                                           
+                expires 30d;                                                   
+                tcp_nodelay off;                                                                        
+            }                                                                  
+                                                                                                        
+            ## Handle D7 image styles
+            location ~* /files/styles/ {
+                expires 365d;
+                try_files $uri @drupal;
+            }
+
+            ## Advanced Help module makes each module provided README available.
+            location ~* ^/help/[^/]*/README\.txt$ {
+                try_files $uri @drupal;
+            }
+
+            ## Regular private file serving (i.e. handled by Drupal).
+            location ~ /system/files/ {
+                try_files $uri @drupal;
+                log_not_found off;
+            }
+
+            ## Allow download of .txt files from files directory
+            location ~* ^/sites/.*/files/(?:.+\.(?:txt)) {
+                tcp_nodelay     off;
+                expires         30d;
+                try_files $uri =404;
+                log_not_found off;
+            }
+
+            ## Replicate the Apache <FilesMatch> directive of Drupal standard
+            ## .htaccess. Disable access to any code files. Return a 404 to curtail
+            ## information disclosure. Hide also the text files.
+            location ~* ^(?:.+\.(?:htaccess|make|txt|engine|inc|info|module|profile|po|sh|.*sql|csv|yml|test|theme|tpl(?:\.php)?|xtmpl|config)|code-style\.pl|/Entries.*|/Repository|/Root|/Tag|/Template)$ {
+                return 404;
+            }
+
+            ###
+            ### Advagg_css and Advagg_js support.
+            ###
+            location ~* files/advagg_(?:css|js)/ {
+                expires       max;
+                etag          off;
+                access_log    off;
+                log_not_found off;
+                ## Set the OS file cache.
+                open_file_cache max=3000 inactive=120s;
+                open_file_cache_valid 45s;
+                open_file_cache_min_uses 2;
+                open_file_cache_errors off;
+                add_header Cache-Control "no-transform, public";
+                add_header Last-Modified "Wed, 20 Jan 1988 04:20:42 GMT";
+                add_header Access-Control-Allow-Origin *;
+                add_header X-Header "AdvAgg Generator 2.0 CDN";
+                try_files $uri @drupal;
+            }
+
+            ## Serve static files & images directly, without all standard drupal rewrites, php-fpm etc.
+            location ~* ^.+\.(?:css|js|jpe?g|gif|png|ico|svg|swf|docx?|xlsx?|tiff?|txt|cgi|bat|pl|dll|aspx?|exe|class)$ {
+                tcp_nodelay     off;
+                expires         365d;
+                add_header Cache-Control "public";
+                ## Set the OS file cache.
+                open_file_cache max=10000 inactive=120s;
+                open_file_cache_valid 45s;
+                open_file_cache_min_uses 2;
+                open_file_cache_errors off;
+                try_files $uri =404;
+                log_not_found off;
+                access_log off;
+            }
+
+            ## PDFs and powerpoint files handling.
+            location ~* ^.+\.(?:pdf|pptx?)$ {
+                expires 30d;
+                ## No need to bleed constant updates. Send the all shebang in one
+                ## fell swoop.
+                tcp_nodelay off;
+            }
+
+            # Configure webfont access
+            location ~* \.(?:ttf|ttc|otf|eot|woff|woff2|font.css)$ {
+                # Uncomment to allow cross domain webfont access
+                # Set cache rules for webfonts.
+                expires 365d;
+                add_header Cache-Control "public";
+                ## Set the OS file cache.
+                open_file_cache max=10000 inactive=120s;
+                open_file_cache_valid 45s;
+                open_file_cache_min_uses 2;
+                open_file_cache_errors off;
+                try_files $uri =404;
+                log_not_found off;
+                access_log off;
+            }
+
+            ## Serve bigger media/static/archive files directly, without all standard drupal rewrites, php-fpm etc.
+            location ~* ^.+\.(?:avi|mpe?g|mov|wmv|mp3|mp4|m4a|ogg|flv|wav|midi|zip|tar|t?gz|rar)$ {
+                expires         365d;
+                tcp_nodelay     off;
+                try_files $uri =404;
+                log_not_found off;
+                access_log off;
+            }
+
+            ## Deny bots on never cached uri without 403 response.
+            location ~* ^/(?:user|admin|cart|checkout|logout|abuse|flag) {
+                if ( $http_user_agent ~* (?:crawl|goog|yahoo|spider|bot|yandex|bing|tracker|click|parser) ) {
+                return 444;
+                }
+                try_files $uri @drupal;
+            }
+
+            location = /robots.txt {
+                add_header  Content-Type  text/plain;
+                return 200 "User-agent: *\nDisallow: /\n";
+            }
+
+            location = /radioactivity_node.php {
+                try_files $uri @drupal;
+            }
+
+            ## Allow radioactivity to work.
+            location ~* /emit.php {
+                include fastcgi.conf;
+                fastcgi_param  SCRIPT_FILENAME    $document_root/sites/all/modules/contrib/radioactivity/emit.php;
+                fastcgi_pass php;
+            }
+
+            # This is cool because no php is touched for static content                                                                                                                                                                                                                                                                                                   
+            try_files $uri @drupal;                                                                                                                        
+        }                                                                                                                                                  
+                                                                                                                                                                                                                                                                                                                                                                                                        
+        location @drupal {                                                                                                                                 
+            include fastcgi.conf;                                                                                                                          
+            fastcgi_param QUERY_STRING $query_string;                                                                                                      
+            fastcgi_param SCRIPT_NAME /index.php;                                                                                                          
+            fastcgi_param SCRIPT_FILENAME $document_root/index.php;                                     
+            fastcgi_pass php;                                                                                                                                                                                                                                                 
+        }
+
+        location @drupal-no-args {                                                                                                                         
+            include fastcgi.conf;                                                                                                                          
+            fastcgi_param QUERY_STRING q=$uri;                                                          
+            fastcgi_param SCRIPT_NAME /index.php;                                                                                                          
+            fastcgi_param SCRIPT_FILENAME $document_root/index.php;                                                                                        
+            fastcgi_pass php;                                                                                                                              
+        }                                                                                                                                                  
+                                                                                                                                                          
+        location = /index.php {                                                                         
+            fastcgi_pass php;                                                                                                                              
+        }
+
+        location ~* ^/core/authorize.php {                                                                                                                 
+            include fastcgi.conf;                                                                                                                          
+            fastcgi_param QUERY_STRING $args;                                                                                                              
+            fastcgi_param SCRIPT_NAME /core/authorize.php;                                                                                                 
+            fastcgi_param SCRIPT_FILENAME $document_root/core/authorize.php;                                                                               
+            fastcgi_pass php;                                                  
+        }                                                                                                                                                  
+                                                                                                                                                          
+        location = /core/modules/statistics/statistics.php {                                                                                               
+            fastcgi_pass php;                                                                                                                              
+        }                                                                                                                                                  
+                                                                                                                                                          
+        location = /cron {                                                                                                                                 
+            include fastcgi.conf;                                                                                                                          
+            fastcgi_param QUERY_STRING $args;                                                                                                              
+            fastcgi_param SCRIPT_NAME /index.php;                                                       
+            fastcgi_param SCRIPT_FILENAME $document_root/index.php;                                                                                        
+            fastcgi_pass php;                                                                                                                              
+        }
+
+        location ~* ^/update.php {                                                                                                                         
+            include fastcgi.conf;                                                                                                                          
+            fastcgi_param QUERY_STRING $args;                                                           
+            fastcgi_param SCRIPT_NAME /update.php;                                                                                                         
+            fastcgi_param SCRIPT_FILENAME $document_root/update.php;                                                                                       
+            fastcgi_pass php;                                                                                                                              
+        }                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     
+                                                                                                                                                          
+        location = /robots.txt {                                                                        
+            access_log off;                                                                                                                                
+            try_files $uri @drupal-no-args;                                                                                                                
+        } 
+                                                                                                                                                                                                  
+        location ~* ^/.well-known/ {                                                                                                                       
+            allow all;                                                                                                                                     
+        }                                                                                                                                                  
+                                                                                                                                                          
+        location @empty {                                                                                                                                  
+            expires 30d;                                                       
+            empty_gif;                                                                                                                                     
+        }
+
+        location = /authorize.php {
+            include fastcgi.conf;
+            fastcgi_param  SCRIPT_FILENAME    $document_root/authorize.php;
+            fastcgi_pass php;
+        }
+
+        ## Run the update from the web interface with Drupal 7.
+        location = /update.php {
+            include fastcgi.conf;
+            fastcgi_param  SCRIPT_FILENAME    $document_root/update.php;
+            fastcgi_pass php;
+        }
+
+        ## Run the install from the web interface with Drupal 7.
+        location = /install.php {
+            include fastcgi.conf;
+            fastcgi_param  SCRIPT_FILENAME    $document_root/install.php;
+            fastcgi_pass php;
+        }
+
+        ## Run the install from the web interface with Drupal 8.
+        location = /core/install.php {
+            include fastcgi.conf;
+            fastcgi_param  SCRIPT_FILENAME    $document_root/core/install.php;
+            fastcgi_pass php;
+        }
+
+        ## Allow running _ping.php
+        location = /_ping.php {
+            include fastcgi.conf;
+            fastcgi_param  SCRIPT_FILENAME    $document_root/_ping.php;
+            fastcgi_pass php;
+            access_log off;
+        }
+
+        # Handle autocomplete to-cleanURLs policy
+        if ( $args ~* "^q=(?<query_value>.*)" ) {
+            rewrite ^/index.php$ $host/?q=$query_value? permanent;
+        }
+
+        ## Disallow access to patches directory.
+        location ^~ /patches { return 404; }
+
+        ## Disallow access to drush backup directory.
+        location ^~ /backup { return 404; }
+
+        ## Most sites won't have configured favicon
+        ## and since its always grabbed, turn it off in access log
+        ## and turn off it's not-found error in the error log
+        location = /favicon.ico { access_log off; log_not_found off; try_files /favicon.ico @empty; }
+
+        ## Same for apple-touch-icon files
+        location = /apple-touch-icon.png { access_log off; log_not_found off; }
+        location = /apple-touch-icon-precomposed.png { access_log off; log_not_found off; }
+
+        ## Return an in memory 1x1 transparent GIF.
+        location @empty {
+            expires 30d;
+            empty_gif;
+        }
+
+        ## Rather than just denying .ht* in the config, why not deny
+        ## access to all .invisible files
+        location ~ /\. { return 404; access_log off; log_not_found off; }
+
+        ## Any other attempt to access PHP files returns a 404.
+        location ~* ^.+\.php$ {
+            return 404;
+        }                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              
+                                                                                                                                                                                                                                                                                                                                                                    
+    } 

--- a/chart/templates/drupal-configmap-nginx.yaml
+++ b/chart/templates/drupal-configmap-nginx.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: nginx-conf
+  name: {{ .Release.Name }}-nginx-conf
 data:
   nginx.conf: |
     user                            nginx;                                                 

--- a/chart/templates/drupal-configmap-php.yaml
+++ b/chart/templates/drupal-configmap-php.yaml
@@ -1,0 +1,171 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-php-conf
+data:
+  php.ini: |
+    [PHP]
+    engine = On
+    short_open_tag = Off
+    precision = -1
+    output_buffering = 4096
+    zlib.output_compression = Off
+    implicit_flush = Off
+    unserialize_callback_func =
+    serialize_precision = -1
+    disable_classes =
+    realpath_cache_size = 32k
+    realpath_cache_ttl = 120
+    zend.enable_gc = On
+    expose_php = Off
+    max_execution_time = 60
+    max_input_time = 60
+    memory_limit = 256M
+    error_reporting = E_ALL
+    display_errors = 0
+    display_startup_errors = 0
+    log_errors = 1
+    log_errors_max_len = 10240
+    ignore_repeated_errors = Off
+    ignore_repeated_source = Off
+    report_memleaks = On
+    track_errors = 0
+    html_errors = On
+    variables_order = EGPCS
+    request_order = GP
+    register_argc_argv = Off
+    auto_globals_jit = On
+    post_max_size = {{ .Values.drupal.php.post_max_size }};
+    auto_prepend_file =
+    auto_append_file =
+    default_mimetype = "text/html"
+    default_charset = "UTF-8"
+    doc_root =
+    user_dir =
+    enable_dl = Off
+    cgi.fix_pathinfo = 0
+    file_uploads = On
+    upload_max_filesize = {{ .Values.drupal.php.upload_max_filesize }};
+    max_file_uploads = 20
+    allow_url_fopen = On
+    allow_url_include = Off
+    default_socket_timeout = 60
+
+    [CLI Server]
+    cli_server.color = On
+
+    [Date]
+    date.timezone = Europe/Helsinki
+    
+    [Pdo_mysql]
+    pdo_mysql.cache_size = 2000
+    pdo_mysql.default_socket =
+
+    [mail function]
+    mail.add_x_header = Off
+
+    [SQL]
+    sql.safe_mode = Off
+
+    [MySQLi]
+    mysqli.max_persistent = -1
+    mysqli.allow_persistent = On
+    mysqli.max_links = -1
+    mysqli.cache_size = 2000
+    mysqli.default_port = 3306
+    mysqli.reconnect = Off
+
+    [mysqlnd]
+    mysqlnd.collect_statistics = On
+    mysqlnd.collect_memory_statistics = Off
+
+    [PostgreSQL]
+    pgsql.allow_persistent = On
+    pgsql.auto_reset_persistent = Off
+    pgsql.max_persistent = -1
+    pgsql.max_links = -1
+    pgsql.ignore_notice = 0
+    pgsql.log_notice = 0
+
+    [bcmath]
+    bcmath.scale = 0
+
+    [Session]
+    session.save_handler = files
+    session.save_path = /tmp
+    session.use_strict_mode = 0
+    session.use_cookies = 1
+    session.use_only_cookies = 1
+    session.name = PHPSESSID
+    session.auto_start = 0
+    session.cookie_lifetime = 0
+    session.cookie_path = /
+    session.cookie_domain =
+    session.cookie_httponly = 1
+    session.serialize_handler = php_binary
+    session.gc_probability = 1
+    session.gc_divisor = 10000
+    session.gc_maxlifetime = 1440
+    session.referer_check =
+    session.cache_limiter = nocache
+    session.cache_expire = 180
+    session.use_trans_sid = 0
+    session.hash_function = 0
+    session.hash_bits_per_character = 5
+    url_rewriter.tags = "a=href,area=href,frame=src,input=src,form=fakeentry"
+
+    [Assertion]
+    zend.assertions = -1
+
+    [mbstring]
+    mbstring.internal_encoding = UTF-8
+
+    [Tidy]
+    tidy.clean_output = Off
+
+    [soap]
+    soap.wsdl_cache_enabled = 1
+    soap.wsdl_cache_dir = "/tmp"
+    soap.wsdl_cache_ttl = 86400
+    soap.wsdl_cache_limit = 5
+
+    [ldap]
+    ldap.max_links = -1
+
+    [opcache]
+    opcache.enable = 1
+    opcache.enable_cli = 0
+    opcache.memory_consumption = 128
+    opcache.interned_strings_buffer = 32
+    opcache.max_accelerated_files = 10000
+    opcache.use_cwd = ${PHP_OPCACHE_USE_CWD}
+    opcache.validate_timestamps = 1
+    opcache.revalidate_freq = 2
+    opcache.enable_file_override = 0
+    opcache.log_verbosity_level = 2
+
+    [igbinary]
+    igbinary.compact_strings=1                                           
+  
+
+  php-fpm.conf: |
+    [global]
+    error_log = /proc/self/fd/2
+    log_level = notice ; Possible Values: alert, error, warning, notice, debug
+    daemonize = no
+    include=/etc/php7/php-fpm.d/*.conf                                               
+
+  www.conf: |
+    [www]
+    listen = [::]:9000
+    pm = ondemand
+    pm.max_children = 100
+    pm.start_servers = 5
+    pm.min_spare_servers = 5
+    pm.max_spare_servers = 20
+    pm.process_idle_timeout = 60s
+    pm.max_requests = 500
+    access.log = /proc/self/fd/2
+    catch_workers_output = yes
+    clear_env = no
+    

--- a/chart/templates/drupal-deployment.yaml
+++ b/chart/templates/drupal-deployment.yaml
@@ -44,8 +44,24 @@ spec:
         volumeMounts:
         - name: drupal-public-files
           mountPath: /var/www/html/web/sites/default/files
+        - name: nginx-conf
+          mountPath: /etc/nginx/nginx.conf # mount nginx-conf configmap volume to /etc/nginx
+          readOnly: true
+          subPath: nginx.conf
+        - name: nginx-conf
+          mountPath: /etc/nginx/conf.d/drupal.conf # mount nginx-conf configmap volume to /etc/nginx
+          readOnly: true
+          subPath: conf.d/drupal.conf
 
       volumes:
         {{ include "drupal.volumes" . | indent 8}}
+        - name: nginx-conf
+          configMap:
+            name: nginx-conf
+            items:
+              - key: nginx.conf
+                path: nginx.conf
+              - key: drupal.conf
+                path: conf.d/drupal.conf
 
       {{ include "drupal.imagePullSecrets" . | indent 6 }}

--- a/chart/templates/drupal-deployment.yaml
+++ b/chart/templates/drupal-deployment.yaml
@@ -29,15 +29,6 @@ spec:
         resources:
           requests:
             cpu: "50m"
-        env:
-        - name: NGINX_STATIC_CONTENT_OPEN_FILE_CACHE
-          value: "off"
-        - name: NGINX_ERROR_LOG_LEVEL
-          value: debug
-        - name: NGINX_BACKEND_HOST
-          value: localhost
-        - name: NGINX_SERVER_ROOT
-          value: /var/www/html/web
         ports:
         - containerPort: 80
           name: drupal

--- a/chart/templates/drupal-deployment.yaml
+++ b/chart/templates/drupal-deployment.yaml
@@ -48,11 +48,10 @@ spec:
         {{ include "drupal.volumes" . | indent 8}}
         - name: nginx-conf
           configMap:
-            name: nginx-conf
+            name: {{ .Release.Name }}-nginx-conf
             items:
               - key: nginx.conf
                 path: nginx.conf
               - key: drupal.conf
                 path: conf.d/drupal.conf
-
       {{ include "drupal.imagePullSecrets" . | indent 6 }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -2,6 +2,7 @@
 # These variables are build-specific and should be passed via the --set parameter.
 nginx:
   image: 'you need to pass in a value for nginx.image to your helm chart'
+  loglevel: notice # available are: debug; info; notice; warn; error; crit; alert; emerg 
 drupal:
   image: 'you need to pass in a value for drupal.image to your helm chart'
 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -14,8 +14,9 @@ drupal:
   # need to be base64 encoded
   hashsalt: "template-hash-salt" 
   env:
-  #these are added to drupal environment
-    PHP_FPM_CLEAR_ENV: "no"
+  php:
+    upload_max_filesize: 60M
+    post_max_size: 60M
 
   # Create a volume for private files.
   privateFiles:


### PR DESCRIPTION
Stories: 
  Move nginx env vars from pod definition to base docker image (SLT-148)
  Configure php.ini using a ConfigMap mounted as a volume (SLT-144)


Implementation:

Added 2 configmap templates: 
 drupal-configmap-nginx.yaml (defines /etc/nginx/nginx.conf and /etc/nginx/conf.d/drupal.conf
(env vars in docker image were not used, added nginx config as configmap with option to define loglevel from values.yml)

 drupal-configmap-php.yaml (defines  /etc/php7/php.ini, /etc/php7/php-fpm.conf, /etc/php7/php-fpm.d/www.conf)
 
In values.yml defined few options that get included in these configs
 Values.nginx.loglevel
 Values.drupal.php.post_max_size
 Values.drupal.php.upload_max_filesize
 
Added respective volumes and mounts in _helpers.tpl and drupal-deployment.yaml