### PR TITLE
SLT-173 & SLT-170: streamline gdpr-dump usage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
       - run: helm unittest ./chart
 
       - run: |
-          if grep machbarmacher/gdpr-dump composer.json; then
+          if ! grep machbarmacher/gdpr-dump composer.json; then
             echo "Please install machbarmacher/gdpr-dump for sanitized database dumps."
           elif [ ! -f gdpr.json ]; then
             echo "machbarmacher/gdpr-dump is present but no gdpr.json was found."

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,8 +24,6 @@ jobs:
 
       - run: |
           composer install -n --prefer-dist --ignore-platform-reqs --no-dev
-          composer config repositories.gdpr-dump-mods git https://github.com/Jancis/gdpr-dump
-          composer require machbarmacher/gdpr-dump:dev-mods -n --ignore-platform-reqs
 
       - save_cache:
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,13 @@ jobs:
 
       - run: helm unittest ./chart
 
+      - run: |
+          if grep machbarmacher/gdpr-dump composer.json; then
+            echo "Please install machbarmacher/gdpr-dump for sanitized database dumps."
+          elif [ ! -f gdpr.json ]; then
+            echo "machbarmacher/gdpr-dump is present but no gdpr.json was found."
+          fi
+
   build:
     docker:
       - image: wunderio/silta-circleci:v0.1

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -136,20 +136,21 @@ referenceData:
 
   schedule: '0 3 * * *'
   command: |
