### PR TITLE
SLT-223 cronjob labels

### DIFF
--- a/chart/templates/drupal-cron.yaml
+++ b/chart/templates/drupal-cron.yaml
@@ -23,7 +23,7 @@ spec:
               {{- include "drupal.volumeMounts" $ | nindent 14 }}
             command: ["/bin/sh", "-c"]
             args:
-              - if [ ! {{ include "drupal.deployment-in-progress-test" . }} ]; then {{ $job.command | quote }} else exit 1; fi
+              - "if [ ! {{ include "drupal.deployment-in-progress-test" . }} ]; then {{ $job.command }}; else exit 1; fi"
             resources:
               {{- $.Values.php.resources | toYaml | nindent 14 }}
           restartPolicy: OnFailure

--- a/chart/tests/drupal_cron_test.yaml
+++ b/chart/tests/drupal_cron_test.yaml
@@ -50,11 +50,11 @@ tests:
           count: 2
       - equal:
           path: spec.jobTemplate.spec.template.spec.containers[0].args[0]
-          value: 'if [ ! -f /var/www/html/web/sites/default/files/_deployment ]; then "foo" else exit 1; fi'
+          value: 'if [ ! -f /var/www/html/web/sites/default/files/_deployment ]; then foo; else exit 1; fi'
         documentIndex: 0
       - equal:
           path: spec.jobTemplate.spec.template.spec.containers[0].args[0]
-          value: 'if [ ! -f /var/www/html/web/sites/default/files/_deployment ]; then "bar" else exit 1; fi'
+          value: 'if [ ! -f /var/www/html/web/sites/default/files/_deployment ]; then bar; else exit 1; fi'
         documentIndex: 1
       - equal:
           path: spec.schedule


### PR DESCRIPTION
In the process of adding labels to the individual jobs created by cronjobs so they can be properly cleaned up, I also noticed a regression introduced in https://github.com/wunderio/drupal-project-k8s/pull/88 which caused all cron jobs to fail.