### PR TITLE
Make mariadb env variables optional

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -64,6 +64,7 @@ imagePullSecrets:
 {{- end }}
 
 {{- define "drupal.env" }}
+{{- if or (not (hasKey .Values.mariadb "enabled")) .Values.mariadb.enabled }}
 - name: DB_USER
   value: "{{ .Values.mariadb.db.user }}"
 - name: DB_NAME
@@ -75,6 +76,7 @@ imagePullSecrets:
     secretKeyRef:
       name: {{ .Release.Name }}-mariadb
       key: mariadb-password
+{{- end }}      
 - name: HASH_SALT
   valueFrom:
     secretKeyRef:

--- a/chart/tests/mariadb.yaml
+++ b/chart/tests/mariadb.yaml
@@ -1,0 +1,38 @@
+suite: drupal mariadb
+templates:
+  - drupal-deployment.yaml
+  - postinstall.yaml
+  - postupgrade.yaml
+  - drupal-cron.yaml
+tests:
+  - it: sets mariadb user
+    set:
+      mariadb.db.user: testuser
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DB_USER
+            value: testuser
+
+  - it: sets mariadb user  in drupal environment if mariadb explicitly enabled
+    set:
+      mariad.enabled: true
+      mariadb.db.user: testuser
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DB_USER
+            value: testuser
+
+  - it: sets no mariadb user in drupal environment if mariadb disabled
+    set:
+      mariadb.enabled: false
+      mariadb.db.user: testuser
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DB_USER
+            value: testuser


### PR DESCRIPTION
Currently the database values are always assumed to be coming from the mariadb values. 

But we can allow for the possibility that these are set directly in values.drupal.env. We simply need to NOT automatically write the database variables from mariadb if mariadb is disabled.

Without this setting env variables like "DB_USER" via values.drupal.env will cause duplicate environment variables, which can be problematic.

