### PR TITLE
Load database credentials from Lando.

### DIFF
--- a/web/sites/default/settings.php
+++ b/web/sites/default/settings.php
@@ -14,6 +14,21 @@ $databases['default']['default'] = [
   'collation' => 'utf8mb4_general_ci',
 ];
 
+if (getenv('LANDO_INFO')) {
+  /*
+   * Load database credentials from Lando.
+   */
+  $lando_info = json_decode(getenv('LANDO_INFO'), TRUE);
+  $databases['default']['default'] = [
+    'driver' => 'mysql',
+    'database' => $lando_info['database']['creds']['database'],
+    'username' => $lando_info['database']['creds']['user'],
+    'password' => $lando_info['database']['creds']['password'],
+    'host' => $lando_info['database']['internal_connection']['host'],
+    'port' => $lando_info['database']['internal_connection']['port'],
+  ];
+}
+
 // Location of the site configuration files.
 $config_directories[CONFIG_SYNC_DIRECTORY] = '../config/sync';
 


### PR DESCRIPTION
To test, just run:
```
lando start
lando drush site-install
```
This should run without errors.