### PR TITLE
SLT-161: Add readiness and liveness checks to nginx.

### DIFF
--- a/chart/templates/drupal-deployment.yaml
+++ b/chart/templates/drupal-deployment.yaml
@@ -58,7 +58,14 @@ spec:
           mountPath: /etc/nginx/.htaccess
           readOnly: true
           subPath: .htaccess
-        {{- end }}  
+        {{- end }}
+        livenessProbe:
+          tcpSocket:
+            port: 80
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 80
         resources:
 {{ .Values.nginx.resources | toYaml | indent 10 }}
 


### PR DESCRIPTION
Liveness checks: If nginx is not listening on port 80, we need to kill the container. We don't want to do an HTTP request on port 80, because most requests are forwarded to the php container, and if that one fails we would be killing the wrong container.

Readiness checks: For this one we actually want to wait until we are serving successful responses before we start serving traffic from that container.