### PR TITLE
Make ambassador optional and configurable

### DIFF
--- a/chart/templates/drupal-service.yaml
+++ b/chart/templates/drupal-service.yaml
@@ -5,14 +5,15 @@ metadata:
   labels:
     {{- include "drupal.release_labels" . | nindent 4 }}
   annotations:
+{{- if .Values.ambassador.enabled }}
     getambassador.io/config: |
       apiVersion: ambassador/v0
       kind:  Mapping
       name:  {{ .Release.Name }}-drupal
       host: {{ template "drupal.domain" . }}
-      prefix: /
       service: {{ .Release.Name }}-drupal.{{ .Release.Namespace }}.svc.cluster.local:80
-      timeout_ms: 30000
+      {{- .Values.ambassador.config | toYaml | nindent 6 }}
+{{- end }}
     domain: {{ template "drupal.domain" . }}
 spec:
   type: NodePort

--- a/chart/tests/drupal_service_test.yaml
+++ b/chart/tests/drupal_service_test.yaml
@@ -28,3 +28,24 @@ tests:
       - equal:
           path: "metadata.annotations.domain"
           value: "baz.foo.silta.example.com"
+
+  - it: adds the ambassador annotation by default
+    asserts:
+      - matchRegex:
+          path: metadata.annotations.getambassador\.io/config
+          pattern: 'apiVersion: ambassador/v0'
+
+  - it: adds ambassador config values
+    set:
+      ambassador.config.foo: 'bar'
+    asserts:
+      - matchRegex:
+          path: metadata.annotations.getambassador\.io/config
+          pattern: 'foo: bar'
+
+  - it: can disable ambassador
+    set:
+      ambassador.enabled: false
+    asserts:
+      - isNull:
+          path: metadata.annotations.getambassador\.io/config

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -216,3 +216,13 @@ elasticsearch:
 memcached:
   enabled: false
   maxItemMemory: 128
+
+# Configure ambassador for routing inbound traffic. We typically enable ambassador on development 
+# environments, but disable it and instead use a dedicated ingress resource on production; some 
+# providers have limits on the number of dedicated ingress resources available in a cluster. 
+ambassador:
+  enabled: true
+  # Optional configuration arguments for ambassador. 
+  config:
+    prefix: /
+    timeout_ms: 30000


### PR DESCRIPTION
Fixes #86 

Provides a value to enable/disable ambassador, and allows for ambassador config to be added as values.

Sidenote: 
I'm unsure if the domain annotation on the drupal service should be included only if the ambassador annotation is included. I actually mis-set the domain annotation when using an nginx ingress and it still worked fine, so I'm not sure what its purpose is.