### PR TITLE
SLT-199 prettier helm output

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -19,7 +19,7 @@ release: {{ .Release.Name }}
 {{ regexReplaceAll "[^[:alnum:]]" (.Values.environmentName | default .Release.Name) "-" | lower | trunc 50 | trimSuffix "-" }}
 {{- end -}}
 
-{{- define "drupal.php-container" }}
+{{- define "drupal.php-container" -}}
 image: {{ .Values.php.image | quote }}
 env: {{ include "drupal.env" . }}
 ports:
@@ -27,28 +27,28 @@ ports:
     name: drupal
 {{- end }}
 
-{{- define "drupal.volumeMounts" }}
-  - name: drupal-public-files
-    mountPath: /var/www/html/web/sites/default/files
-  {{- if .Values.privateFiles.enabled }}
-  - name: drupal-private-files
-    mountPath: /var/www/html/private
-  {{- end }}
-  - name: php-conf
-    mountPath: /etc/php7/php.ini
-    readOnly: true
-    subPath: php_ini
-  - name: php-conf
-    mountPath: /etc/php7/php-fpm.conf
-    readOnly: true
-    subPath: php-fpm_conf
-  - name: php-conf
-    mountPath: /etc/php7/php-fpm.d/www.conf
-    readOnly: true
-    subPath: www_conf
+{{- define "drupal.volumeMounts" -}}
+- name: drupal-public-files
+  mountPath: /var/www/html/web/sites/default/files
+{{- if .Values.privateFiles.enabled }}
+- name: drupal-private-files
+  mountPath: /var/www/html/private
+{{- end }}
+- name: php-conf
+  mountPath: /etc/php7/php.ini
+  readOnly: true
+  subPath: php_ini
+- name: php-conf
+  mountPath: /etc/php7/php-fpm.conf
+  readOnly: true
+  subPath: php-fpm_conf
+- name: php-conf
+  mountPath: /etc/php7/php-fpm.d/www.conf
+  readOnly: true
+  subPath: www_conf
 {{- end }}
 
-{{- define "drupal.volumes" }}
+{{- define "drupal.volumes" -}}
 - name: drupal-public-files
   persistentVolumeClaim:
     claimName: {{ .Release.Name }}-public-files

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -1,4 +1,4 @@
-{{- define "drupal.release_labels" }}
+{{- define "drupal.release_labels" -}}
 app: {{ .Values.app | quote }}
 release: {{ .Release.Name }}
 {{- end }}

--- a/chart/templates/drupal-configmap-nginx.yaml
+++ b/chart/templates/drupal-configmap-nginx.yaml
@@ -3,7 +3,7 @@ kind: ConfigMap
 metadata:
   name: {{ .Release.Name }}-nginx-conf
   labels:
-    {{ include "drupal.release_labels" . | indent 4 }}
+    {{- include "drupal.release_labels" . | nindent 4 }}
 data:
   nginx_conf: |
     user                            nginx;                                                 

--- a/chart/templates/drupal-configmap-php.yaml
+++ b/chart/templates/drupal-configmap-php.yaml
@@ -3,7 +3,7 @@ kind: ConfigMap
 metadata:
   name: {{ .Release.Name }}-php-conf
   labels:
-    {{ include "drupal.release_labels" . | indent 4 }}
+    {{- include "drupal.release_labels" . | nindent 4 }}
 data:
   php_ini: |
     [PHP]

--- a/chart/templates/drupal-cron.yaml
+++ b/chart/templates/drupal-cron.yaml
@@ -4,7 +4,7 @@ kind: CronJob
 metadata:
   name: {{ $.Release.Name }}-cron-{{ $index }}
   labels:
-    {{ include "drupal.release_labels" $ | indent 4 }}
+    {{- include "drupal.release_labels" $ | nindent 4 }}
 spec:
   schedule: {{ $job.schedule | quote }}
   concurrencyPolicy: Forbid

--- a/chart/templates/drupal-cron.yaml
+++ b/chart/templates/drupal-cron.yaml
@@ -15,18 +15,18 @@ spec:
         spec:
           containers:
           - name: drupal-cron
-            {{ include "drupal.php-container" $ | indent 12 }}
+            {{- include "drupal.php-container" $ | nindent 12 }}
             volumeMounts:
