### PR TITLE
Feature/slt 153 cicleanup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ jobs:
 
       - run: |
           # Login to docker repository
-          echo $GCLOUD_KEY_JSON | docker login -u _json_key --password-stdin https://eu.gcr.io
+          echo $GCLOUD_KEY_JSON | docker login -u _json_key --password-stdin $DOCKER_REPO_URL
 
           # Build the Nginx image and push it to the repository.
           docker build -t $DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/${CIRCLE_PROJECT_REPONAME,,}-nginx:$CIRCLE_SHA1 web

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
       - setup_remote_docker
 
       - run: |
-          #echo $DOCKER_PASSWORD | docker login -u $DOCKER_USER --password-stdin $DOCKER_REPO_HOST
+          
           echo $GCLOUD_KEY_JSON | docker login -u _json_key --password-stdin https://eu.gcr.io
 
           # Build the Nginx image and push it to the repository.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,12 +77,12 @@ jobs:
       - set_release_name
 
       - run: |
+          # Save key, authenticate and set compute zone
           echo $GCLOUD_KEY_JSON > ${HOME}/gcloud-service-key.json
-
           gcloud auth activate-service-account --key-file=${HOME}/gcloud-service-key.json --project $GCLOUD_PROJECT_NAME
           gcloud config set compute/zone $GCLOUD_COMPUTE_ZONE
 
-          # updates a kubeconfig file with appropriate credentials and endpoint information 
+          # Updates a kubeconfig file with appropriate credentials and endpoint information 
           # to point kubectl at a specific cluster in Google Kubernetes Engine
           gcloud container clusters get-credentials $GCLOUD_COMPUTE_ZONE  --zone $GCLOUD_COMPUTE_ZONE --project $GCLOUD_PROJECT_NAME
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,9 @@
-version: 2
+version: 2.1
+commands:
+  set_release_name:
+    steps:
+      - run: /home/circleci/utils/set_release_name.sh
+
 jobs:
   validate:
     docker:
@@ -67,9 +72,7 @@ jobs:
     steps:
       - checkout
 
-      - run: |
-          # Set the release name for later reuse.
-          /home/circleci/utils/set_release_name.sh
+      - set_release_name
 
       - run: |
           echo $GCLOUD_KEY_JSON > ${HOME}/gcloud-service-key.json

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,15 +67,9 @@ jobs:
     steps:
       - checkout
 
-      # Set the release name for later reuse.
-      # Release name length is 37 chars long, which leaves max 16 chars for kubernetes resource name.
-      # Release name is prefixed with w because  it _HAS_ to start with alphabetic character. w 4 wunder.
       - run: |
