### PR TITLE
SLT-188: Inject DRUSH_OPTIONS_URI environment variable

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -42,6 +42,8 @@ env:
     value: "{{ .Values.shell.gitAuth.apiToken }}"
   - name: GITAUTH_REPOSITORY_URL
     value: "{{ .Values.shell.gitAuth.repositoryUrl }}"
+  - name: DRUSH_OPTIONS_URI
+    value: "http://{{- template "drupal.domain" . }}"
 ports:
   - containerPort: 22
 volumeMounts:


### PR DESCRIPTION
Generates correct hostname for `drush uli` command when it's run inside the `shell` container