### PR TITLE
SLT-166: Import reference database dump for new environments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,7 +98,6 @@ jobs:
             --set mariadb.db.password=$DB_USER_PASS \
             --namespace=${CIRCLE_PROJECT_REPONAME,,} \
             --values silta.yml \
-            --timeout=600 \
             --wait
 
 workflows:

--- a/chart/templates/postinstall.yaml
+++ b/chart/templates/postinstall.yaml
@@ -9,7 +9,7 @@ metadata:
     # job is considered part of the release.
     "helm.sh/hook": post-install
     "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": "hook-succeeded,before-hook-creation"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
 spec:
   template:
     spec:

--- a/chart/templates/postupgrade.yaml
+++ b/chart/templates/postupgrade.yaml
@@ -9,7 +9,7 @@ metadata:
     # job is considered part of the release.
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": "hook-succeeded,before-hook-creation"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
 spec:
   template:
     spec:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -76,6 +76,10 @@ php:
       if [ -f reference-data/db.sql.gz ]; then
         echo "Importing reference database dump"
         cat reference-data/db.sql.gz | gunzip | drush sql-cli
+
+        echo "Importing public files"
+        tar xf reference-data/public_files.tar.gz
+
         drush cr
         drush updatedb -n
         if [ -f config/sync/core.extension.yml ]; then
@@ -134,13 +138,18 @@ referenceData:
   command: |
     if [[ "$(drush status --field=bootstrap)" == "Successful" ]];
     then
-      # NFS doesn't support replacing a file, so we delete it instead.
-      rm -f reference-data/db.sql.gz
+      # NFS doesn't support replacing files, so we delete them instead.
+      rm -f reference-data/*
+
+      # Export database dump.
       if [ -f gdpr.json ]; then
         drush sql-dump --gzip --extra-dump="--gdpr-replacements-file=../gdpr.json" --result-file ../reference-data/db.sql
       else
         drush sql-dump --gzip --result-file ../reference-data/db.sql
       fi
+
+      # Export public files.
+      tar cz --exclude=css --exclude=js -f reference-data/public_files.tar.gz web/sites/default/files/
     else
       echo "Drupal is not installed, skipping reference database dump."
     fi

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -77,7 +77,7 @@ php:
     command: |
       if [ -f reference-data/db.sql.gz ]; then
         echo "Importing reference database dump"
-        cat reference-data/db.sql.gz | gunzip | drush sql-query
+        cat reference-data/db.sql.gz | gunzip | drush sql-cli
 
       elif [ -f config/sync/core.extension.yml ]; then
         echo "Installing Drupal from existing configuration"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -65,11 +65,9 @@ php:
   cron:
     - schedule: '0 * * * *'
       command: |
-        bootstrapped=$(drush status --field=bootstrap);
-        if [[ $bootstrapped = "Successful" ]];
-        then
-          drush cron;
-        fi;
+        if [[ "$(drush status --field=bootstrap)" == "Successful" ]]; then
+          drush cron
+        fi
 
   # Post-installation hook.
   # This is run every time a new environment is created.
@@ -97,10 +95,10 @@ php:
   # This is run every time a new environment is upgraded.
   postupgrade:
     command: |
-      cd web;
-      conf_count=$(ls ../config/sync/ | wc -l);
-      if [ $conf_count -gt 1 ]; then drush updatedb -n; drush config-import -n; drush entity-updates -n;
-      fi;
+      drush updatedb -n
+      if [ -f config/sync/core.extension.yml ]; then
+        drush config-import -n
+      fi
 
   # Pass additional environment variables to all php containers as key-value pairs.
   env: {}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -76,7 +76,7 @@ php:
       if [ -f reference-data/db.sql.gz ]; then
         echo "Importing reference database dump"
         cat reference-data/db.sql.gz | gunzip | drush sql-cli
-
+        drush cr
         drush updatedb -n
         if [ -f config/sync/core.extension.yml ]; then
           drush config-import -n

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -75,11 +75,18 @@ php:
   # This is run every time a new environment is created.
   postinstall:
     command: |
-      cd web;
-      conf_count=$(ls ../config/sync/ | wc -l);
-      if [ $conf_count -gt 1 ]; then drush site-install -n config_installer;
-      else drush site-install minimal -y;
-      fi;
+      if [ -f reference-data/db.sql.gz ]; then
+        echo "Importing reference database dump"
+        cat reference-data/db.sql.gz | gunzip | drush sql-query
+
+      elif [ -f config/sync/core.extension.yml ]; then
+        echo "Installing Drupal from existing configuration"
+        drush site-install -n config_installer
+
+      else
+        echo "No configuration found, installing a plain drupal site"
+        drush site-install -n standard
+      fi
 
   # Post-upgrade hook.
   # This is run every time a new environment is upgraded.

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -79,6 +79,11 @@ php:
         echo "Importing reference database dump"
         cat reference-data/db.sql.gz | gunzip | drush sql-cli
 
+        drush updatedb -n
+        if [ -f config/sync/core.extension.yml ]; then
+          drush config-import -n
+        fi
+
       elif [ -f config/sync/core.extension.yml ]; then
         echo "Installing Drupal from existing configuration"
         drush site-install -n config_installer


### PR DESCRIPTION
You can delete the `w68f3d122-b5a8b6f7-feature-reference-da` release and re-run the last deployment from https://circleci.com/gh/wunderio/drupal-project-k8s/tree/feature%2Freference-data-import, you will then get a working environment running on http://feature-reference-data-import.drupal-project-k8s.silta.wdr.io/ based on the latest reference database dump. Note that name of the admin user is set to a random generated value, thanks to the GDPR sanitization.

What is not included and moved to a dedicated ticket:
- Optimise the dumps so the cache tables are not included
- Copy the drupal ~public and~ private files 
- Skip dumps if the gdpr-dump package is not present