### PR TITLE
Define app name as a helper

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -4,10 +4,6 @@ version: {{ .Chart.Version }}
 release: {{ .Release.Name }}
 {{- end }}
 
-{{- define "drupal.app" -}}
-drupal
-{{- end -}}
-
 {{- define "drupal.domain" -}}
 {{ regexReplaceAll "[^[:alnum:]]" .Values.branchname "-" | lower }}.{{ .Release.Namespace }}.{{ .Values.clusterDomain }}
 {{- end -}}

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -4,6 +4,10 @@ version: {{ .Chart.Version }}
 release: {{ .Release.Name }}
 {{- end }}
 
+{{- define "drupal.app" -}}
+drupal
+{{- end -}}
+
 {{- define "drupal.domain" -}}
 {{ regexReplaceAll "[^[:alnum:]]" .Values.branchname "-" | lower }}.{{ .Release.Namespace }}.{{ .Values.clusterDomain }}
 {{- end -}}

--- a/chart/templates/drupal-deployment.yaml
+++ b/chart/templates/drupal-deployment.yaml
@@ -3,19 +3,19 @@ kind: Deployment
 metadata:
   name: {{ .Release.Name }}-drupal
   labels:
-    app: {{ include "drupal.app" . }}
+    app: {{ .Values.drupal.app | quote }}
     release: {{ .Release.Name }}
 spec:
   selector:
     matchLabels:
-      app: {{ include "drupal.app" . }}
+      app: {{ .Values.drupal.app | quote }}
       release: {{ .Release.Name }}
   strategy:
     type: Recreate
   template:
     metadata:
       labels:
-        app: {{ include "drupal.app" . }}
+        app: {{ .Values.drupal.app | quote }}
         release: {{ .Release.Name }}
     spec:
       containers:

--- a/chart/templates/drupal-deployment.yaml
+++ b/chart/templates/drupal-deployment.yaml
@@ -3,19 +3,19 @@ kind: Deployment
 metadata:
   name: {{ .Release.Name }}-drupal
   labels:
-    app: drupal
+    app: {{ include "drupal.app" . }}
     release: {{ .Release.Name }}
 spec:
   selector:
     matchLabels:
-      app: drupal
+      app: {{ include "drupal.app" . }}
       release: {{ .Release.Name }}
   strategy:
     type: Recreate
   template:
     metadata:
       labels:
-        app: drupal
+        app: {{ include "drupal.app" . }}
         release: {{ .Release.Name }}
     spec:
       containers:

--- a/chart/templates/drupal-service.yaml
+++ b/chart/templates/drupal-service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   name: {{ .Release.Name }}-drupal
   labels:
-    app: {{ include "drupal.app" . }}
+    app: {{ .Values.drupal.app | quote }}
     release: {{ .Release.Name }}
   annotations:
     getambassador.io/config: |
@@ -19,5 +19,5 @@ spec:
   ports:
     - port: 80
   selector:
-    app: {{ include "drupal.app" . }}
+    app: {{ .Values.drupal.app | quote }}
     release: {{ .Release.Name }}

--- a/chart/templates/drupal-service.yaml
+++ b/chart/templates/drupal-service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   name: {{ .Release.Name }}-drupal
   labels:
-    app: drupal
+    app: {{ include "drupal.app" . }}
     release: {{ .Release.Name }}
   annotations:
     getambassador.io/config: |
@@ -19,5 +19,5 @@ spec:
   ports:
     - port: 80
   selector:
-    app: drupal
+    app: {{ include "drupal.app" . }}
     release: {{ .Release.Name }}

--- a/chart/templates/drupal-volumes.yaml
+++ b/chart/templates/drupal-volumes.yaml
@@ -3,7 +3,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: {{ .Release.Name }}-public-files
   labels:
-    app: {{ include "drupal.app" . }}
+    app: {{ .Values.drupal.app | quote }}
     release: {{ .Release.Name }}
 spec:
   storageClassName: nfs
@@ -19,7 +19,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: {{ .Release.Name }}-private-files
   labels:
-    app: {{ include "drupal.app" . }}
+    app: {{ .Values.drupal.app | quote }}
     release: {{ .Release.Name }}
 spec:
   storageClassName: nfs

--- a/chart/templates/drupal-volumes.yaml
+++ b/chart/templates/drupal-volumes.yaml
@@ -3,7 +3,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: {{ .Release.Name }}-public-files
   labels:
-    app: drupal
+    app: {{ include "drupal.app" . }}
     release: {{ .Release.Name }}
 spec:
   storageClassName: nfs
@@ -19,7 +19,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: {{ .Release.Name }}-private-files
   labels:
-    app: drupal
+    app: {{ include "drupal.app" . }}
     release: {{ .Release.Name }}
 spec:
   storageClassName: nfs

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -19,6 +19,8 @@ drupal:
   # Create a volume for private files.
   privateFiles:
     enabled: false
+    
+  app: drupal  
 
   postinstall:
     command: |


### PR DESCRIPTION
Gitlab offers terminal access to K8s environments from the Gitlab UI, and UI feedback on deployments but only if  "app" has a specific value `app=$CI_ENVIRONMENT_SLUG`.

So how about allowing parent charts to customise the app name if they want to?