### PR TITLE
Feature/slt 220 fix backoff limit exceeded

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -156,6 +156,10 @@ done
 rm /var/www/html/reference-data/_fs-test
 {{- end }}
 
+{{- define "drupal.deployment-in-progress-test" -}}
+-f /var/www/html/web/sites/default/files/_deployment
+{{- end -}}
+
 {{- define "drupal.post-release-command" -}}
 set -e
 
@@ -166,7 +170,9 @@ set -e
 {{ include "drupal.wait-for-db-command" . }}
 
 {{ if .Release.IsInstall }}
+touch /var/www/html/web/sites/default/files/_deployment
 {{ .Values.php.postinstall.command}}
+rm /var/www/html/web/sites/default/files/_deployment
 {{ else }}
 {{ .Values.php.postupgrade.command}}
 {{ end }}

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -142,8 +142,26 @@ TIME_WAITING=0
 done
 {{- end }}
 
+{{- define "drupal.wait-for-ref-fs-command" }}
+TIME_WAITING=0
+until touch /var/www/html/reference-data/_fs-test; do
+  echo "Waiting for reference-data fs..."; sleep 2
+  TIME_WAITING=$((TIME_WAITING+2))
+
+  if [ $TIME_WAITING -gt 20 ]; then
+    echo "Reference data filesystem timeout"
+    exit 1
+  fi
+done
+rm /var/www/html/reference-data/_fs-test
+{{- end }}
+
 {{- define "drupal.post-release-command" -}}
 set -e
+
+{{- if eq .Values.referenceData.referenceEnvironment .Values.environmentName }}
+{{ include "drupal.wait-for-ref-fs-command" . }}
+{{- end }}
 
 {{ include "drupal.wait-for-db-command" . }}
 

--- a/chart/templates/drupal-cron.yaml
+++ b/chart/templates/drupal-cron.yaml
@@ -13,16 +13,6 @@ spec:
     spec:
       template:
         spec:
-          initContainers:
-          - name: wait-for-db
-            {{- include "drupal.php-container" $ | nindent 12 }}
-            volumeMounts:
-            {{- include "drupal.volumeMounts" $ | nindent 14 }}
-            command: ["/bin/sh", "-c"]
-            args:
-              - while [ {{ include "drupal.deployment-in-progress-test" . }} ]; do sleep 2; done
-            resources:
-              {{- $.Values.php.resources | toYaml | nindent 14 }}
           containers:
           - name: drupal-cron
             {{- include "drupal.php-container" $ | nindent 12 }}
@@ -30,7 +20,7 @@ spec:
               {{- include "drupal.volumeMounts" $ | nindent 14 }}
             command: ["/bin/sh", "-c"]
             args:
-              - {{ $job.command | quote }}
+              - if [ ! {{ include "drupal.deployment-in-progress-test" . }} ]; then {{ $job.command | quote }} else exit 1; fi
             resources:
               {{- $.Values.php.resources | toYaml | nindent 14 }}
           restartPolicy: OnFailure

--- a/chart/templates/drupal-cron.yaml
+++ b/chart/templates/drupal-cron.yaml
@@ -20,7 +20,7 @@ spec:
             {{- include "drupal.volumeMounts" $ | nindent 14 }}
             command: ["/bin/sh", "-c"]
             args:
-              - while [ -f /var/www/html/web/sites/default/files/_deployment ]; do sleep 2; done
+              - while [ {{ include "drupal.deployment-in-progress-test" . }} ]; do sleep 2; done
             resources:
               {{- $.Values.php.resources | toYaml | nindent 14 }}
           containers:

--- a/chart/templates/drupal-cron.yaml
+++ b/chart/templates/drupal-cron.yaml
@@ -13,6 +13,16 @@ spec:
     spec:
       template:
         spec:
