### PR TITLE
Replace the drush liveness probe with a simple check of the tcp socket.

### DIFF
--- a/chart/templates/drupal-deployment.yaml
+++ b/chart/templates/drupal-deployment.yaml
@@ -24,11 +24,8 @@ spec:
       - name: drupal
         {{ include "drupal.php-container" . | indent 8}}
         livenessProbe:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - drush status
+          tcpSocket:
+            port: 9000
         readinessProbe:
           exec:
             command:


### PR DESCRIPTION
Based on our discussion from earlier today, we shouldn't restart the php-fpm container if it can't connect to the database, as that's probably won't fix the source of the problem.