### PR TITLE
Use "before-hook-creation" for postinstall cleanup

### DIFF
--- a/chart/templates/postinstall.yaml
+++ b/chart/templates/postinstall.yaml
@@ -10,7 +10,7 @@ metadata:
     # job is considered part of the release.
     "helm.sh/hook": post-install
     "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": "hook-succeeded,before-hook-creation"
 spec:
   template:
     spec:


### PR DESCRIPTION
See https://github.com/helm/helm/blob/master/docs/charts_hooks.md#automatically-delete-hook-from-previous-release

Using "before-hook-creation" makes it possible to reinstall a release that failed in postinstall; without this Helm will try to  reinstall but fail because the failed postinstall job is still hanging around.

I'm not actually sure you want to delete the postinstall job if it's successful, it might have useful troubleshooting info even if it succeeded. But you definitely do want it deleted when you try to reinstall ...