-          LOWERCASE_BRANCH=${CIRCLE_BRANCH,,}
-          REPONAME_HASH=$(echo ${CIRCLE_PROJECT_REPONAME,,} | shasum -a 256 | cut -c 1-8 )
-          BRANCHNAME_HASH=$(echo $LOWERCASE_BRANCH | shasum -a 256 | cut -c 1-8 )
-          BRANCHNAME_TRUNCATED=$(echo ${LOWERCASE_BRANCH//[^[:alnum:]]/-} | cut -c 1-20 | sed 's/^\(.*\)-$/\1/' )
-          echo "export RELEASE_NAME='w$REPONAME_HASH-$BRANCHNAME_HASH-$BRANCHNAME_TRUNCATED'" >> $BASH_ENV
+          # Set the release name for later reuse.
+          /home/circleci/set_release_name.sh
 
       - run: |
           echo $GCLOUD_KEY_JSON > ${HOME}/gcloud-service-key.json

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   validate:
     docker:
-      - image: wunderio/silta-circleci:v0.1
+      - image: wunderio/silta-circleci-test
 
     steps:
       - checkout
@@ -13,7 +13,7 @@ jobs:
 
   build:
     docker:
-      - image: wunderio/silta-circleci:v0.1
+      - image: wunderio/silta-circleci-test
 
     steps:
       - checkout
@@ -62,17 +62,23 @@ jobs:
 
   deploy:
     docker:
-      - image: wunderio/silta-circleci:v0.1
+      - image: wunderio/silta-circleci-test
 
     steps:
       - checkout
 
       - run: |
           # Set the release name for later reuse.
-          /home/circleci/set_release_name.sh
+          /home/circleci/utils/set_release_name.sh
 
       - run: |
           echo $GCLOUD_KEY_JSON > ${HOME}/gcloud-service-key.json
+          # /home/circleci/utils/gcloud_init.sh \
+          #   $SERVICE_KEY_PATH \
+          #   $PROJECT_NAME \
+          #   $COMPUTE_ZONE \
+          #   $CLUSTER_NAME
+
           gcloud auth activate-service-account --key-file=${HOME}/gcloud-service-key.json
           gcloud config set project silta-204108
           gcloud config set compute/zone europe-west2-a

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
       - setup_remote_docker
 
       - run: |
-          
+          # Login to docker repository
           echo $GCLOUD_KEY_JSON | docker login -u _json_key --password-stdin https://eu.gcr.io
 
           # Build the Nginx image and push it to the repository.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,16 +78,14 @@ jobs:
 
       - run: |
           echo $GCLOUD_KEY_JSON > ${HOME}/gcloud-service-key.json
-          # /home/circleci/utils/gcloud_init.sh \
-          #   $SERVICE_KEY_PATH \
-          #   $PROJECT_NAME \
-          #   $COMPUTE_ZONE \
-          #   $CLUSTER_NAME
 
           gcloud auth activate-service-account --key-file=${HOME}/gcloud-service-key.json
-          gcloud config set project silta-204108
-          gcloud config set compute/zone europe-west2-a
-          gcloud container clusters get-credentials silta-1 --zone europe-west2-a --project silta-204108
+          gcloud config set project $GCLOUD_PROJECT_NAME
+          gcloud config set compute/zone $GCLOUD_COMPUTE_ZONE
+
+          # updates a kubeconfig file with appropriate credentials and endpoint information 
+          # to point kubectl at a specific cluster in Google Kubernetes Engine
+          gcloud container clusters get-credentials $GCLOUD_COMPUTE_ZONE  --zone $GCLOUD_COMPUTE_ZONE --project $GCLOUD_PROJECT_NAME
 
       - run: |
           helm dependency build ./chart

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,6 +51,8 @@ jobs:
             - node_modules
           key: v1-yarn-{{ checksum "yarn.lock" }}
 
+      # To build Docker images for deployment, we must use a special setup_remote_docker 
+      # key which creates a separate environment for each build.
       - setup_remote_docker
 
       - run: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,7 +84,7 @@ jobs:
 
           # Updates a kubeconfig file with appropriate credentials and endpoint information 
           # to point kubectl at a specific cluster in Google Kubernetes Engine
-          gcloud container clusters get-credentials $GCLOUD_COMPUTE_ZONE  --zone $GCLOUD_COMPUTE_ZONE --project $GCLOUD_PROJECT_NAME
+          gcloud container clusters get-credentials $GCLOUD_CLUSTER_NAME  --zone $GCLOUD_COMPUTE_ZONE --project $GCLOUD_PROJECT_NAME
 
       - run: |
           helm dependency build ./chart

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,8 +79,7 @@ jobs:
       - run: |
           echo $GCLOUD_KEY_JSON > ${HOME}/gcloud-service-key.json
 
-          gcloud auth activate-service-account --key-file=${HOME}/gcloud-service-key.json
-          gcloud config set project $GCLOUD_PROJECT_NAME
+          gcloud auth activate-service-account --key-file=${HOME}/gcloud-service-key.json --project $GCLOUD_PROJECT_NAME
           gcloud config set compute/zone $GCLOUD_COMPUTE_ZONE
 
           # updates a kubeconfig file with appropriate credentials and endpoint information 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,9 @@ commands:
   set_release_name:
     steps:
       - run: /home/circleci/utils/set_release_name.sh
+  setup_cluster_access:
+    steps:
+      - run: /home/circleci/utils/gcloud_init.sh
 
 jobs:
   validate:
@@ -76,15 +79,7 @@ jobs:
 
       - set_release_name
 
-      - run: |
-          # Save key, authenticate and set compute zone
-          echo $GCLOUD_KEY_JSON > ${HOME}/gcloud-service-key.json
-          gcloud auth activate-service-account --key-file=${HOME}/gcloud-service-key.json --project $GCLOUD_PROJECT_NAME
-          gcloud config set compute/zone $GCLOUD_COMPUTE_ZONE
-
-          # Updates a kubeconfig file with appropriate credentials and endpoint information 
-          # to point kubectl at a specific cluster in Google Kubernetes Engine
-          gcloud container clusters get-credentials $GCLOUD_CLUSTER_NAME  --zone $GCLOUD_COMPUTE_ZONE --project $GCLOUD_PROJECT_NAME
+      - setup_cluster_access
 
       - run: |
           helm dependency build ./chart


### PR DESCRIPTION
Story: SLT-153
Move env variable to silta-circleci docker image 
Remove obsolete docker repository login.
Remove hard-coded values (“silta-204108”, “europe-west2-a”, etc)

Implementation: 
Circle CI workflow upgraded to 2.1 and set_release_name and setup_cluster_access commands defined 
Logic itself (as bash scripts) moved to circleci image
Hard-coded variables move to circleCI context ($GCLOUD_COMPUTE_ZONE, $GCLOUD_PROJECT_NAME, $GCLOUD_CLUSTER_NAME, $DOCKER_REPO_URL)

Testing: 
For testing the current workflow refers to wunderio/silta-circleci-test image that has the scripts. After scripts are in  wunderio/silta-circleci (https://github.com/wunderio/silta-circleci/pull/5), this should be changed back to wunderio/silta-circleci:v0.N
