### PR TITLE
SLT-17: Periodical drush SQL-Dump using gdpr-dump.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,10 @@ jobs:
           keys:
             - v1-dependencies-{{ checksum "composer.lock" }}
 
-      - run: composer install -n --prefer-dist --ignore-platform-reqs --no-dev
+      - run: |
+          composer install -n --prefer-dist --ignore-platform-reqs --no-dev
+          composer config repositories.gdpr-dump-mods git https://github.com/Jancis/gdpr-dump
+          composer require machbarmacher/gdpr-dump:dev-mods -n --ignore-platform-reqs
 
       - save_cache:
           paths:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
 # Dockerfile for the Drupal container.
 FROM wunderio/drupal-php-fpm:v0.1
 
+USER root
+RUN mkdir -p /var/backups/db
+RUN chown www-data:www-data /var/backups/db
+
 COPY --chown=www-data:www-data . /var/www/html
 USER www-data
 RUN mkdir -p -m +w /var/www/html/web/sites/default/files

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,7 @@
 FROM wunderio/drupal-php-fpm:v0.1
 
 USER root
-RUN mkdir -p /var/backups/db
-RUN chown www-data:www-data /var/backups/db
+RUN mkdir -p /var/reference-data && chown www-data:www-data /var/reference-data
 
 COPY --chown=www-data:www-data . /var/www/html
 USER www-data

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This project template is an opinionated fork of the popular [Drupal-composer tem
 
 - Copy this repository and push it to our organization. 
 - Log in to CircleCI using your Github account and add the new project.
-
+- Create and maintain a Personal Data mapping list for automatic data sanitization in `gdpr.json` file. See GDPR sanitization section for more information.
  
 ## How it works
 
@@ -21,3 +21,35 @@ Have a look at the file for details, but in short this is how it works:
 - Create a custom docker image for Drupal and nginx, and push those to a docker registry (typically that of your cloud provider).
 - Install or update our helm chart while passing our custom images as parameters.
 - The helm chart executes the usual drush deployment commands.
+
+## GDPR sanitization
+
+SQL data dump for developers is parsed with [GDPR Tools](https://github.com/machbarmacher/gdpr-dump) project.
+You can create a `/gdpr.json` file with [Faker](https://packagist.org/packages/fzaninotto/faker) formatters that will allow replacing data as it's dumped from database using `mysqldump` / `drush sql-dump` command.  
+
+```
+{
+  "users_field_data": {
+    "name": {"formatter": "name"},
+    "pass": {"formatter": "password"},
+    "mail": {"formatter": "email"},
+    "init": {"formatter": "clear"}
+  }
+} 
+```
+Available formatters:
+```
+**name** - generates a name
+**phoneNumber** - generates a phone number
+**username** - generates a random user name
+**password** - generates a random password
+**email** - generates a random email address
+**date** - generates a date
+**longText** - generates a sentence
+**number** - generates a number
+**randomText** - generates a sentence
+**text** - generates a paragraph
+**uri** - generates a URI
+**clear** - generates an empty string
+```
+You can also add extra elements and attributes, like `_cookies`, `_description` or `_purpose` to enrich the Personal Data information. Just make sure it's marked or prefixed so that it does not mess up GDPR dump when it looks for table data replacements.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Have a look at the file for details, but in short this is how it works:
 
 ## GDPR sanitization
 
-SQL data dump for developers is parsed with [GDPR Tools](https://github.com/machbarmacher/gdpr-dump) project.
+SQL data dump for developers is parsed with [GDPR Dump](https://github.com/machbarmacher/gdpr-dump) project.
 You can create a `/gdpr.json` file with [Faker](https://packagist.org/packages/fzaninotto/faker) formatters that will allow replacing data as it's dumped from database using `mysqldump` / `drush sql-dump` command.  
 
 ```
@@ -37,19 +37,6 @@ You can create a `/gdpr.json` file with [Faker](https://packagist.org/packages/f
   }
 } 
 ```
-Available formatters:
-```
-**name** - generates a name
-**phoneNumber** - generates a phone number
-**username** - generates a random user name
-**password** - generates a random password
-**email** - generates a random email address
-**date** - generates a date
-**longText** - generates a sentence
-**number** - generates a number
-**randomText** - generates a sentence
-**text** - generates a paragraph
-**uri** - generates a URI
-**clear** - generates an empty string
-```
+Available formatters listed in [GDPR Dump project documentation](https://github.com/machbarmacher/gdpr-dump#using-gdpr-replacements). 
+
 You can also add extra elements and attributes, like `_cookies`, `_description` or `_purpose` to enrich the Personal Data information. Just make sure it's marked or prefixed so that it does not mess up GDPR dump when it looks for table data replacements.

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -77,10 +77,6 @@ imagePullSecrets:
 {{- end }}
 
 {{- define "drupal.env" }}
-- name: IS_REFERENCE_ENVIRONMENT
-  value: {{ eq .Values.referenceData.referenceEnvironment .Values.environmentName | int | quote }}
-- name: REFERENCE_ENVIRONMENT
-  value: {{ include "drupal.referenceEnvironment" . | quote }}
 {{- if .Values.mariadb.enabled }}
 - name: DB_USER
   value: "{{ .Values.mariadb.db.user }}"

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -54,9 +54,6 @@ volumeMounts:
   persistentVolumeClaim:
     claimName: {{ .Release.Name }}-private-files
 {{- end }}
-- name: reference-data-volume
-  persistentVolumeClaim:
-    claimName: {{ include "drupal.referenceEnvironment" . }}-reference-data
 - name: php-conf
   configMap:
     name: {{ .Release.Name }}-php-conf
@@ -67,6 +64,11 @@ volumeMounts:
         path: php-fpm_conf
       - key: www_conf
         path: www_conf
+{{- end }}
+{{- define "drupal.reference-data-volume" }}
+- name: reference-data-volume
+  persistentVolumeClaim:
+    claimName: {{ include "drupal.referenceEnvironment" . }}-reference-data
 {{- end }}
 
 {{- define "drupal.imagePullSecrets" }}

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -5,7 +5,11 @@ release: {{ .Release.Name }}
 {{- end }}
 
 {{- define "drupal.domain" -}}
-{{ regexReplaceAll "[^[:alnum:]]" (.Values.environmentName | default .Release.Name) "-" | lower }}.{{ .Release.Namespace }}.{{ .Values.clusterDomain }}
+{{ include "drupal.environmentName" . }}.{{ .Release.Namespace }}.{{ .Values.clusterDomain }}
+{{- end -}}
+
+{{- define "drupal.environmentName" -}}
+{{ regexReplaceAll "[^[:alnum:]]" (.Values.environmentName | default .Release.Name) "-" | lower }}
 {{- end -}}
 
 {{- define "drupal.php-container" }}
@@ -21,8 +25,8 @@ volumeMounts:
   - name: drupal-private-files
     mountPath: /var/www/html/private
   {{- end }}
-  - name: drupal-dbdump-volume
-    mountPath: /var/backups/db
+  - name: reference-data-volume
+    mountPath: /var/reference-data
   - name: php-conf
     mountPath: /etc/php7/php.ini
     readOnly: true
@@ -46,9 +50,9 @@ volumeMounts:
   persistentVolumeClaim:
     claimName: {{ .Release.Name }}-private-files
 {{- end }}
-- name: drupal-dbdump-volume
+- name: reference-data-volume
   persistentVolumeClaim:
-    claimName: {{ .Release.Namespace }}-dbdump
+    claimName: {{ .Values.referenceData.referenceEnvironment }}-reference-data
 - name: php-conf
   configMap:
     name: {{ .Release.Name }}-php-conf

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -12,6 +12,10 @@ release: {{ .Release.Name }}
 {{ regexReplaceAll "[^[:alnum:]]" (.Values.environmentName | default .Release.Name) "-" | lower }}
 {{- end -}}
 
+{{- define "drupal.referenceEnvironment" -}}
+{{ regexReplaceAll "[^[:alnum:]]" .Values.referenceData.referenceEnvironment "-" | lower }}
+{{- end -}}
+
 {{- define "drupal.php-container" }}
 image: {{ .Values.php.image | quote }}
 env: {{ include "drupal.env" . }}
@@ -52,7 +56,7 @@ volumeMounts:
 {{- end }}
 - name: reference-data-volume
   persistentVolumeClaim:
-    claimName: {{ .Values.referenceData.referenceEnvironment }}-reference-data
+    claimName: {{ include "drupal.referenceEnvironment" . }}-reference-data
 - name: php-conf
   configMap:
     name: {{ .Release.Name }}-php-conf
@@ -76,7 +80,7 @@ imagePullSecrets:
 - name: IS_REFERENCE_ENVIRONMENT
   value: {{ eq .Values.referenceData.referenceEnvironment .Values.environmentName | int | quote }}
 - name: REFERENCE_ENVIRONMENT
-  value: {{ .Values.referenceData.referenceEnvironment | quote }}
+  value: {{ include "drupal.referenceEnvironment" . | quote }}
 {{- if .Values.mariadb.enabled }}
 - name: DB_USER
   value: "{{ .Values.mariadb.db.user }}"

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -21,6 +21,8 @@ volumeMounts:
   - name: drupal-private-files
     mountPath: /var/www/html/private
   {{- end }}
+  - name: drupal-dbdump-volume
+    mountPath: /var/backups/db
   - name: php-conf
     mountPath: /etc/php7/php.ini
     readOnly: true
@@ -44,6 +46,9 @@ volumeMounts:
   persistentVolumeClaim:
     claimName: {{ .Release.Name }}-private-files
 {{- end }}
+- name: drupal-dbdump-volume
+  persistentVolumeClaim:
+    claimName: {{ .Release.Namespace }}-dbdump
 - name: php-conf
   configMap:
     name: {{ .Release.Name }}-php-conf
@@ -64,6 +69,10 @@ imagePullSecrets:
 {{- end }}
 
 {{- define "drupal.env" }}
+- name: BRANCHNAME
+  value: {{ .Values.branchname }}
+- name: PRODUCTION_BRANCHNAME
+  value: {{ .Values.production_branchname | default "production" }}
 {{- if .Values.mariadb.enabled }}
 - name: DB_USER
   value: "{{ .Values.mariadb.db.user }}"

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -72,7 +72,7 @@ imagePullSecrets:
 - name: IS_REFERENCE_ENVIRONMENT
   value: {{ eq .Values.referenceEnvironment .Values.environmentName }}
 - name: REFERENCE_ENVIRONMENT
-  value: {{ .Values.referenceEnvironment }}
+  value: {{ .Values.referenceEnvironment | quote }}
 {{- if .Values.mariadb.enabled }}
 - name: DB_USER
   value: "{{ .Values.mariadb.db.user }}"

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -70,7 +70,7 @@ imagePullSecrets:
 
 {{- define "drupal.env" }}
 - name: IS_REFERENCE_ENVIRONMENT
-  value: {{ .Values.referenceEnvironment == .Values.environmentName }}
+  value: {{ eq .Values.referenceEnvironment .Values.environmentName }}
 - name: REFERENCE_ENVIRONMENT
   value: {{ .Values.referenceEnvironment }}
 {{- if .Values.mariadb.enabled }}

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -70,7 +70,7 @@ imagePullSecrets:
 
 {{- define "drupal.env" }}
 - name: IS_REFERENCE_ENVIRONMENT
-  value: {{ eq .Values.referenceEnvironment .Values.environmentName }}
+  value: {{ eq .Values.referenceEnvironment .Values.environmentName | int | quote }}
 - name: REFERENCE_ENVIRONMENT
   value: {{ .Values.referenceEnvironment | quote }}
 {{- if .Values.mariadb.enabled }}

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -70,9 +70,9 @@ imagePullSecrets:
 
 {{- define "drupal.env" }}
 - name: IS_REFERENCE_ENVIRONMENT
-  value: {{ eq .Values.referenceEnvironment .Values.environmentName | int | quote }}
+  value: {{ eq .Values.referenceData.referenceEnvironment .Values.environmentName | int | quote }}
 - name: REFERENCE_ENVIRONMENT
-  value: {{ .Values.referenceEnvironment | quote }}
+  value: {{ .Values.referenceData.referenceEnvironment | quote }}
 {{- if .Values.mariadb.enabled }}
 - name: DB_USER
   value: "{{ .Values.mariadb.db.user }}"

--- a/chart/templates/drupal-volumes.yaml
+++ b/chart/templates/drupal-volumes.yaml
@@ -33,7 +33,7 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ .Values.referenceEnvironment }}-reference-data
+  name: {{ include "drupal.environmentName" . }}-reference-data
   labels:
     app: {{ .Values.app | quote }}
     release: {{ .Release.Name }}

--- a/chart/templates/drupal-volumes.yaml
+++ b/chart/templates/drupal-volumes.yaml
@@ -28,3 +28,20 @@ spec:
     requests:
       storage: {{ .Values.privateFiles.storage }}
 {{- end }}
+---
+{{- if eq .Values.referenceData.referenceEnvironment .Values.environmentName }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Values.referenceEnvironment }}-reference-data
+  labels:
+    app: {{ .Values.app | quote }}
+    release: {{ .Release.Name }}
+spec:
+  storageClassName: {{ .Values.referenceData.storageClassName }}
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: {{ .Values.referenceData.storage }}
+{{- end }}

--- a/chart/templates/drupal-volumes.yaml
+++ b/chart/templates/drupal-volumes.yaml
@@ -33,7 +33,7 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ include "drupal.environmentName" . }}-reference-data
+  name: {{ include "drupal.referenceEnvironment" . }}-reference-data
   labels:
     app: {{ .Values.app | quote }}
     release: {{ .Release.Name }}

--- a/chart/templates/postinstall.yaml
+++ b/chart/templates/postinstall.yaml
@@ -23,3 +23,4 @@ spec:
       {{ include "drupal.imagePullSecrets" . | indent 6 }}
       volumes:
         {{ include "drupal.volumes" . | indent 8 }}
+        {{ include "drupal.reference-data-volume" . | indent 8 }}

--- a/chart/templates/postupgrade.yaml
+++ b/chart/templates/postupgrade.yaml
@@ -23,3 +23,4 @@ spec:
       {{ include "drupal.imagePullSecrets" . | indent 6 }}
       volumes:
         {{ include "drupal.volumes" . | indent 8 }}
+        {{ include "drupal.reference-data-volume" . | indent 8 }}

--- a/chart/templates/reference-data-cron.yaml
+++ b/chart/templates/reference-data-cron.yaml
@@ -23,6 +23,7 @@ spec:
           restartPolicy: OnFailure
           volumes:
             {{ include "drupal.volumes" . | indent 12 }}
+            {{ include "drupal.reference-data-volume" . | indent 12 }}
 
           {{ include "drupal.imagePullSecrets" . | indent 10 }}
 {{- end }}

--- a/chart/templates/reference-data-cron.yaml
+++ b/chart/templates/reference-data-cron.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  name: {{ .Release.Name }}-reference-data-cron
+  name: {{ .Release.Name }}-refdata
   labels:
     {{ include "drupal.release_labels" . | indent 4 }}
 spec:

--- a/chart/templates/reference-data-cron.yaml
+++ b/chart/templates/reference-data-cron.yaml
@@ -8,7 +8,6 @@ metadata:
 spec:
   schedule: {{ .Values.referenceData.schedule | quote }}
   concurrencyPolicy: Forbid
-  backOffLimit: 3
   jobTemplate:
     spec:
       template:

--- a/chart/templates/reference-data-cron.yaml
+++ b/chart/templates/reference-data-cron.yaml
@@ -1,0 +1,30 @@
+{{- if eq .Values.referenceData.referenceEnvironment .Values.environmentName }}
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: {{ .Release.Name }}-reference-data-cron
+  labels:
+    {{ include "drupal.release_labels" . | indent 4 }}
+spec:
+  schedule: {{ .Values.referenceData.schedule | quote }}
+  concurrencyPolicy: Forbid
+  backOffLimit: 3
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: reference-data-cron
+            {{ include "drupal.php-container" . | indent 12 }}
+            command: ["/bin/sh", "-c"]
+            args:
+              - {{ .Values.referenceData.command | quote }}
+            resources:
+{{ .Values.php.resources | toYaml | indent 14 }}
+          restartPolicy: OnFailure
+          volumes:
+            {{ include "drupal.volumes" . | indent 12 }}
+
+          {{ include "drupal.imagePullSecrets" . | indent 10 }}
+{{- end }}
+---

--- a/chart/tests/reference_data_test.yaml
+++ b/chart/tests/reference_data_test.yaml
@@ -26,9 +26,9 @@ tests:
 
   - it: takes reference data information
     set:
-      environmentName: 'foo'
+      environmentName: 'feature/FOO'
       referenceData:
-        referenceEnvironment: 'foo'
+        referenceEnvironment: 'feature/FOO'
         storage: 123Gi
         storageClassName: foo
         schedule: '0 1 2 3 *'
@@ -40,7 +40,7 @@ tests:
         path: spec.template.spec.containers[0].env
         content:
           name: REFERENCE_ENVIRONMENT
-          value: foo
+          value: feature-foo
     - contains:
         path: spec.template.spec.containers[0].env
         content:

--- a/chart/tests/reference_data_test.yaml
+++ b/chart/tests/reference_data_test.yaml
@@ -6,16 +6,6 @@ templates:
 tests:
   - it: has no reference data volume by default
     asserts:
-    - contains:
-        path: spec.template.spec.containers[0].env
-        content:
-          name: REFERENCE_ENVIRONMENT
-          value: master
-    - contains:
-        path: spec.template.spec.containers[0].env
-        content:
-          name: IS_REFERENCE_ENVIRONMENT
-          value: "0"
     # Only one volume is defined.
     - hasDocuments:
         count: 1
@@ -36,16 +26,6 @@ tests:
       php.env:
         foo: bar
     asserts:
-    - contains:
-        path: spec.template.spec.containers[0].env
-        content:
-          name: REFERENCE_ENVIRONMENT
-          value: feature-foo
-    - contains:
-        path: spec.template.spec.containers[0].env
-        content:
-          name: IS_REFERENCE_ENVIRONMENT
-          value: "1"
     - hasDocuments:
         count: 2
       template: drupal-volumes.yaml

--- a/chart/tests/reference_data_test.yaml
+++ b/chart/tests/reference_data_test.yaml
@@ -1,0 +1,93 @@
+suite: reference data
+templates:
+  - drupal-deployment.yaml
+  - drupal-volumes.yaml
+  - reference-data-cron.yaml
+tests:
+  - it: has no reference data volume by default
+    asserts:
+    - contains:
+        path: spec.template.spec.containers[0].env
+        content:
+          name: REFERENCE_ENVIRONMENT
+          value: master
+    - contains:
+        path: spec.template.spec.containers[0].env
+        content:
+          name: IS_REFERENCE_ENVIRONMENT
+          value: "0"
+    # Only one volume is defined.
+    - hasDocuments:
+        count: 1
+      template: drupal-volumes.yaml
+    - hasDocuments:
+        count: 0
+      template: reference-data-cron.yaml
+
+  - it: takes reference data information
+    set:
+      environmentName: 'foo'
+      referenceData:
+        referenceEnvironment: 'foo'
+        storage: 123Gi
+        storageClassName: foo
+        schedule: '0 1 2 3 *'
+        command: "echo Hello World"
+      php.env:
+        foo: bar
+    asserts:
+    - contains:
+        path: spec.template.spec.containers[0].env
+        content:
+          name: REFERENCE_ENVIRONMENT
+          value: foo
+    - contains:
+        path: spec.template.spec.containers[0].env
+        content:
+          name: IS_REFERENCE_ENVIRONMENT
+          value: "1"
+    - hasDocuments:
+        count: 2
+      template: drupal-volumes.yaml
+    - template: drupal-volumes.yaml
+      documentIndex: 1
+      equal:
+        path: spec.storageClassName
+        value: foo
+    - template: drupal-volumes.yaml
+      documentIndex: 1
+      equal:
+        path: spec.resources.requests.storage
+        value: 123Gi
+
+    - isKind:
+        of: CronJob
+      template: reference-data-cron.yaml
+    - isKind:
+        of: CronJob
+      template: reference-data-cron.yaml
+
+    - template: reference-data-cron.yaml
+      contains:
+        path: spec.jobTemplate.spec.template.spec.containers[0].env
+        content:
+          name: foo
+          value: bar
+    - template: reference-data-cron.yaml
+      contains:
+        path: spec.jobTemplate.spec.template.spec.volumes
+        content:
+          name: "drupal-public-files"
+          persistentVolumeClaim:
+            claimName: RELEASE-NAME-public-files
+    - template: reference-data-cron.yaml
+      equal:
+        path: spec.schedule
+        value: '0 1 2 3 *'
+    - template: reference-data-cron.yaml
+      equal:
+        path: spec.jobTemplate.spec.template.spec.containers[0].args[0]
+        value: "echo Hello World"
+
+
+

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -8,9 +8,6 @@ clusterDomain: "silta.wdr.io"
 # This name is mainly used to create nice subdomains for each environment.
 environmentName: ""
 
-# The name of the reference environment from which data will be copied for new environments.
-referenceEnvironment: "master"
-
 # Configure image pull secrets for the containers. This is not needed on GKE.
 # See https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
 imagePullSecrets: []
@@ -112,6 +109,13 @@ publicFiles:
 # Configure an optional volume used for Drupal private files.
 privateFiles:
   enabled: false
+  storage: 1G
+  storageClassName: nfs
+
+# Configure reference data that will be used when creating new environments.
+referenceData:
+  # The name of the environment from which reference data will be copied.
+  referenceEnvironment: 'master'
   storage: 1G
   storageClassName: nfs
 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -50,14 +50,16 @@ php:
   # When overriding this value, make sure to include the `drush cron` command.
   cron:
     - schedule: '0 * * * *'
-      command: 'bootstrapped=$(drush status --field=bootstrap);
+      command: |
+        bootstrapped=$(drush status --field=bootstrap);
         if [[ $bootstrapped = "Successful" ]];
         then
           drush cron;
-        fi;'
+        fi;
     - schedule: '0 3 * * *'
-      command: 'bootstrapped=$(drush status --field=bootstrap);
-        if [[ $bootstrapped = "Successful" ]] && [[ IS_REFERENCE_ENVIRONMENT ]];
+      command: |
+        bootstrapped=$(drush status --field=bootstrap);
+        if [[ $bootstrapped = "Successful" ]] && [[ $IS_REFERENCE_ENVIRONMENT ]];
         then
           DUMP_PATH=/var/backups/db/${REFERENCE_ENVIRONMENT//[^[:alnum:]]/-}-latest.sql;
           rm $DUMP_PATH;
@@ -67,7 +69,7 @@ php:
           else
             drush sql-dump --result-file $DUMP_PATH;
           fi
-        fi;'
+        fi;
 
   # Post-installation hook.
   # This is run every time a new environment is created.

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -6,7 +6,7 @@ clusterDomain: "silta.wdr.io"
 # An optional human-readable label for the environment, defaults to the release name.
 # We typically pass the branch name when we build dedicated environments per branch.
 # This name is mainly used to create nice subdomains for each environment.
-environmentName: null
+environmentName: ""
 
 # The name of the reference environment from which data will be copied for new environments.
 referenceEnvironment: "master"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -13,7 +13,24 @@ drupal:
 
   cron:
     - schedule: '0 * * * *'
-      command: 'drush cron'
+      command: 'bootstrapped=$(drush status --field=bootstrap);
+        if [[ $bootstrapped = "Successful" ]];
+        then
+          drush cron;
+        fi;'
+    - schedule: '0 3 * * *'
+      command: 'bootstrapped=$(drush status --field=bootstrap);
+        if [[ $bootstrapped = "Successful" ]] && [[ "$BRANCHNAME" = "$PRODUCTION_BRANCHNAME" ]];
+        then
+          DUMP_PATH=/var/backups/db/${BRANCHNAME//[^[:alnum:]]/-}-latest.sql;
+          rm $DUMP_PATH;
+          if [ -f ../gdpr.json ]; then
+            export PATH=../vendor/bin:$PATH;
+            drush sql-dump --extra-dump="--gdpr-replacements-file=../gdpr.json" --result-file $DUMP_PATH;
+          else
+            drush sql-dump --result-file $DUMP_PATH;
+          fi
+        fi;'
 
   # will be generated random hashsalt if not provided here
   # need to be base64 encoded
@@ -76,3 +93,4 @@ clusterDomain: "silta.wdr.io"
 imagePullSecrets: []
 
 branchname: "default"
+production_branchname: "master"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -123,10 +123,12 @@ referenceData:
   schedule: '0 3 * * *'
   command: |
     bootstrapped=$(drush status --field=bootstrap);
-    if [[ $bootstrapped = "Successful" ]] && [[ $IS_REFERENCE_ENVIRONMENT ]];
+    if [[ $bootstrapped = "Successful" ]];
     then
-      DUMP_PATH=/var/backups/db/${REFERENCE_ENVIRONMENT//[^[:alnum:]]/-}-latest.sql;
-      rm $DUMP_PATH;
+      DUMP_PATH=/var/reference-data/db-latest.sql;
+
+      # NFS doesn't support replacing a file, so we delete it instead.
+      rm -f $DUMP_PATH;
       if [ -f ../gdpr.json ]; then
         export PATH=../vendor/bin:$PATH;
         drush sql-dump --extra-dump="--gdpr-replacements-file=../gdpr.json" --result-file $DUMP_PATH;

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -53,20 +53,6 @@ php:
         then
           drush cron;
         fi;
-    - schedule: '0 3 * * *'
-      command: |
-        bootstrapped=$(drush status --field=bootstrap);
-        if [[ $bootstrapped = "Successful" ]] && [[ $IS_REFERENCE_ENVIRONMENT ]];
-        then
-          DUMP_PATH=/var/backups/db/${REFERENCE_ENVIRONMENT//[^[:alnum:]]/-}-latest.sql;
-          rm $DUMP_PATH;
-          if [ -f ../gdpr.json ]; then
-            export PATH=../vendor/bin:$PATH;
-            drush sql-dump --extra-dump="--gdpr-replacements-file=../gdpr.json" --result-file $DUMP_PATH;
-          else
-            drush sql-dump --result-file $DUMP_PATH;
-          fi
-        fi;
 
   # Post-installation hook.
   # This is run every time a new environment is created.
@@ -116,6 +102,23 @@ privateFiles:
 referenceData:
   # The name of the environment from which reference data will be copied.
   referenceEnvironment: 'master'
+
+  schedule: '0 3 * * *'
+  command: |
+    bootstrapped=$(drush status --field=bootstrap);
+    if [[ $bootstrapped = "Successful" ]] && [[ $IS_REFERENCE_ENVIRONMENT ]];
+    then
+      DUMP_PATH=/var/backups/db/${REFERENCE_ENVIRONMENT//[^[:alnum:]]/-}-latest.sql;
+      rm $DUMP_PATH;
+      if [ -f ../gdpr.json ]; then
+        export PATH=../vendor/bin:$PATH;
+        drush sql-dump --extra-dump="--gdpr-replacements-file=../gdpr.json" --result-file $DUMP_PATH;
+      else
+        drush sql-dump --result-file $DUMP_PATH;
+      fi
+    fi;
+
+
   storage: 1G
   storageClassName: nfs
 

--- a/gdpr.json
+++ b/gdpr.json
@@ -1,0 +1,8 @@
+{
+  "users_field_data": {
+    "name": {"formatter": "name"},
+    "pass": {"formatter": "password"},
+    "mail": {"formatter": "email"},
+    "init": {"formatter": "clear"}
+  }
+}


### PR DESCRIPTION
**What this PR does:**

I've set up a cron rule that is invoked every day at 3:00 AM and runs a `drush sql-dump` command provided by [GDPR Tools](https://github.com/machbarmacher/gdpr-dump). The sql dump is only run when the current branchname equals predefined `production_branchname` in `values.yaml`

We have a [slightly modified](https://github.com/Jancis/gdpr-dump) version currently because of following issues/improvements:
 - ~https://github.com/machbarmacher/gdpr-dump/pull/28~
 - https://github.com/machbarmacher/gdpr-dump/issues/26 
Once the issues are fixed, we can go back to [original](https://github.com/machbarmacher/gdpr-dump). 

This allows site developers to create a `/gdpr.json` file with [Faker](https://packagist.org/packages/fzaninotto/faker) formatters that will allow replacing data as it's dumped from database using `mysqldump` / `drush sql-dump` command.  

```
{
  "users_field_data": {
    "name": {"formatter": "name"},
    "pass": {"formatter": "password"},
    "mail": {"formatter": "email"},
    "init": {"formatter": "clear"}
  }
} 
```
Available formatters:

> **name** - generates a name
> **phoneNumber** - generates a phone number
> **username** - generates a random user name
> **password** - generates a random password
> **email** - generates a random email address
> **date** - generates a date
> **longText** - generates a sentence
> **number** - generates a number
> **randomText** - generates a sentence
> **text** - generates a paragraph
> **uri** - generates a URI
> **clear** - generates an empty string

Developers can also add extra elements and attributes, like `_cookies`, `_description` or `_purpose` that could bring this file closer to automatic PD documentation generation. Just have to be marked or prefixed so that it does not mess up GDPR dump when it looks for table data replacements.

**Testing:**

It works on my machine, I swear! But you can branch it, change the cron interval to something like `*/5 * * * *` and `production_branchname` to the name of your branch (i.e. `feature/SLT-17-gdpr-dump`). Deploy and you should see updated sql dump at `/var/backups/db/` every five minutes. You can search the dump file for string `users_` and see that all user names, emails and such are changed. It also changes the name of anonymous user, which is not an ideal situation, but we can't do much about it at this time. 

**Important note**

While working on this, I ran into issue where dump couldn't rewrite existing dump. 
```
sh: can't create /var/backups/db/feature-SLT-17-gdpr-dump-latest.sql: Invalid argument
```
This also happened on `sites/default/files/`, but I found the way around by [removing the file first ](https://github.com/wunderio/drupal-project-k8s/pull/40/files#diff-f18d9ef27be2f36a73a018900706456eR26)and then making the database dump. This seems to work perfectly, but there could still be a [bigger issue with persistent storage](https://github.com/kubernetes-incubator/external-storage/issues/223#issuecomment-344972640) so I created a [bug report](https://wunder.atlassian.net/browse/SLT-150) out of this.