### PR TITLE
SLT-228: add support for elasticsearch_helper

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -97,7 +97,7 @@ imagePullSecrets:
   value: {{ .Release.Name }}-memcached
 {{- end }}
 {{- if .Values.elasticsearch.enabled }}
-- name: ELASTIC_HOST
+- name: ELASTICSEARCH_HOST
   value: {{ .Release.Name }}-elastic
 {{- end }}
 - name: HASH_SALT

--- a/chart/tests/elasticsearch_test.yaml
+++ b/chart/tests/elasticsearch_test.yaml
@@ -9,7 +9,7 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].env
           content:
-            name: ELASTIC_HOST
+            name: ELASTICSEARCH_HOST
             value: RELEASE-NAME-elastic
 
   - it: sets no elasticsearch hostname in drupal environment if elasticsearch is disabled
@@ -19,5 +19,5 @@ tests:
       - notContains:
           path: spec.template.spec.containers[0].env
           content:
-            name: ELASTIC_HOST
+            name: ELASTICSEARCH_HOST
             value: RELEASE-NAME-elastic

--- a/web/sites/default/settings.silta.php
+++ b/web/sites/default/settings.silta.php
@@ -23,6 +23,14 @@ if (getenv('PRIVATE_FILES_PATH')) {
 }
 
 /**
+ * If Elasticsearch is enabled, add configuration for the Elasticsearch Helper module.
+ */
+if (getenv('ELASTICSEARCH_HOST')) {
+  $config['elasticsearch_helper.settings']['elasticsearch_helper']['host'] = getenv('ELASTICSEARCH_HOST');;
+  $config['elasticsearch_helper.settings']['elasticsearch_helper']['port'] = "9200";
+}
+
+/**
  * Set the memcache server hostname when a memcached server is available
  */
 if (getenv('MEMCACHED_HOST')) {


### PR DESCRIPTION
The same way we configure the memcache module when the memcache service is enabled, we can configure elasticsearch_helper when the elasticsearch service is enabled.