### PR TITLE
Readiness improvements

### DIFF
--- a/chart/templates/drupal-deployment.yaml
+++ b/chart/templates/drupal-deployment.yaml
@@ -33,7 +33,8 @@ spec:
             - /bin/sh
             - -c
             - drush check-bootstrap
-          periodSeconds: 1
+          periodSeconds: 3
+          timeoutSeconds: 3
         resources:
 {{ .Values.php.resources | toYaml | indent 10 }}
 
@@ -72,7 +73,8 @@ spec:
           httpGet:
             path: /
             port: 80
-          periodSeconds: 1
+          periodSeconds: 3
+          timeoutSeconds: 3
         resources:
 {{ .Values.nginx.resources | toYaml | indent 10 }}
 

--- a/chart/templates/drupal-deployment.yaml
+++ b/chart/templates/drupal-deployment.yaml
@@ -33,6 +33,7 @@ spec:
             - /bin/sh
             - -c
             - drush check-bootstrap
+          periodSeconds: 1
         resources:
 {{ .Values.php.resources | toYaml | indent 10 }}
 
@@ -71,6 +72,7 @@ spec:
           httpGet:
             path: /
             port: 80
+          periodSeconds: 1
         resources:
 {{ .Values.nginx.resources | toYaml | indent 10 }}
 


### PR DESCRIPTION
Based on the load tests, we see two necessary improvements for the readiness checks:

- The readiness checks should be done more frequently (the default is every 10 seconds), so once Drupal is installed it takes less time for the pod to be marked as ready and for the service to be active.
- Under load, Drupal can take longer to respond, exceeding the default liveness and readiness timeout of 1 second. While this is not ideal, such conditions can commonly occur after a cache rebuild, so we need to be more tolerant.