### PR TITLE
Feature/slt 183 postinstall db readiness check

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -76,7 +76,7 @@ php:
       TIME_WAITING=0
       until mysqladmin status --connect_timeout=2 -u $DB_USER -p$DB_PASS -h $DB_HOST > /dev/null 2>&1; do
         echo "Waiting for database..."; sleep 5
-        ((TIME_WAITING +=5))
+        (( TIME_WAITING +=5 ))
 
         if [ $TIME_WAITING -gt 60 ]; then
           echo "Database connection timeout"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -75,15 +75,18 @@ php:
     command: |
       if [ -f reference-data/db.sql.gz ]; then
         TIME_WAITING=0
-        until drush check-bootstrap:db || [ $TIME_WAITING -gt 60 ]; do
+        until mysqladmin status --connect_timeout=2 -u $DB_USER -p$DB_PASS -h $DB_HOST > /dev/null 2>&1 || [ $TIME_WAITING -gt 60 ]; do
           sleep 5;
-          TIME_WAITING=$(( TIME_WAITING + 5 ))
+          TIME_WAITING=$(( $TIME_WAITING + 5 ))
         done
 
-        if [ $TIME_WAITING -lt 60 ]; then
-          echo "Importing reference database dump"
-          cat reference-data/db.sql.gz | gunzip | drush sql-cli
+        if [ $TIME_WAITING -gt 60 ]; then
+          echo "Database connection timeout"
+          exit 1
         fi
+
+        echo "Importing reference database dump"
+        cat reference-data/db.sql.gz | gunzip | drush sql-cli
 
         echo "Importing public files"
         tar xf reference-data/public_files.tar.gz

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -74,8 +74,16 @@ php:
   postinstall:
     command: |
       if [ -f reference-data/db.sql.gz ]; then
-        echo "Importing reference database dump"
-        cat reference-data/db.sql.gz | gunzip | drush sql-cli
+        TIME_WAITING=0
+        until drush check-bootstrap:db || [ $TIME_WAITING -gt 60 ]; do
+          sleep 5;
+          TIME_WAITING=$(( TIME_WAITING + 5 ))
+        done
+
+        if [ $TIME_WAITING -lt 60 ]; then
+          echo "Importing reference database dump"
+          cat reference-data/db.sql.gz | gunzip | drush sql-cli
+        fi
 
         echo "Importing public files"
         tar xf reference-data/public_files.tar.gz

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -74,15 +74,15 @@ php:
   postinstall:
     command: |
       TIME_WAITING=0
-      until mysqladmin status --connect_timeout=2 -u $DB_USER -p$DB_PASS -h $DB_HOST > /dev/null 2>&1 || [ $TIME_WAITING -gt 60 ]; do
-        sleep 5;
-        TIME_WAITING=$(( $TIME_WAITING + 5 ))
-      done
+      until mysqladmin status --connect_timeout=2 -u $DB_USER -p$DB_PASS -h $DB_HOST > /dev/null 2>&1; do
+        echo "Waiting for database..."; sleep 5
+        ((TIME_WAITING +=5))
 
-      if [ $TIME_WAITING -gt 60 ]; then
-        echo "Database connection timeout"
-        exit 1
-      fi
+        if [ $TIME_WAITING -gt 60 ]; then
+          echo "Database connection timeout"
+          exit 1
+        fi
+      done
 
       if [ -f reference-data/db.sql.gz ]; then
 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -73,17 +73,18 @@ php:
   # This is run every time a new environment is created.
   postinstall:
     command: |
-      if [ -f reference-data/db.sql.gz ]; then
-        TIME_WAITING=0
-        until mysqladmin status --connect_timeout=2 -u $DB_USER -p$DB_PASS -h $DB_HOST > /dev/null 2>&1 || [ $TIME_WAITING -gt 60 ]; do
-          sleep 5;
-          TIME_WAITING=$(( $TIME_WAITING + 5 ))
-        done
+      TIME_WAITING=0
+      until mysqladmin status --connect_timeout=2 -u $DB_USER -p$DB_PASS -h $DB_HOST > /dev/null 2>&1 || [ $TIME_WAITING -gt 60 ]; do
+        sleep 5;
+        TIME_WAITING=$(( $TIME_WAITING + 5 ))
+      done
 
-        if [ $TIME_WAITING -gt 60 ]; then
-          echo "Database connection timeout"
-          exit 1
-        fi
+      if [ $TIME_WAITING -gt 60 ]; then
+        echo "Database connection timeout"
+        exit 1
+      fi
+
+      if [ -f reference-data/db.sql.gz ]; then
 
         echo "Importing reference database dump"
         cat reference-data/db.sql.gz | gunzip | drush sql-cli

--- a/drush/Commands/CheckBootstrapCommands.php
+++ b/drush/Commands/CheckBootstrapCommands.php
@@ -16,7 +16,7 @@ class CheckBootstrapCommands extends DrushCommands implements SiteAliasManagerAw
    *
    * @command check-bootstrap:full
    * @aliases check-bootstrap, cb
-   * @bootstrap max
+   * @bootstrap max full
    */
   public function isBootstrapFull() {
     $this->checkBootstrapPhase(DRUSH_BOOTSTRAP_DRUPAL_FULL);
@@ -28,7 +28,7 @@ class CheckBootstrapCommands extends DrushCommands implements SiteAliasManagerAw
    * @see DRUSH_BOOTSTRAP_DRUPAL_DATABASE
    *
    * @command check-bootstrap:db
-   * @bootstrap max
+   * @bootstrap max db
    */
   public function isBootstrapDatabase() {
     $this->checkBootstrapPhase(DRUSH_BOOTSTRAP_DRUPAL_DATABASE);
@@ -40,7 +40,7 @@ class CheckBootstrapCommands extends DrushCommands implements SiteAliasManagerAw
    * @see DRUSH_BOOTSTRAP_DRUPAL_CONFIGURATION
    *
    * @command check-bootstrap:config
-   * @bootstrap max
+   * @bootstrap max config
    */
   public function isBootstrapConfiguration() {
     $this->checkBootstrapPhase(DRUSH_BOOTSTRAP_DRUPAL_CONFIGURATION);
@@ -52,7 +52,7 @@ class CheckBootstrapCommands extends DrushCommands implements SiteAliasManagerAw
    * @see DRUSH_BOOTSTRAP_DRUPAL_SITE
    *
    * @command check-bootstrap:site
-   * @bootstrap max
+   * @bootstrap max site
    */
   public function isBootstrapSite() {
     $this->checkBootstrapPhase(DRUSH_BOOTSTRAP_DRUPAL_SITE);
@@ -64,7 +64,7 @@ class CheckBootstrapCommands extends DrushCommands implements SiteAliasManagerAw
    * @see DRUSH_BOOTSTRAP_DRUPAL_ROOT
    *
    * @command check-bootstrap:root
-   * @bootstrap max
+   * @bootstrap max root
    */
   public function isBootstrapRoot() {
     $this->checkBootstrapPhase(DRUSH_BOOTSTRAP_DRUPAL_ROOT);


### PR DESCRIPTION
**Story:** 
https://wunder.atlassian.net/browse/SLT-183

**Description:**
> When a helm release is created without the `--wait` parameter, the post-install hook gets executed right away, before the database is ready. The post-install hook should poll the database using `drush status --field=Database` and wait for the output to be `Connected`.

Tried to use both `drush status --field=Database` and the new `drush check-bootstrap:db`, but it returned `[notice] Missing database table: key_value` so i went with a raw database connection.

I'm open to any suggestion of making this a bit less ugly.
