### PR TITLE
Leave random password generation to the mariadb chart

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -62,11 +62,13 @@ mariadb:
   replication:
     enabled: false
   rootUser:
-    password: "{{ randAlphaNum 10 }}" # pass in a value to your helm chart to override this
+    # A random password will be generated if you do not supply one. 
+    password:
   db:
     name: drupal
     user: drupal
-    password: "{{ randAlphaNum 10 }}" # pass in a value to your helm chart to override this
+    # A random password will be generated if you do not supply one. 
+    password:
 
 # Cluster configuration.
 clusterDomain: "silta.wdr.io"


### PR DESCRIPTION
If I don't explicitly specify a password in my parent values.yaml, my drupal installation fails.
Running printenv inside the dysfunctional drupal pod I see:
`DB_PASS={{ randAlphaNum 10 }}`

Which seems wrong, and to come from your values.yaml. I think the problem is that values.yaml is not processed as template, so `{{ randAlphaNum 10 }}` is being treated as a literal password, and something down the line can't handle a password with spaces in it.

It's also unnecessary to have this in values, we can leave it to the mariadb chart to handle random generation.