### PR TITLE
SLT-86: Use ambassadors use_remote_address and config nginx httpauth

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -91,3 +91,17 @@ imagePullSecrets:
   value: '/var/www/html/private'
 {{- end }}
 {{- end }}
+
+{{- define "nginx.basicauth" }}
+  {{- if .Values.nginx.basicauth.enabled }}
+  satisfy any;
+  allow 127.0.0.1;
+  {{- range .Values.nginx.noauthips }}
+  allow {{ . }};
+  {{- end }}
+  deny all;
+
+  auth_basic "Restricted";
+  auth_basic_user_file /etc/nginx/.htaccess;
+  {{- end }}
+{{- end }}

--- a/chart/templates/drupal-configmap-nginx.yaml
+++ b/chart/templates/drupal-configmap-nginx.yaml
@@ -5,7 +5,8 @@ metadata:
 data:
   nginx.conf: |
     user                            nginx;                                                 
-    worker_processes                auto;                                                  
+    worker_processes                auto;
+
     error_log                       /proc/self/fd/2 {{ .Values.nginx.loglevel }};                                 
                                                                                           
     events {                                                                               
@@ -13,16 +14,20 @@ data:
         multi_accept                on;                                                    
     }                                                                                      
                                                                                           
-    http {                                                                                 
+    http {
+
+        set_real_ip_from                {{ .Values.nginx.realipfrom }};
+        real_ip_header                  X-Forwarded-For;
+
         include                     /etc/nginx/mime.types;                                 
         default_type                application/octet-stream;                              
                                                                                           
-        log_format                  real_ip '$http_x_real_ip - $remote_user [$time_local] '
-                                            '"$request" $status $body_bytes_sent '
-                                            '"$http_referer" "$http_user_agent"';
+        log_format  main            '$remote_addr - $remote_user [$time_local] "$request" '
+                                    '$status $body_bytes_sent "$http_referer" '
+                                    '"$http_user_agent" "$http_x_forwarded_for"';
                                                             
                                                                                                               
-        access_log                  /proc/self/fd/1 combined;
+        access_log                  /proc/self/fd/1 main;
                                               
         send_timeout                60s;       
         sendfile                    on;        
@@ -84,9 +89,10 @@ data:
         index index.php;
                                                                               
         include fastcgi.conf;
-                                          
+
+        {{ include "nginx.basicauth" . | indent 6}}                                     
                                               
-        location / {                                                        
+        location / {                                                          
                                                     
             location ~* /system/files/ {
                 include fastcgi.conf;                                                                                                                      
@@ -353,10 +359,10 @@ data:
             access_log off;
         }
 
-        # Handle autocomplete to-cleanURLs policy
-        if ( $args ~* "^q=(?<query_value>.*)" ) {
-            rewrite ^/index.php$ $host/?q=$query_value? permanent;
-        }
+        # # Handle autocomplete to-cleanURLs policy
+        # if ( $args ~* "^q=(?<query_value>.*)" ) {
+        #     rewrite ^/index.php$ $host/?q=$query_value? permanent;
+        # }
 
         ## Disallow access to patches directory.
         location ^~ /patches { return 404; }
@@ -388,4 +394,5 @@ data:
             return 404;
         }                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                                                                                     
-    } 
+    }
+

--- a/chart/templates/drupal-deployment.yaml
+++ b/chart/templates/drupal-deployment.yaml
@@ -56,6 +56,12 @@ spec:
           mountPath: /etc/nginx/conf.d/drupal.conf # mount nginx-conf configmap volume to /etc/nginx
           readOnly: true
           subPath: conf.d/drupal.conf
+        {{- if .Values.nginx.basicauth.enabled }}
+        - name: nginx-basicauth
+          mountPath: /etc/nginx/.htaccess
+          readOnly: true
+          subPath: .htaccess
+        {{- end }}  
         resources:
 {{ .Values.nginx.resources | toYaml | indent 10 }}
 
@@ -69,4 +75,12 @@ spec:
                 path: nginx.conf
               - key: drupal.conf
                 path: conf.d/drupal.conf
+        {{- if .Values.nginx.basicauth.enabled }}
+        - name: nginx-basicauth
+          secret:
+            secretName: {{ .Release.Name }}-secrets-drupal
+            items:
+              - key: .htaccess
+                path: .htaccess
+        {{- end }}
       {{ include "drupal.imagePullSecrets" . | indent 6 }}

--- a/chart/templates/drupal-secret.yaml
+++ b/chart/templates/drupal-secret.yaml
@@ -11,3 +11,7 @@ data:
   {{ else }}
   hashsalt: {{ "{{ randAlphaNum 10 }}" | b64enc }}
   {{- end }}
+  {{- if .Values.nginx.basicauth.enabled }}
+  .htaccess: | 
+    {{ .Values.nginx.htaccess | b64enc }}
+  {{- end }}

--- a/chart/templates/drupal-service.yaml
+++ b/chart/templates/drupal-service.yaml
@@ -15,8 +15,15 @@ metadata:
       prefix: /
       service: {{ .Release.Name }}-drupal.{{ .Release.Namespace }}.svc.cluster.local:80
       timeout_ms: 30000
+      ---
+      apiVersion: ambassador/v0
+      kind: Module
+      name:  ambassador
+      config:
+        use_remote_address: true
 spec:
   type: NodePort
+  externalTrafficPolicy: Local
   ports:
     - port: 80
   selector:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -7,6 +7,15 @@ nginx:
     requests:
       cpu: 10m
       memory: 10M
+  realipfrom: 10.0.0.0/8
+  basicauth:
+    enabled: true
+  noauthips:
+    - 10.0.0.0/24 # GKE internal IPs
+    - 94.237.27.124
+  htaccess: |
+    susr:$apr1$0lHDNy4R$KCsw/NvLiapRJu1MgNN25.
+
 
 drupal:
   image: 'you need to pass in a value for drupal.image to your helm chart'


### PR DESCRIPTION
Story: Add basic auth protection (this goes slightly beyond what is asked in story (single per-cluster auth endpoint with static credentials) since in this implementation httpauth secret and whitelisted IPs can be configured per project in values.yml)

Testing: 
Deploy and attempt to connect to project URL. If not from whitelisted IP - htaccess prompt should be presented. User and password as defined Values should be accepted. If from whitelisted - password should not be prompted. Also check logs - you can see now that external IP is logged (nginx set_real_ip_from directive is used to get clients external IP and ambassadors use_remote_address config)

Notes: 
1.Some refactoring may be required for readability (e.g. if .Values.nginx.basicauth.enabled is used in 4 places but presently I do not see easy way around.)
2. if ( $args ~* "^q=(?<query_value>.*)" ) .. directive is commented out since that produced lots of noise in debug and leaving it out does not seam to impact funcitonality.