-              {{ include "drupal.volumeMounts" $ | indent 14 }}
+              {{- include "drupal.volumeMounts" $ | nindent 14 }}
             command: ["/bin/sh", "-c"]
             args:
               - {{ $job.command | quote }}
             resources:
-{{ $.Values.php.resources | toYaml | indent 14 }}
+              {{- $.Values.php.resources | toYaml | nindent 14 }}
           restartPolicy: OnFailure
           volumes:
-            {{ include "drupal.volumes" $ | indent 12 }}
+            {{- include "drupal.volumes" $ | nindent 12 }}
 
-          {{ include "drupal.imagePullSecrets" $ | indent 10 }}
+          {{- include "drupal.imagePullSecrets" $ | nindent 10 }}
 ---
 {{- end }}

--- a/chart/templates/drupal-deployment.yaml
+++ b/chart/templates/drupal-deployment.yaml
@@ -21,9 +21,9 @@ spec:
       containers:
       # php-fpm container.
       - name: php
-        {{ include "drupal.php-container" . | indent 8}}
+        {{- include "drupal.php-container" . | nindent 8}}
         volumeMounts:
-          {{ include "drupal.volumeMounts" . | indent 10 }}
+          {{- include "drupal.volumeMounts" . | nindent 10 }}
         livenessProbe:
           tcpSocket:
             port: 9000
@@ -34,7 +34,7 @@ spec:
             - -c
             - drush check-bootstrap
         resources:
-{{ .Values.php.resources | toYaml | indent 10 }}
+          {{- .Values.php.resources | toYaml | nindent 10 }}
 
       # Nginx container
       - name: nginx
@@ -72,10 +72,10 @@ spec:
             path: /
             port: 80
         resources:
-{{ .Values.nginx.resources | toYaml | indent 10 }}
+          {{- .Values.nginx.resources | toYaml | nindent 10 }}
 
       volumes:
-        {{ include "drupal.volumes" . | indent 8}}
+        {{- include "drupal.volumes" . | nindent 8}}
         - name: nginx-conf
           configMap:
             name: {{ .Release.Name }}-nginx-conf
@@ -92,4 +92,4 @@ spec:
               - key: .htaccess
                 path: .htaccess
         {{- end }}
-      {{ include "drupal.imagePullSecrets" . | indent 6 }}
+      {{- include "drupal.imagePullSecrets" . | nindent 6 }}

--- a/chart/templates/drupal-deployment.yaml
+++ b/chart/templates/drupal-deployment.yaml
@@ -3,19 +3,19 @@ kind: Deployment
 metadata:
   name: {{ .Release.Name }}-drupal
   labels:
