### PR TITLE
Stray reference to gcr in postupgrade

### DIFF
--- a/chart/templates/postupgrade.yaml
+++ b/chart/templates/postupgrade.yaml
@@ -21,7 +21,6 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
         - {{ .Values.drupal.postupgrade.command | quote }}
-      imagePullSecrets:
-      - name: gcr
+      {{ include "drupal.imagePullSecrets" . | indent 6 }}
       volumes:
         {{ include "drupal.volumes" . | indent 8 }}


### PR DESCRIPTION
This one got added in a parallel branch, it missed the cleanup of the gcr imagePullSecrets. 