+          initContainers:
+          - name: wait-for-db
+            {{- include "drupal.php-container" $ | nindent 12 }}
+            volumeMounts:
+            {{- include "drupal.volumeMounts" $ | nindent 14 }}
+            command: ["/bin/sh", "-c"]
+            args:
+              - while [ -f /var/www/html/web/sites/default/files/_deployment ]; do sleep 2; done
+            resources:
+              {{- $.Values.php.resources | toYaml | nindent 14 }}
           containers:
           - name: drupal-cron
             {{- include "drupal.php-container" $ | nindent 12 }}

--- a/chart/templates/drupal-deployment.yaml
+++ b/chart/templates/drupal-deployment.yaml
@@ -38,7 +38,7 @@ spec:
             command:
             - /bin/sh
             - -c
-            - timeout -t 3 drush check-bootstrap
+            - if [ ! -f /var/www/html/web/sites/default/files/_deployment ]; then timeout -t 3 drush check-bootstrap; else exit 1; fi
           periodSeconds: 3
         resources:
           {{- .Values.php.resources | toYaml | nindent 10 }}

--- a/chart/templates/drupal-deployment.yaml
+++ b/chart/templates/drupal-deployment.yaml
@@ -38,7 +38,7 @@ spec:
             command:
             - /bin/sh
             - -c
-            - if [ ! -f /var/www/html/web/sites/default/files/_deployment ]; then timeout -t 3 drush check-bootstrap; else exit 1; fi
+            - if [ ! {{ include "drupal.deployment-in-progress-test" . }} ]; then timeout -t 3 drush check-bootstrap; else exit 1; fi
           periodSeconds: 3
         resources:
           {{- .Values.php.resources | toYaml | nindent 10 }}

--- a/chart/tests/drupal_cron_test.yaml
+++ b/chart/tests/drupal_cron_test.yaml
@@ -50,11 +50,11 @@ tests:
           count: 2
       - equal:
           path: spec.jobTemplate.spec.template.spec.containers[0].args[0]
-          value: 'foo'
+          value: 'if [ ! -f /var/www/html/web/sites/default/files/_deployment ]; then "foo" else exit 1; fi'
         documentIndex: 0
       - equal:
           path: spec.jobTemplate.spec.template.spec.containers[0].args[0]
-          value: 'bar'
+          value: 'if [ ! -f /var/www/html/web/sites/default/files/_deployment ]; then "bar" else exit 1; fi'
         documentIndex: 1
       - equal:
           path: spec.schedule

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -89,11 +89,15 @@ php:
 
       elif [ -f config/sync/core.extension.yml ]; then
         echo "Installing Drupal from existing configuration"
+        touch /var/www/html/web/sites/default/files/_deployment
         drush site-install -n config_installer
+        rm /var/www/html/web/sites/default/files/_deployment
 
       else
         echo "No configuration found, installing a plain drupal site"
+        touch /var/www/html/web/sites/default/files/_deployment
         drush site-install -n standard
+        rm /var/www/html/web/sites/default/files/_deployment
       fi
 
   # Post-upgrade hook.

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -89,15 +89,11 @@ php:
 
       elif [ -f config/sync/core.extension.yml ]; then
         echo "Installing Drupal from existing configuration"
-        touch /var/www/html/web/sites/default/files/_deployment
         drush site-install -n config_installer
-        rm /var/www/html/web/sites/default/files/_deployment
 
       else
         echo "No configuration found, installing a plain drupal site"
-        touch /var/www/html/web/sites/default/files/_deployment
         drush site-install -n standard
-        rm /var/www/html/web/sites/default/files/_deployment
       fi
 
   # Post-upgrade hook.


### PR DESCRIPTION
 - Creates temporary file while site-install is running and prevents php requests and cron commands from being run. It's because I suspect some drush actions create tables in database while site-install is running, hence breaking the deployment. And because backofflimit is set to 0, it fails right away.
- Waits for reference FS to be ready by trying to touch a file on it. It's only set up to work on `.Values.referenceData.referenceEnvironment`. Maybe it should work every time to be more reliable, but then the storage can't be read-only for non-`referenceEnvironment` environments.