-    if [[ "$(drush status --field=bootstrap)" == "Successful" ]];
-    then
-      # NFS doesn't support replacing files, so we delete them instead.
-      rm -f reference-data/*
+    if [[ "$(drush status --field=bootstrap)" == "Successful" ]]; then
 
-      # Export database dump.
-      if [ -f gdpr.json ]; then
-        drush sql-dump --gzip --extra-dump="--gdpr-replacements-file=../gdpr.json" --result-file ../reference-data/db.sql
+      if [ -d vendor/machbarmacher/gdpr-dump ] && [ -f gdpr.json ]; then
+
+        # NFS doesn't support replacing files, so we delete them instead.
+        rm -f reference-data/*
+
+        # Export database dump.
+        drush sql-dump --gzip --result-file ../reference-data/db2.sql
+
+        # Export public files.
+        tar cz --exclude=css --exclude=js -f reference-data/public_files.tar.gz web/sites/default/files/
       else
-        drush sql-dump --gzip --result-file ../reference-data/db.sql
+        echo "Reference dumps are only enabled with proper sanitization. Make sure machbarmacher/gdpr-dump is installed and gdpr.json is present in the project root."
       fi
-
-      # Export public files.
-      tar cz --exclude=css --exclude=js -f reference-data/public_files.tar.gz web/sites/default/files/
     else
       echo "Drupal is not installed, skipping reference database dump."
     fi

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -138,7 +138,7 @@ referenceData:
 
   schedule: '0 3 * * *'
   command: |
-    if [[ "$(drush status --field=bootstrap)" == "Successful" ]]; then
+    if drush check-bootstrap; then
 
       if [ -d vendor/machbarmacher/gdpr-dump ] && [ -f gdpr.json ]; then
 
@@ -146,7 +146,7 @@ referenceData:
         rm -f reference-data/*
 
         # Export database dump.
-        drush sql-dump --gzip --result-file ../reference-data/db2.sql
+        drush sql-dump --gzip --result-file ../reference-data/db.sql
 
         # Export public files.
         tar cz --exclude=css --exclude=js -f reference-data/public_files.tar.gz web/sites/default/files/

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
         "drupal/simplei": "^1.0",
         "drupal/warden": "*",
         "drush/drush": "^9.0.0",
+        "machbarmacher/gdpr-dump": "dev-master",
         "vlucas/phpdotenv": "^2.4",
         "webflo/drupal-finder": "^1.0.0",
         "webmozart/path-util": "^2.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "0c6fcc90854c0faff396efaebab54053",
-    "content-hash": "827ec7e545e62d14b69e84fab56e9b16",
+    "hash": "2fab6e25a377c6379a9005dcf1b69c71",
+    "content-hash": "545c69e6fe7b58de382d5a4e30863ba6",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -122,6 +122,37 @@
                 "stack"
             ],
             "time": "2017-12-20 14:37:45"
+        },
+        {
+            "name": "bomoko/mysql-cnf-parser",
+            "version": "0.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/bomoko/mysql_cnf_parser.git",
+                "reference": "5e98657a6846ff8a3b3f3e7c1f98b03dcf1bc9ab"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/bomoko/mysql_cnf_parser/zipball/5e98657a6846ff8a3b3f3e7c1f98b03dcf1bc9ab",
+                "reference": "5e98657a6846ff8a3b3f3e7c1f98b03dcf1bc9ab",
+                "shasum": ""
+            },
+            "require": {
+                "nette/finder": "^3.0@dev",
+                "webmozart/path-util": "^2.3@dev"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.3@dev"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "bomoko\\MysqlCnfParser\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "description": ".cnf parser",
+            "time": "2018-06-19 02:30:15"
         },
         {
             "name": "chi-teck/drupal-code-generator",
@@ -2615,6 +2646,56 @@
             "time": "2018-09-25 20:59:41"
         },
         {
+            "name": "fzaninotto/faker",
+            "version": "v1.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/fzaninotto/Faker.git",
+                "reference": "f72816b43e74063c8b10357394b6bba8cb1c10de"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/fzaninotto/Faker/zipball/f72816b43e74063c8b10357394b6bba8cb1c10de",
+                "reference": "f72816b43e74063c8b10357394b6bba8cb1c10de",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.3 || ^7.0"
+            },
+            "require-dev": {
+                "ext-intl": "*",
+                "phpunit/phpunit": "^4.8.35 || ^5.7",
+                "squizlabs/php_codesniffer": "^1.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.8-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Faker\\": "src/Faker/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "François Zaninotto"
+                }
+            ],
+            "description": "Faker is a PHP library that generates fake data for you.",
+            "keywords": [
+                "data",
+                "faker",
+                "fixtures"
+            ],
+            "time": "2018-07-12 10:23:15"
+        },
+        {
             "name": "g1a/composer-test-scenarios",
             "version": "2.2.0",
             "source": {
@@ -2924,6 +3005,61 @@
             "time": "2017-03-20 17:10:46"
         },
         {
+            "name": "ifsnop/mysqldump-php",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ifsnop/mysqldump-php.git",
+                "reference": "16b7dc787ea494165eb948d6a5920a315456bd26"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ifsnop/mysqldump-php/zipball/16b7dc787ea494165eb948d6a5920a315456bd26",
+                "reference": "16b7dc787ea494165eb948d6a5920a315456bd26",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "3.7.*",
+                "squizlabs/php_codesniffer": "1.*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Ifsnop\\": "src/Ifsnop/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Diego Torres",
+                    "homepage": "https://github.com/ifsnop",
+                    "role": "Developer"
+                }
+            ],
+            "description": "PHP version of mysqldump cli that comes with MySQL",
+            "homepage": "https://github.com/ifsnop/mysqldump-php",
+            "keywords": [
+                "PHP7",
+                "database",
+                "hhvm",
+                "mariadb",
+                "mysql",
+                "mysql-backup",
+                "mysqldump",
+                "pdo",
+                "php",
+                "php5",
+                "sql"
+            ],
+            "time": "2018-10-12 22:21:12"
+        },
+        {
             "name": "jakub-onderka/php-console-color",
             "version": "v0.2",
             "source": {
@@ -3120,6 +3256,60 @@
             "time": "2017-05-10 09:20:27"
         },
         {
+            "name": "machbarmacher/gdpr-dump",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/machbarmacher/gdpr-dump.git",
+                "reference": "a1dc9cd1fc1677822c624d5c38939859c14f6630"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/machbarmacher/gdpr-dump/zipball/a1dc9cd1fc1677822c624d5c38939859c14f6630",
+                "reference": "a1dc9cd1fc1677822c624d5c38939859c14f6630",
+                "shasum": ""
+            },
+            "require": {
+                "bomoko/mysql-cnf-parser": "^0.0.2",
+                "cweagans/composer-patches": "^1.6",
+                "fzaninotto/faker": "^1.7",
+                "ifsnop/mysqldump-php": "dev-master",
+                "symfony/console": "^3.0",
+                "symfony/event-dispatcher": "~3.4|~4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.2"
+            },
+            "bin": [
+                "mysqldump"
+            ],
+            "type": "library",
+            "extra": {
+                "patches": {
+                    "ifsnop/mysqldump-php": {
+                        "Add getter": "https://patch-diff.githubusercontent.com/raw/ifsnop/mysqldump-php/pull/137.patch"
+                    }
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "machbarmacher\\GdprDump\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Axel Rutz",
+                    "email": "axel.rutz@machbarmacher.net"
+                }
+            ],
+            "description": "A drop-in replacement for mysqldump that optionally sanitizes DB fields for better GDPR conformity.",
+            "time": "2018-11-07 06:07:11"
+        },
+        {
             "name": "masterminds/html5",
             "version": "2.3.1",
             "source": {
@@ -3183,6 +3373,144 @@
                 "xml"
             ],
             "time": "2018-10-22 16:58:34"
+        },
+        {
+            "name": "nette/finder",
+            "version": "v3.0.0-RC",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nette/finder.git",
+                "reference": "21d4aa7834e8cb58f3a1666607acdf00d7486edb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nette/finder/zipball/21d4aa7834e8cb58f3a1666607acdf00d7486edb",
+                "reference": "21d4aa7834e8cb58f3a1666607acdf00d7486edb",
+                "shasum": ""
+            },
+            "require": {
+                "nette/utils": "^2.4 || ~3.0.0",
+                "php": ">=7.0"
+            },
+            "conflict": {
+                "nette/nette": "<2.2"
+            },
+            "require-dev": {
+                "nette/tester": "^2.0",
+                "tracy/tracy": "^2.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause",
+                "GPL-2.0",
+                "GPL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "David Grudl",
+                    "homepage": "https://davidgrudl.com"
+                },
+                {
+                    "name": "Nette Community",
+                    "homepage": "https://nette.org/contributors"
+                }
+            ],
+            "description": "Nette Finder: Files Searching",
+            "homepage": "https://nette.org",
+            "time": "2017-02-02 02:09:35"
+        },
+        {
+            "name": "nette/utils",
+            "version": "v2.5.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nette/utils.git",
+                "reference": "17b9f76f2abd0c943adfb556e56f2165460b15ce"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nette/utils/zipball/17b9f76f2abd0c943adfb556e56f2165460b15ce",
+                "reference": "17b9f76f2abd0c943adfb556e56f2165460b15ce",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6.0"
+            },
+            "conflict": {
+                "nette/nette": "<2.2"
+            },
+            "require-dev": {
+                "nette/tester": "~2.0",
+                "tracy/tracy": "^2.3"
+            },
+            "suggest": {
+                "ext-gd": "to use Image",
+                "ext-iconv": "to use Strings::webalize() and toAscii()",
+                "ext-intl": "for script transliteration in Strings::webalize() and toAscii()",
+                "ext-json": "to use Nette\\Utils\\Json",
+                "ext-mbstring": "to use Strings::lower() etc...",
+                "ext-xml": "to use Strings::length() etc. when mbstring is not available"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.5-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ],
+                "files": [
+                    "src/loader.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause",
+                "GPL-2.0",
+                "GPL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "David Grudl",
+                    "homepage": "https://davidgrudl.com"
+                },
+                {
+                    "name": "Nette Community",
+                    "homepage": "https://nette.org/contributors"
+                }
+            ],
+            "description": "🛠 Nette Utils: lightweight utilities for string & array manipulation, image handling, safe JSON encoding/decoding, validation, slug or strong password generating etc.",
+            "homepage": "https://nette.org",
+            "keywords": [
+                "array",
+                "core",
+                "datetime",
+                "images",
+                "json",
+                "nette",
+                "paginator",
+                "password",
+                "slugify",
+                "string",
+                "unicode",
+                "utf-8",
+                "utility",
+                "validation"
+            ],
+            "time": "2018-09-18 10:22:16"
         },
         {
             "name": "nikic/php-parser",
@@ -7893,7 +8221,9 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": [],
+    "stability-flags": {
+        "machbarmacher/gdpr-dump": 20
+    },
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": [],

--- a/drush/drush.yml
+++ b/drush/drush.yml
@@ -4,3 +4,10 @@
 # Docs at https://github.com/drush-ops/drush/blob/master/examples/example.drush.yml
 #
 # Edit or remove this file as needed.
+
+command:
+  sql:
+    dump:
+      options:
+        # Always sanitize database dump with gdpr-dump.
+        extra-dump: "--gdpr-replacements-file=../gdpr.json"


### PR DESCRIPTION
The main changes are:
- Use the official version of machbarmacher/gdpr-dump now that https://github.com/machbarmacher/gdpr-dump/pull/28 and https://github.com/machbarmacher/gdpr-dump/pull/27 have been merged
- Only create a reference dump if machbarmacher/gdpr-dump is installed and configured. 

This code only runs automatically on the reference branch, I ran it manually on the environment for testing purposes.