### PR TITLE
Generated twig files should not be on shared storage.

### DIFF
--- a/web/sites/default/settings.php
+++ b/web/sites/default/settings.php
@@ -55,6 +55,11 @@ $settings['file_scan_ignore_directories'] = [
 ];
 
 /**
+ * Generated twig files should not be on shared storage.
+ */
+$settings['php_storage']['twig']['directory'] = '/tmp';
+
+/**
  * If a volume has been set for private files, tell Drupal about it.
  */
 if (getenv('PRIVATE_FILES_PATH')) {


### PR DESCRIPTION
By default, Twig templates are compiled as PHP files which are stored along with uploaded assets. This is not only a potential minor security issue, but it can also have a performance impact as shared storage is usually slower. 

To check:
- sites/default/files should not contain a "php" folder
- /tmp should contain a "twig" folder where the compiled php files are located