### PR TITLE
SLT-169: Removes failed release before deployment if it was the first release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,6 +106,7 @@ jobs:
           if [[ "$( helm list --failed | grep $RELEASE_NAME  | cut -f2 )" -eq 1 ]]; then
             echo "Removing failed first release"
             helm delete --purge $RELEASE_NAME
+            sleep 30
           fi
 
           helm upgrade --install $RELEASE_NAME ./chart \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,6 +103,11 @@ jobs:
       - run: |
           helm dependency build ./chart
 
+          if [[ "$( helm list --failed | grep $RELEASE_NAME  | cut -f2 )" -eq 1 ]]; then
+            echo "Removing failed first release"
+            helm delete --purge $RELEASE_NAME
+          fi
+
           helm upgrade --install $RELEASE_NAME ./chart \
             --set environmentName=$CIRCLE_BRANCH \
             --set php.image=$DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/${CIRCLE_PROJECT_REPONAME,,}-php:$CIRCLE_SHA1 \

--- a/chart/templates/reference-data-cron.yaml
+++ b/chart/templates/reference-data-cron.yaml
@@ -16,7 +16,7 @@ spec:
           containers:
           - name: reference-data-cron
             {{ include "drupal.php-container" . | indent 12 }}
-            command: ["/bin/bash", "-c"]
+            command: ["/bin/sh", "-c"]
             args:
               - {{ .Values.referenceData.command | quote }}
             resources:

--- a/chart/templates/reference-data-cron.yaml
+++ b/chart/templates/reference-data-cron.yaml
@@ -16,7 +16,7 @@ spec:
           containers:
           - name: reference-data-cron
             {{ include "drupal.php-container" . | indent 12 }}
-            command: ["/bin/sh", "-c"]
+            command: ["/bin/bash", "-c"]
             args:
               - {{ .Values.referenceData.command | quote }}
             resources:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -76,7 +76,7 @@ php:
       TIME_WAITING=0
       until mysqladmin status --connect_timeout=2 -u $DB_USER -p$DB_PASS -h $DB_HOST > /dev/null 2>&1; do
         echo "Waiting for database..."; sleep 5
-        (( TIME_WAITING +=5 ))
+        TIME_WAITING=$((TIME_WAITING+5))
 
         if [ $TIME_WAITING -gt 60 ]; then
           echo "Database connection timeout"


### PR DESCRIPTION
**Story:**
https://wunder.atlassian.net/browse/SLT-169

**What this PR does:**
- Fixes related thing (by adjusting the addition syntax to work on `sh`):
```
Waiting for database...
/bin/sh: TIME_WAITING: not found
Waiting for database...
/bin/sh: TIME_WAITING: not found
```
- Lists failed releases, looks for a release with exact name, and extracts second column (release number). Compares with "1" and removes the release if it matches.

Other ways to solve this:
 - use `helm upgrade --force`, but it could potentially remove some production site data in case it's marked as failed, so we really need this for the first deployment
 -  smarter way to extract release number, like matching on `helm get`, but the string matching there could potentially get false positive on releases "10-19; 100-199; 1000 ....". Didn't find a way to get current release number of a helm other than scraping it off the `helm list`.

**Further improvements:**
The issue now is that `helm delete` does not wait for all resources to be deleted and so the `helm install` that happens right after it can't be done since there are still some resources dangling around. I've added a sleep command for 30 seconds. Ideally, [there would be a `--wait` flag](https://github.com/helm/helm/issues/2378), just like `helm install` has.

Test build:
https://circleci.com/gh/wunderio/drupal-project-k8s/4880
```
Hang tight while we grab the latest from your chart repositories...
...Successfully got an update from the "stable" chart repository
Update Complete. ⎈Happy Helming!⎈
Saving 1 charts
Downloading mariadb from repo https://kubernetes-charts.storage.googleapis.com/
Deleting outdated charts
Removing failed first release
release "drupal-project-k8s--feature-slt-169-51b5" deleted
Release "drupal-project-k8s--feature-slt-169-51b5" does not exist. Installing it now.
NAME:   drupal-project-k8s--feature-slt-169-51b5
LAST DEPLOYED: Tue Nov 20 09:12:08 2018
NAMESPACE: drupal-project-k8s
STATUS: DEPLOYED
```
```
Log output from the deployment container
Waiting for database...
Waiting for database...
Waiting for database...
Waiting for database...
Waiting for database...
Waiting for database...
Importing reference database dump
Importing public files
 [success] Cache rebuild complete.
 [error]  The directory <em class="placeholder">../config/sync</em> does not exist. 
 [success] No database updates required.
```