### PR TITLE
Feature/slt 186 make ssh optional

### DIFF
--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -7,6 +7,7 @@ Basicauth username: {{ .Values.nginx.basicauth.credentials.username }}
 Basicauth password: {{ .Values.nginx.basicauth.credentials.password }}
 {{- end }}
 
+{{- if and (.Values.shell.enabled) (ne .Values.referenceData.referenceEnvironment .Values.environmentName) }}
 SSH connection:
 
   ssh www-admin@{{ template "drupal.environment.hostname" . }}-shell.{{ .Release.Namespace }} -J www-admin@ssh.{{ .Values.clusterDomain }}
@@ -14,3 +15,4 @@ SSH connection:
 SSH connection (alternative):
 
   ssh www-admin@{{ template "drupal.environment.hostname" . }}-shell.{{ .Release.Namespace }} -o ProxyCommand="ssh -W %h:%p www-admin@ssh.{{ .Values.clusterDomain }}"
+{{- end }}

--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -7,7 +7,7 @@ Basicauth username: {{ .Values.nginx.basicauth.credentials.username }}
 Basicauth password: {{ .Values.nginx.basicauth.credentials.password }}
 {{- end }}
 
-{{- if and (.Values.shell.enabled) (ne .Values.referenceData.referenceEnvironment .Values.environmentName) }}
+{{- if .Values.shell.enabled }}
 SSH connection:
 
   ssh www-admin@{{ template "drupal.environment.hostname" . }}-shell.{{ .Release.Namespace }} -J www-admin@ssh.{{ .Values.clusterDomain }}

--- a/chart/templates/shell-deployment.yaml
+++ b/chart/templates/shell-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if and (.Values.shell.enabled) (ne .Values.referenceData.referenceEnvironment .Values.environmentName) }}
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -22,3 +23,5 @@ spec:
       volumes:
         {{ include "drupal.volumes" . | indent 8}}
       {{ include "drupal.imagePullSecrets" . | indent 6 }}
+{{- end }}
+---

--- a/chart/templates/shell-deployment.yaml
+++ b/chart/templates/shell-deployment.yaml
@@ -1,4 +1,4 @@
-{{- if and (.Values.shell.enabled) (ne .Values.referenceData.referenceEnvironment .Values.environmentName) }}
+{{- if .Values.shell.enabled }}
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:

--- a/chart/templates/shell-service.yaml
+++ b/chart/templates/shell-service.yaml
@@ -1,3 +1,4 @@
+{{- if and (.Values.shell.enabled) (ne .Values.referenceData.referenceEnvironment .Values.environmentName) }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -11,3 +12,5 @@ spec:
       port: 22
   selector:
     {{ include "shell.release_labels" . | indent 4 }}
+{{- end }}
+---

--- a/chart/templates/shell-service.yaml
+++ b/chart/templates/shell-service.yaml
@@ -1,4 +1,4 @@
-{{- if and (.Values.shell.enabled) (ne .Values.referenceData.referenceEnvironment .Values.environmentName) }}
+{{- if .Values.shell.enabled }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/chart/tests/shell_deployment_test.yaml
+++ b/chart/tests/shell_deployment_test.yaml
@@ -1,0 +1,49 @@
+suite: shell deployment
+templates:
+  - shell-deployment.yaml
+tests:
+  - it: is a deployment with default values
+    set:
+      shell.enabled: true
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: spec.replicas
+          value: 1
+      - equal:
+          path: metadata.labels.app
+          value: shell
+
+  - it: deployment does not exist when disabled
+    set:
+      shell.enabled: false
+    asserts:
+      - hasDocuments:
+        count: 0
+
+  - it: uses the right docker images
+    set:
+      shell.enabled: true
+      shell.image: 'shell-12345'
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: 'shell-12345'
+
+  - it: sets environment variables correctly
+    set:
+      shell.enabled: true
+      shell.gitAuth.repositoryUrl: 'foo'
+      shell.gitAuth.apiToken: 'bar'
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GITAUTH_REPOSITORY_URL
+            value: foo
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GITAUTH_API_TOKEN
+            value: bar

--- a/chart/tests/shell_service_test.yaml
+++ b/chart/tests/shell_service_test.yaml
@@ -1,0 +1,16 @@
+suite: shell service
+templates:
+  - shell-service.yaml
+tests:
+  - it: is a service when enabled
+    set:
+      shell.enabled: true
+    asserts:
+      - isKind:
+          of: Service
+  - it: service does not exist when disabled
+    set:
+      shell.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -132,6 +132,7 @@ php:
 
 # Configuration for everything that runs in shell container.
 shell:
+  enabled: false
   # The docker image to be used. This is typically passed by your CI system using the --set parameter.
   image: 'you need to pass in a value for shell.image to your helm chart'
   # Values for the SSH gitAuth.

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -132,7 +132,7 @@ php:
 
 # Configuration for everything that runs in shell container.
 shell:
-  enabled: false
+  enabled: true
   # The docker image to be used. This is typically passed by your CI system using the --set parameter.
   image: 'you need to pass in a value for shell.image to your helm chart'
   # Values for the SSH gitAuth.


### PR DESCRIPTION
- Enables shell container (SSH) only when `values.yaml` `shell.enabled` is set to `true`. It's off by default now   
- Some tests, that check the `enabled` setting and that required values are correctly passed as environment variables into shell container.  
- Even when the shell **is** enabled it is not set when the `referenceEnvironment` equals `environmentName` (production, master). This also means, first deployment to master can't be fixed with a db push trough shell container, another branch has to be created for it. So maybe the initial setup should be changed somehow. This is only because some projects might still want to have shell, but there is no way to do it per-branch.  