### PR TITLE
Expand mariadb conditions

### DIFF
--- a/chart/requirements.yaml
+++ b/chart/requirements.yaml
@@ -2,4 +2,4 @@ dependencies:
 - name: mariadb
   version: 4.x.x
   repository: https://kubernetes-charts.storage.googleapis.com/
-  condition: mariadb.enabled
+  condition: mariadb.enabled,drupal.mariadb.enabled,global.mariadb.enabled


### PR DESCRIPTION
You'd think that in a parent chart setting 
```
drupal:
  mariadb:
    enabled: false

```
Would switch off the mariadb chart, but it doesn't. 

This is because the condition 'mariadb.enabled' in the drupal chart's requirements.yaml is evaluated in  the top-level chart, not the drupal chart.

I suggest expanding the requirement condition to make it 'mariadb.enabled,drupal.mariadb.enabled,global.mariadb.enabled'.

Relying on mariadb.enabled in the parent chart is particularly poor because we're already explicitly checking  mariadb.enabled in the drupal chart (so as to not pass mariadb database variables into drupal environment), so if we left things as they are now then any parent chart would need to do this:
```
mariadb:
  enabled: false
drupal:
  mariadb:
    enabled: false
```
Which is confusing and silly.