### PR TITLE
Remove failed postupgrade jobs only when necessary

### DIFF
--- a/chart/templates/postupgrade.yaml
+++ b/chart/templates/postupgrade.yaml
@@ -10,7 +10,7 @@ metadata:
     # job is considered part of the release.
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
+    "helm.sh/hook-delete-policy": "hook-succeeded,before-hook-creation"
 spec:
   template:
     spec:


### PR DESCRIPTION
Currently postupgrade jobs that fail dissappear without trace; this fix should leave the job (and thus logs) around which will help troubleshooting. They should be automatically removed when another upgrade is tried.