### PR TITLE
SLT-162 deployment selector fix

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -1,6 +1,5 @@
 {{- define "drupal.release_labels" }}
 app: {{ .Values.app | quote }}
-version: {{ .Chart.Version }}
 release: {{ .Release.Name }}
 {{- end }}
 

--- a/chart/templates/drupal-deployment.yaml
+++ b/chart/templates/drupal-deployment.yaml
@@ -9,12 +9,14 @@ spec:
   selector:
     matchLabels:
       {{ include "drupal.release_labels" . | indent 6 }}
+      deployment: drupal
   strategy:
     type: Recreate
   template:
     metadata:
       labels:
         {{ include "drupal.release_labels" . | indent 8 }}
+        deployment: drupal
     spec:
       containers:
       # php-fpm container.


### PR DESCRIPTION
We are facing this issue: https://github.com/helm/helm/issues/2494

The pod selector for a deployment and the label template need to be identical, the selector is also immutable. This leads to a problem when the chart version is used as a label, upgrading to a newer version is then not allowed.

This fix itself breaks an upgrade because it changes an immutable field. There is no need to delete the whole release though, it is sufficient to delete the deployment and re-run the helm upgrade.