### PR TITLE
SLT-193: Only try to run post-release hooks a single time.

### DIFF
--- a/chart/templates/post-release.yaml
+++ b/chart/templates/post-release.yaml
@@ -11,6 +11,8 @@ metadata:
     "helm.sh/hook-weight": "-5"
     "helm.sh/hook-delete-policy": "before-hook-creation"
 spec:
+  completions: 1
+  backoffLimit: 1
   template:
     spec:
       restartPolicy: Never


### PR DESCRIPTION
Most of the time, if a post-release hook fails it's because of an issue with the project (invalid configuration, etc), so retrying up to 6 times with increasing intervals (the default behavior for kubernetes jobs) is not helpful. It actually easily leads to a timeout, at which point the call to `helm upgrade` fails and the logs are not displayed.