-    {{ include "drupal.release_labels" . | indent 4 }}
+    {{- include "drupal.release_labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
-      {{ include "drupal.release_labels" . | indent 6 }}
+      {{- include "drupal.release_labels" . | nindent 6 }}
       deployment: drupal
   strategy:
     type: Recreate
   template:
     metadata:
       labels:
-        {{ include "drupal.release_labels" . | indent 8 }}
+        {{- include "drupal.release_labels" . | nindent 8 }}
         deployment: drupal
     spec:
       containers:

--- a/chart/templates/drupal-secret.yaml
+++ b/chart/templates/drupal-secret.yaml
@@ -3,7 +3,7 @@ kind: Secret
 metadata:
   name: {{ .Release.Name }}-secrets-drupal
   labels:
-    {{ include "drupal.release_labels" . | indent 4 }}
+    {{- include "drupal.release_labels" . | nindent 4 }}
 type: Opaque
 data:
   {{- if .Values.php.hashsalt }}

--- a/chart/templates/drupal-service.yaml
+++ b/chart/templates/drupal-service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   name: {{ .Release.Name }}-drupal
   labels:
-    {{ include "drupal.release_labels" . | indent 4 }}
+    {{- include "drupal.release_labels" . | nindent 4 }}
   annotations:
     getambassador.io/config: |
       apiVersion: ambassador/v0
@@ -20,5 +20,5 @@ spec:
   ports:
     - port: 80
   selector:
-    {{ include "drupal.release_labels" . | indent 4 }}
+    {{- include "drupal.release_labels" . | nindent 4 }}
     deployment: drupal

--- a/chart/templates/drupal-volumes.yaml
+++ b/chart/templates/drupal-volumes.yaml
@@ -3,7 +3,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: {{ .Release.Name }}-public-files
   labels:
-    {{ include "drupal.release_labels" . | indent 4 }}
+    {{- include "drupal.release_labels" . | nindent 4 }}
 spec:
   storageClassName: {{ .Values.publicFiles.storageClassName }}
   accessModes:
@@ -54,7 +54,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: {{ .Release.Name }}-shell-keys
   labels:
-    {{ include "drupal.release_labels" . | indent 4 }}
+    {{- include "drupal.release_labels" . | nindent 4 }}
 spec:
   storageClassName: {{ .Values.shell.storageClassName }}
   accessModes:

--- a/chart/templates/elasticsearch.yaml
+++ b/chart/templates/elasticsearch.yaml
@@ -4,18 +4,18 @@ kind: Deployment
 metadata:
   name: {{ .Release.Name }}-elastic
   labels:
-    {{ include "drupal.release_labels" . | indent 4 }}
+    {{- include "drupal.release_labels" . | nindent 4 }}
     service: elasticsearch
 spec:
   replicas: 1
   selector:
     matchLabels:
-      {{ include "drupal.release_labels" . | indent 6 }}
+      {{- include "drupal.release_labels" . | nindent 6 }}
       service: elasticsearch
   template:
     metadata:
       labels:
-        {{ include "drupal.release_labels" . | indent 8 }}
+        {{- include "drupal.release_labels" . | nindent 8 }}
         service: elasticsearch
     #For pod updates, kill the current pod, stand up the new one
     strategy:
@@ -84,7 +84,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: {{ .Release.Name }}-elastic-data
   labels:
-    {{ include "drupal.release_labels" . | indent 4 }}
+    {{- include "drupal.release_labels" . | nindent 4 }}
     service: elasticsearch
 spec:
   storageClassName: {{ .Values.elasticsearch.persistence.storageClassName }}
@@ -99,7 +99,7 @@ kind: Service
 metadata:
   name: {{ .Release.Name }}-elastic
   labels:
-    {{ include "drupal.release_labels" . | indent 4 }}
+    {{- include "drupal.release_labels" . | nindent 4 }}
     service: elasticsearch
 spec:
   type: NodePort
@@ -107,6 +107,6 @@ spec:
   - name: elastic
     port: 9200
   selector:
-    {{ include "drupal.release_labels" . | indent 4 }}
+    {{- include "drupal.release_labels" . | nindent 4 }}
     service: elasticsearch
 {{- end }}

--- a/chart/templates/post-release.yaml
+++ b/chart/templates/post-release.yaml
@@ -18,12 +18,12 @@ spec:
       restartPolicy: Never
       containers:
       - name: post-release
-        {{ include "drupal.php-container" . | indent 8 }}
+        {{- include "drupal.php-container" . | nindent 8 }}
         command: ["/bin/sh", "-c"]
         args:
         - {{ include "drupal.post-release-command" . | quote }}
         volumeMounts:
-          {{ include "drupal.volumeMounts" . | indent 8 }}
+          {{- include "drupal.volumeMounts" . | nindent 10 }}
           {{- if .Values.referenceData.enabled }}
           - name: reference-data-volume
             mountPath: /var/www/html/reference-data
@@ -31,9 +31,9 @@ spec:
             readOnly: true
             {{- end }}
           {{- end }}
-      {{ include "drupal.imagePullSecrets" . | indent 6 }}
+      {{- include "drupal.imagePullSecrets" . | nindent 6 }}
       volumes:
-        {{ include "drupal.volumes" . | indent 8 }}
+        {{- include "drupal.volumes" . | nindent 8 }}
         {{- if .Values.referenceData.enabled }}
         - name: reference-data-volume
           persistentVolumeClaim:

--- a/chart/templates/post-release.yaml
+++ b/chart/templates/post-release.yaml
@@ -3,7 +3,7 @@ kind: Job
 metadata:
   name: "{{ .Release.Name }}-post-release"
   labels:
-    {{ include "drupal.release_labels" . | indent 4 }}
+    {{- include "drupal.release_labels" . | nindent 4 }}
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.

--- a/chart/templates/reference-data-cron.yaml
+++ b/chart/templates/reference-data-cron.yaml
@@ -15,25 +15,25 @@ spec:
         spec:
           containers:
           - name: reference-data-cron
-            {{ include "drupal.php-container" . | indent 12 }}
+            {{- include "drupal.php-container" . | nindent 12 }}
             volumeMounts:
-              {{ include "drupal.volumeMounts" . | indent 12 }}
+              {{- include "drupal.volumeMounts" . | nindent 14 }}
               - name: reference-data-volume
                 mountPath: /var/www/html/reference-data
             command: ["/bin/sh", "-c"]
             args:
               - {{ .Values.referenceData.command | quote }}
             resources:
-{{ .Values.php.resources | toYaml | indent 14 }}
+              {{- .Values.php.resources | toYaml | nindent 14 }}
           restartPolicy: OnFailure
           volumes:
-            {{ include "drupal.volumes" . | indent 12 }}
+            {{- include "drupal.volumes" . | nindent 12 }}
             - name: reference-data-volume
               persistentVolumeClaim:
                 claimName: {{ include "drupal.referenceEnvironment" . }}-reference-data
 
 
-          {{ include "drupal.imagePullSecrets" . | indent 10 }}
+          {{- include "drupal.imagePullSecrets" . | nindent 10 }}
 {{- end }}
 {{- end }}
 ---

--- a/chart/templates/reference-data-cron.yaml
+++ b/chart/templates/reference-data-cron.yaml
@@ -5,7 +5,7 @@ kind: CronJob
 metadata:
   name: {{ .Release.Name }}-refdata
   labels:
-    {{ include "drupal.release_labels" . | indent 4 }}
+    {{- include "drupal.release_labels" . | nindent 4 }}
 spec:
   schedule: {{ .Values.referenceData.schedule | quote }}
   concurrencyPolicy: Forbid

--- a/chart/templates/shell-deployment.yaml
+++ b/chart/templates/shell-deployment.yaml
@@ -4,18 +4,18 @@ kind: Deployment
 metadata:
   name: {{ .Release.Name }}-shell
   labels:
-    {{- include "drupal.release_labels" . | indent 4 }}
+    {{- include "drupal.release_labels" . | nindent 4 }}
     service: shell
 spec:
   replicas: 1
   selector:
     matchLabels:
-      {{- include "drupal.release_labels" . | indent 6 }}
+      {{- include "drupal.release_labels" . | nindent 6 }}
       service: shell
   template:
     metadata:
       labels:
-        {{- include "drupal.release_labels" . | indent 8 }}
+        {{- include "drupal.release_labels" . | nindent 8 }}
         service: shell
     spec:
       containers:

--- a/chart/templates/shell-deployment.yaml
+++ b/chart/templates/shell-deployment.yaml
@@ -32,16 +32,16 @@ spec:
         ports:
           - containerPort: 22
         volumeMounts:
-          {{- include "drupal.volumeMounts" . | indent 6 }}
+        {{- include "drupal.volumeMounts" . | nindent 8 }}
         - name: shell-keys
           mountPath: /etc/ssh/keys
         resources:
-{{ .Values.php.resources | toYaml | indent 10 }}
+          {{- .Values.php.resources | toYaml | nindent 10 }}
       volumes:
-      {{- include "drupal.volumes" . | indent 6 }}
+      {{- include "drupal.volumes" . | nindent 6 }}
       - name: shell-keys
         persistentVolumeClaim:
           claimName: {{ .Release.Name }}-shell-keys
-      {{ include "drupal.imagePullSecrets" . | indent 6 }}
+      {{- include "drupal.imagePullSecrets" . | nindent 6 }}
 {{- end }}
 ---

--- a/chart/templates/shell-service.yaml
+++ b/chart/templates/shell-service.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: {{ template "drupal.environment.hostname" . }}-shell
   labels:
-    {{ include "drupal.release_labels" . | indent 4 }}
+    {{- include "drupal.release_labels" . | nindent 4 }}
     service: shell
 spec:
   type: NodePort
@@ -12,7 +12,7 @@ spec:
     - name: ssh
       port: 22
   selector:
-    {{ include "drupal.release_labels" . | indent 4 }}
+    {{- include "drupal.release_labels" . | nindent 4 }}
     service: shell
 {{- end }}
 ---


### PR DESCRIPTION
The main issue with the output of our helm chart was the unecessary newlines. By supressing whitespace around placeholders and using `nindent` (indent with a new line before the first line) instead of just `indent`, all of these should be addressed.

To test, run `helm template chart/ --set environmentName=master | less`, and look at the beautiful YAML that comes out of it :-)