### PR TITLE
SLT-108 skip unnecessary deployments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,8 +130,7 @@ orbs:
         steps:
           - run:
               command: |
-                HASH=`tar --sort=name --exclude-from=<<parameters.path>>/.dockerignore --mtime='2000-01-01 00:00Z' --clamp-mtime -cf - <<parameters.path>> | sha1sum`
-
+                HASH=`tar --sort=name --exclude-from=<<parameters.path>>/.dockerignore --mtime='2000-01-01 00:00Z' --clamp-mtime -cf - <<parameters.path>> | sha1sum | cut -c 1-40`
                 echo "export <<parameters.identifier>>_HASH='$HASH'" >> $BASH_ENV
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,9 +53,9 @@ orbs:
           - checkout:
               path: ~/project
           - steps: <<parameters.codebase-build>>
+          - gcloud-login
           - drupal-docker-build
           - set-release-name
-          - gcloud-login
           - steps: <<parameters.pre-release>>
           - drupal-helm-deploy:
               chart_name: <<parameters.chart_name>>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,10 +132,6 @@ orbs:
         steps:
           - setup_remote_docker
 
-          - restore_cache:
-              keys:
-                - v1-docker-files-hash-
-
           - get-docker-file-hash:
               path: web
               identifier: NGINX
@@ -144,6 +140,10 @@ orbs:
               path: "."
               identifier: PHP
 
+          - restore_cache:
+              keys:
+                - v1-docker-files-hash-
+
           - run:
               name: Build docker images
               command: |
@@ -151,9 +151,9 @@ orbs:
                 echo $GCLOUD_KEY_JSON | docker login -u _json_key --password-stdin https://eu.gcr.io
 
                 # Make sure the directory for our hashes is present.
-                mkdir -p docker-files-hash
+                mkdir -p /tmp/docker-files-hash
 
-                if grep -q $NGINX_HASH docker-files-hash/nginx;
+                if grep -q $NGINX_HASH /tmp/docker-files-hash/nginx;
                 then
                   echo "This nginx image has already been built, the existing image from the Docker repository will be used"
                 else
@@ -162,10 +162,10 @@ orbs:
                   docker push $DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/${CIRCLE_PROJECT_REPONAME,,}-nginx:$NGINX_HASH
 
                   # Keep track that the image for these files has been built.
-                  echo $NGINX_HASH >> docker-files-hash/nginx
+                  echo $NGINX_HASH >> /tmp/docker-files-hash/nginx
                 fi
 
-                if grep -q $PHP_HASH docker-files-hash/php;
+                if grep -q $PHP_HASH /tmp/docker-files-hash/php;
                 then
                   echo "This php and shell images have already been built, the existing images from the Docker repository will be used."
                 else
@@ -178,13 +178,13 @@ orbs:
                   docker push $DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/${CIRCLE_PROJECT_REPONAME,,}-shell:$PHP_HASH
 
                   # Keep track that the image for these files has been built.
-                  echo $PHP_HASH >> docker-files-hash/php
+                  echo $PHP_HASH >> /tmp/docker-files-hash/php
                 fi
 
           - save_cache:
               paths:
-                - docker-files-hash
-              key: v1-docker-files-hash-{{ .BuildNum }}
+                - /tmp/docker-files-hash
+              key: v1-docker-files-hash-{{ epoch }}
 
       set-release-name:
         steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -279,9 +279,9 @@ orbs:
                 helm upgrade --install $RELEASE_NAME <<parameters.chart_name>> \
                   --repo "<<parameters.chart_repository>>" \
                   --set environmentName=$CIRCLE_BRANCH \
-                  --set php.image=$DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/${CIRCLE_PROJECT_REPONAME,,}-php:$CIRCLE_SHA1 \
-                  --set nginx.image=$DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/${CIRCLE_PROJECT_REPONAME,,}-nginx:$CIRCLE_SHA1 \
-                  --set shell.image=$DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/${CIRCLE_PROJECT_REPONAME,,}-shell:$CIRCLE_SHA1 \
+                  --set php.image=$DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/${CIRCLE_PROJECT_REPONAME,,}-php:$PHP_HASH \
+                  --set nginx.image=$DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/${CIRCLE_PROJECT_REPONAME,,}-nginx:$NGINX_HASH \
+                  --set shell.image=$DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/${CIRCLE_PROJECT_REPONAME,,}-shell:$PHP_HASH \
                   --set mariadb.rootUser.password=$DB_ROOT_PASS \
                   --set mariadb.db.password=$DB_USER_PASS \
                   --set shell.gitAuth.repositoryUrl="${CIRCLE_REPOSITORY_URL}" \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,24 @@ orbs:
           - checkout:
               path: ~/project
           - steps: <<parameters.codebase-build>>
-          - drupal-docker-build
+          - setup_remote_docker
+          - run:
+              name: Build docker images
+              command: |
+                # Login to the docker registry.
+                echo $GCLOUD_KEY_JSON | docker login -u _json_key --password-stdin https://eu.gcr.io
+
+                # Build the Nginx image and push it to the repository.
+                docker build -t $DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/${CIRCLE_PROJECT_REPONAME,,}-nginx:$CIRCLE_SHA1 -f silta/nginx.Dockerfile web
+                docker push $DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/${CIRCLE_PROJECT_REPONAME,,}-nginx:$CIRCLE_SHA1
+
+                # Build the Drupal image and push it to the repository.
+                docker build -t $DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/${CIRCLE_PROJECT_REPONAME,,}-php:$CIRCLE_SHA1 -f silta/php.Dockerfile .
+                docker push $DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/${CIRCLE_PROJECT_REPONAME,,}-php:$CIRCLE_SHA1
+
+                # Build the Shell image and push it to the repository.
+                docker build -t $DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/${CIRCLE_PROJECT_REPONAME,,}-shell:$CIRCLE_SHA1 -f silta/shell.Dockerfile .
+                docker push $DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/${CIRCLE_PROJECT_REPONAME,,}-shell:$CIRCLE_SHA1
 
       # Deprecated in favor of drupal-build-deploy.
       drupal-deploy:
@@ -108,10 +125,35 @@ orbs:
           - set-release-name
           - gcloud-login
           - steps: <<parameters.pre-release>>
-          - drupal-helm-deploy:
-              chart_name: <<parameters.chart_name>>
-              chart_repository: <<parameters.chart_repository>>
-              silta_config: <<parameters.silta_config>>
+          - run:
+              name: Deploy helm release
+              command: |
+                if [[ "$( helm list --failed | grep $RELEASE_NAME  | cut -f2 )" -eq 1 ]]; then
+                  echo "Removing failed first release"
+                  helm delete --purge $RELEASE_NAME
+                  sleep 30
+                fi
+
+                helm upgrade --install $RELEASE_NAME <<parameters.chart_name>> \
+                  --repo "<<parameters.chart_repository>>" \
+                  --set environmentName=$CIRCLE_BRANCH \
+                  --set php.image=$DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/${CIRCLE_PROJECT_REPONAME,,}-php:$CIRCLE_SHA1 \
+                  --set nginx.image=$DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/${CIRCLE_PROJECT_REPONAME,,}-nginx:$CIRCLE_SHA1 \
+                  --set shell.image=$DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/${CIRCLE_PROJECT_REPONAME,,}-shell:$CIRCLE_SHA1 \
+                  --set mariadb.rootUser.password=$DB_ROOT_PASS \
+                  --set mariadb.db.password=$DB_USER_PASS \
+                  --set shell.gitAuth.repositoryUrl="${CIRCLE_REPOSITORY_URL}" \
+                  --set shell.gitAuth.apiToken="${GITAUTH_API_TOKEN}" \
+                  --namespace=${CIRCLE_PROJECT_REPONAME,,} \
+                  --values <<parameters.silta_config>>
+          - run:
+              name: Deployment log
+              when: always
+              command: |
+                kubectl logs job/${RELEASE_NAME}-post-release -n ${CIRCLE_PROJECT_REPONAME,,} -f --timestamps=true
+          - run:
+              name: Release information
+              command: helm status $RELEASE_NAME
 
     # CircleCI commands
     commands:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,7 +134,7 @@ orbs:
 
           - restore_cache:
               keys:
-                - v1-docker-files-hash
+                - v1-docker-files-hash-
 
           - get-docker-file-hash:
               path: web
@@ -184,7 +184,7 @@ orbs:
           - save_cache:
               paths:
                 - docker-files-hash
-              key: v1-docker-files-hash
+              key: v1-docker-files-hash-{{ .BuildNum }}
 
       set-release-name:
         steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -198,7 +198,7 @@ orbs:
 
           - get-docker-file-hash:
               path: web
-              identifier: NGINX
+              identifier: nginx
 
           - get-docker-file-hash:
               path: "."
@@ -211,7 +211,7 @@ orbs:
           - build-docker-image:
               dockerfile: silta/nginx.Dockerfile
               path: web
-              identifier: NGINX
+              identifier: nginx
 
           - run:
               name: Build docker images
@@ -284,7 +284,7 @@ orbs:
                   --repo "<<parameters.chart_repository>>" \
                   --set environmentName=$CIRCLE_BRANCH \
                   --set php.image=$DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/${CIRCLE_PROJECT_REPONAME,,}-php:$PHP_HASH \
-                  --set nginx.image=$DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/${CIRCLE_PROJECT_REPONAME,,}-nginx:$NGINX_HASH \
+                  --set nginx.image=$DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/${CIRCLE_PROJECT_REPONAME,,}-nginx:$nginx_HASH \
                   --set shell.image=$DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/${CIRCLE_PROJECT_REPONAME,,}-shell:$PHP_HASH \
                   --set mariadb.rootUser.password=$DB_ROOT_PASS \
                   --set mariadb.db.password=$DB_USER_PASS \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,6 +163,7 @@ orbs:
             type: string
         steps:
           - run:
+              name: Check for changes in <<parameters.path>> folder (<<parameters.identifier>>)
               command: |
                 HASH=`tar --sort=name --exclude-from=<<parameters.path>>/.dockerignore --mtime='2000-01-01 00:00Z' --clamp-mtime -cf - <<parameters.path>> | sha1sum | cut -c 1-40`
                 echo "export <<parameters.identifier>>_HASH='$HASH'" >> $BASH_ENV

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -181,11 +181,12 @@ orbs:
               identifier: PHP
 
           - run:
+              name: Login to the docker registry
+              command: echo $GCLOUD_KEY_JSON | docker login -u _json_key --password-stdin https://$DOCKER_REPO_HOST
+
+          - run:
               name: Build docker images
               command: |
-                # Login to the docker registry.
-                echo $GCLOUD_KEY_JSON | docker login -u _json_key --password-stdin https://eu.gcr.io
-
                 if gcloud container images list-tags $DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/${CIRCLE_PROJECT_REPONAME,,}-nginx | grep -q $NGINX_HASH;
                 then
                   echo "This nginx image has already been built, the existing image from the Docker repository will be used"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,6 +140,10 @@ orbs:
               path: web
               identifier: NGINX
 
+          - get-docker-file-hash:
+              path: "."
+              identifier: PHP
+
           - run:
               name: Build docker images
               command: |
@@ -161,13 +165,21 @@ orbs:
                   echo $NGINX_HASH >> docker-files-hash/nginx
                 fi
 
-                # Build the Drupal image and push it to the repository.
-                docker build -t $DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/${CIRCLE_PROJECT_REPONAME,,}-php:$CIRCLE_SHA1 -f silta/php.Dockerfile .
-                docker push $DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/${CIRCLE_PROJECT_REPONAME,,}-php:$CIRCLE_SHA1
+                if grep -q $PHP_HASH docker-files-hash/php;
+                then
+                  echo "This php and shell images have already been built, the existing images from the Docker repository will be used."
+                else
+                  # Build the Drupal image and push it to the repository.
+                  docker build -t $DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/${CIRCLE_PROJECT_REPONAME,,}-php:$PHP_HASH -f silta/php.Dockerfile .
+                  docker push $DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/${CIRCLE_PROJECT_REPONAME,,}-php:$PHP_HASH
 
-                # Build the Shell image and push it to the repository.
-                docker build -t $DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/${CIRCLE_PROJECT_REPONAME,,}-shell:$CIRCLE_SHA1 -f silta/shell.Dockerfile .
-                docker push $DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/${CIRCLE_PROJECT_REPONAME,,}-shell:$CIRCLE_SHA1
+                  # Build the Shell image and push it to the repository.
+                  docker build -t $DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/${CIRCLE_PROJECT_REPONAME,,}-shell:$PHP_HASH -f silta/shell.Dockerfile .
+                  docker push $DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/${CIRCLE_PROJECT_REPONAME,,}-shell:$PHP_HASH
+
+                  # Keep track that the image for these files has been built.
+                  echo $PHP_HASH >> docker-files-hash/php
+                fi
 
           - save_cache:
               paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,9 @@ orbs:
           - checkout:
               path: ~/project
           - steps: <<parameters.codebase-build>>
+          - get-docker-file-hash:
+              path: web
+              identifier: NGINX
           - drupal-docker-build
 
       drupal-deploy:
@@ -114,6 +117,20 @@ orbs:
               paths:
                 - node_modules
               key: v1-yarn-{{ checksum "yarn.lock" }}
+
+      get-docker-file-hash:
+        parameters:
+          path:
+            type: string
+          identifier:
+            type: string
+        steps:
+          - run:
+              command: |
+                <<parameters.identifier>>_HASH=`tar --sort=name --exclude-from=<<parameters.path>>/.dockerignore --mtime='2000-01-01 00:00Z' --clamp-mtime -cf - <<parameters.path>> | sha1sum`
+
+                echo $<<parameters.identifier>>_HASH >> $BASH_ENV
+
 
       drupal-docker-build:
         steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,43 @@ orbs:
           - phpcs
           - steps: <<parameters.post-validation>>
 
+      drupal-build-deploy:
+        executor: silta
+        parameters:
+          drupal-root:
+            type: string
+            default: "."
+          codebase-build:
+            type: steps
+            default: []
+          pre-release:
+            description: Steps to be executed before the Helm release is created.
+            type: steps
+            default: []
+          chart_name:
+            type: string
+            default: drupal
+          chart_repository:
+            type: string
+            default: https://wunderio.github.io/charts/
+          silta_config:
+            type: string
+            default: "silta/silta.yml"
+        working_directory: ~/project/<<parameters.drupal-root>>
+        steps:
+          - checkout:
+              path: ~/project
+          - steps: <<parameters.codebase-build>>
+          - drupal-docker-build
+          - set-release-name
+          - gcloud-login
+          - steps: <<parameters.pre-release>>
+          - drupal-helm-deploy:
+              chart_name: <<parameters.chart_name>>
+              chart_repository: <<parameters.chart_repository>>
+              silta_config: <<parameters.silta_config>>
+
+      # Deprecated in favor of drupal-build-deploy.
       drupal-build:
         executor: silta
         parameters:
@@ -37,11 +74,13 @@ orbs:
             default: []
         working_directory: ~/project/<<parameters.drupal-root>>
         steps:
+          - run: echo "Deprecated, update to drupal-build-deploy in your CircleCI configuration."
           - checkout:
               path: ~/project
           - steps: <<parameters.codebase-build>>
           - drupal-docker-build
 
+      # Deprecated in favor of drupal-build-deploy.
       drupal-deploy:
         executor: silta
         parameters:
@@ -63,6 +102,7 @@ orbs:
             default: "silta/silta.yml"
         working_directory: ~/project/<<parameters.drupal-root>>
         steps:
+          - run: echo "Deprecated, update to drupal-build-deploy in your CircleCI configuration."
           - checkout:
               path: ~/project
           - set-release-name
@@ -274,18 +314,14 @@ workflows:
                   echo "machbarmacher/gdpr-dump is present but no gdpr.json was found."
                 fi
 
-      - silta/drupal-build:
-          name: build
-          context: global_nonprod
-          codebase-build:
-            - silta/drupal-composer-install
-            - silta/yarn-install
-
-      - silta/drupal-deploy:
-          name: deploy
+      - silta/drupal-build-deploy: &build-deploy
+          name: build-deploy
           # Use a local chart during development.
           chart_name: "./chart"
           chart_repository: ""
+          codebase-build:
+            - silta/drupal-composer-install
+            - silta/yarn-install
           pre-release:
             - run:
                 name: Build local helm dependencies
@@ -295,23 +331,12 @@ workflows:
           filters:
             branches:
               ignore: master
-          requires:
-            - build
 
-      - silta/drupal-deploy:
-          name: production-deploy
-          # Use a local chart during development.
-          chart_name: "./chart"
-          chart_repository: ""
-          pre-release:
-            - run:
-                name: Build local helm dependencies
-                command: helm dependency build ./chart
-
-          context: global_nonprod
+      - silta/drupal-build-deploy:
+          <<: *build-deploy
+          name: build-deploy-prod
           silta_config: silta/silta.yml,silta/silta-prod.yml
+          context: global_nonprod
           filters:
             branches:
               only: master
-          requires:
-            - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,19 +155,6 @@ orbs:
                 - node_modules
               key: v1-yarn-{{ checksum "yarn.lock" }}
 
-      get-docker-file-hash:
-        parameters:
-          path:
-            type: string
-          identifier:
-            type: string
-        steps:
-          - run:
-              name: Check for changes in <<parameters.path>> folder (<<parameters.identifier>>)
-              command: |
-                HASH=`tar --sort=name --exclude-from=<<parameters.path>>/.dockerignore --mtime='2000-01-01 00:00Z' --clamp-mtime -cf - <<parameters.path>> | sha1sum | cut -c 1-40`
-                echo "export <<parameters.identifier>>_HASH='$HASH'" >> $BASH_ENV
-
       build-docker-image:
         parameters:
           dockerfile:
@@ -178,10 +165,18 @@ orbs:
             type: string
         steps:
           - run:
-              name: Build docker image
+              name: Build <<parameters.identifier>> docker image
               command: |
                 IMAGE_URL=$DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/${CIRCLE_PROJECT_REPONAME,,}-<<parameters.identifier>>
-                IMAGE_TAG=$<<parameters.identifier>>_HASH
+
+                # Take a hash of all files in the folder except those ignored by docker.
+                # Also make sure modification time or order play no role.
+                IMAGE_TAG=`tar \
+                  --sort=name \
+                  --exclude-from=<<parameters.path>>/.dockerignore \
+                  --mtime='2000-01-01 00:00Z' \
+                  --clamp-mtime \
+                  -cf - <<parameters.path>> | sha1sum | cut -c 1-40`
 
                 if gcloud container images list-tags $IMAGE_URL | grep -q $IMAGE_TAG;
                 then
@@ -191,18 +186,13 @@ orbs:
                   docker push $IMAGE_URL:$IMAGE_TAG
                 fi
 
+                # Persist the image tag so it is available during deployment.
+                echo "export <<parameters.identifier>>_HASH='$IMAGE_TAG'" >> $BASH_ENV
+
 
       drupal-docker-build:
         steps:
           - setup_remote_docker
-
-          - get-docker-file-hash:
-              path: web
-              identifier: nginx
-
-          - get-docker-file-hash:
-              path: "."
-              identifier: PHP
 
           - run:
               name: Login to the docker registry
@@ -213,22 +203,15 @@ orbs:
               path: web
               identifier: nginx
 
-          - run:
-              name: Build docker images
-              command: |
+          - build-docker-image:
+              dockerfile: silta/php.Dockerfile
+              path: "."
+              identifier: php
 
-                if gcloud container images list-tags $DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/${CIRCLE_PROJECT_REPONAME,,}-php | grep -q $PHP_HASH;
-                then
-                  echo "This php and shell images have already been built, the existing images from the Docker repository will be used."
-                else
-                  # Build the Drupal image and push it to the repository.
-                  docker build -t $DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/${CIRCLE_PROJECT_REPONAME,,}-php:$PHP_HASH -f silta/php.Dockerfile .
-                  docker push $DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/${CIRCLE_PROJECT_REPONAME,,}-php:$PHP_HASH
-
-                  # Build the Shell image and push it to the repository.
-                  docker build -t $DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/${CIRCLE_PROJECT_REPONAME,,}-shell:$PHP_HASH -f silta/shell.Dockerfile .
-                  docker push $DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/${CIRCLE_PROJECT_REPONAME,,}-shell:$PHP_HASH
-                fi
+          - build-docker-image:
+              dockerfile: silta/shell.Dockerfile
+              path: "."
+              identifier: shell
 
       set-release-name:
         steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -180,32 +180,22 @@ orbs:
               path: "."
               identifier: PHP
 
-          - restore_cache:
-              keys:
-                - v1-docker-files-hash-
-
           - run:
               name: Build docker images
               command: |
                 # Login to the docker registry.
                 echo $GCLOUD_KEY_JSON | docker login -u _json_key --password-stdin https://eu.gcr.io
 
-                # Make sure the directory for our hashes is present.
-                mkdir -p /tmp/docker-files-hash
-
-                if grep -q $NGINX_HASH /tmp/docker-files-hash/nginx;
+                if gcloud container images list-tags $DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/${CIRCLE_PROJECT_REPONAME,,}-nginx | grep -q $NGINX_HASH;
                 then
                   echo "This nginx image has already been built, the existing image from the Docker repository will be used"
                 else
                   # Build the Nginx image and push it to the repository.
                   docker build -t $DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/${CIRCLE_PROJECT_REPONAME,,}-nginx:$NGINX_HASH -f silta/nginx.Dockerfile web
                   docker push $DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/${CIRCLE_PROJECT_REPONAME,,}-nginx:$NGINX_HASH
-
-                  # Keep track that the image for these files has been built.
-                  echo $NGINX_HASH >> /tmp/docker-files-hash/nginx
                 fi
 
-                if grep -q $PHP_HASH /tmp/docker-files-hash/php;
+                if gcloud container images list-tags $DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/${CIRCLE_PROJECT_REPONAME,,}-php | grep -q $PHP_HASH;
                 then
                   echo "This php and shell images have already been built, the existing images from the Docker repository will be used."
                 else
@@ -216,15 +206,7 @@ orbs:
                   # Build the Shell image and push it to the repository.
                   docker build -t $DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/${CIRCLE_PROJECT_REPONAME,,}-shell:$PHP_HASH -f silta/shell.Dockerfile .
                   docker push $DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/${CIRCLE_PROJECT_REPONAME,,}-shell:$PHP_HASH
-
-                  # Keep track that the image for these files has been built.
-                  echo $PHP_HASH >> /tmp/docker-files-hash/php
                 fi
-
-          - save_cache:
-              paths:
-                - /tmp/docker-files-hash
-              key: v1-docker-files-hash-{{ epoch }}
 
       set-release-name:
         steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -266,9 +266,9 @@ orbs:
                 helm upgrade --install $RELEASE_NAME <<parameters.chart_name>> \
                   --repo "<<parameters.chart_repository>>" \
                   --set environmentName=$CIRCLE_BRANCH \
-                  --set php.image=$DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/${CIRCLE_PROJECT_REPONAME,,}-php:$PHP_HASH \
+                  --set php.image=$DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/${CIRCLE_PROJECT_REPONAME,,}-php:$php_HASH \
                   --set nginx.image=$DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/${CIRCLE_PROJECT_REPONAME,,}-nginx:$nginx_HASH \
-                  --set shell.image=$DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/${CIRCLE_PROJECT_REPONAME,,}-shell:$PHP_HASH \
+                  --set shell.image=$DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/${CIRCLE_PROJECT_REPONAME,,}-shell:$shell_HASH \
                   --set mariadb.rootUser.password=$DB_ROOT_PASS \
                   --set mariadb.db.password=$DB_USER_PASS \
                   --set shell.gitAuth.repositoryUrl="${CIRCLE_REPOSITORY_URL}" \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,12 +40,6 @@ orbs:
           - checkout:
               path: ~/project
           - steps: <<parameters.codebase-build>>
-          - get-docker-file-hash:
-              path: web
-              identifier: NGINX
-          - run:
-              command: |
-                echo $NGINX_HASH
           - drupal-docker-build
 
       drupal-deploy:
@@ -138,15 +132,34 @@ orbs:
         steps:
           - setup_remote_docker
 
+          - restore_cache:
+              keys:
+                - v1-docker-files-hash
+
+          - get-docker-file-hash:
+              path: web
+              identifier: NGINX
+
           - run:
               name: Build docker images
               command: |
                 # Login to the docker registry.
                 echo $GCLOUD_KEY_JSON | docker login -u _json_key --password-stdin https://eu.gcr.io
 
-                # Build the Nginx image and push it to the repository.
-                docker build -t $DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/${CIRCLE_PROJECT_REPONAME,,}-nginx:$CIRCLE_SHA1 -f silta/nginx.Dockerfile web
-                docker push $DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/${CIRCLE_PROJECT_REPONAME,,}-nginx:$CIRCLE_SHA1
+                # Make sure the directory for our hashes is present.
+                mkdir -p docker-files-hash
+
+                if grep -q $NGINX_HASH docker-files-hash/nginx;
+                then
+                  echo "This nginx image has already been built, the existing image from the Docker repository will be used"
+                else
+                  # Build the Nginx image and push it to the repository.
+                  docker build -t $DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/${CIRCLE_PROJECT_REPONAME,,}-nginx:$NGINX_HASH -f silta/nginx.Dockerfile web
+                  docker push $DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/${CIRCLE_PROJECT_REPONAME,,}-nginx:$NGINX_HASH
+
+                  # Keep track that the image for these files has been built.
+                  echo $NGINX_HASH >> docker-files-hash/nginx
+                fi
 
                 # Build the Drupal image and push it to the repository.
                 docker build -t $DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/${CIRCLE_PROJECT_REPONAME,,}-php:$CIRCLE_SHA1 -f silta/php.Dockerfile .
@@ -155,6 +168,11 @@ orbs:
                 # Build the Shell image and push it to the repository.
                 docker build -t $DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/${CIRCLE_PROJECT_REPONAME,,}-shell:$CIRCLE_SHA1 -f silta/shell.Dockerfile .
                 docker push $DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/${CIRCLE_PROJECT_REPONAME,,}-shell:$CIRCLE_SHA1
+
+          - save_cache:
+              paths:
+                - docker-files-hash
+              key: v1-docker-files-hash
 
       set-release-name:
         steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,6 +168,29 @@ orbs:
                 HASH=`tar --sort=name --exclude-from=<<parameters.path>>/.dockerignore --mtime='2000-01-01 00:00Z' --clamp-mtime -cf - <<parameters.path>> | sha1sum | cut -c 1-40`
                 echo "export <<parameters.identifier>>_HASH='$HASH'" >> $BASH_ENV
 
+      build-docker-image:
+        parameters:
+          dockerfile:
+            type: string
+          path:
+            type: string
+          identifier:
+            type: string
+        steps:
+          - run:
+              name: Build docker image
+              command: |
+                IMAGE_URL=$DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/${CIRCLE_PROJECT_REPONAME,,}-<<parameters.identifier>>
+                IMAGE_TAG=$<<parameters.identifier>>_HASH
+
+                if gcloud container images list-tags $IMAGE_URL | grep -q $IMAGE_TAG;
+                then
+                  echo "This <<parameters.identifier>> image has already been built, the existing image from the Docker repository will be used."
+                else
+                  docker build -t $IMAGE_URL:$IMAGE_TAG -f <<parameters.dockerfile>> <<parameters.path>>
+                  docker push $IMAGE_URL:$IMAGE_TAG
+                fi
+
 
       drupal-docker-build:
         steps:
@@ -185,17 +208,14 @@ orbs:
               name: Login to the docker registry
               command: echo $GCLOUD_KEY_JSON | docker login -u _json_key --password-stdin https://$DOCKER_REPO_HOST
 
+          - build-docker-image:
+              dockerfile: silta/nginx.Dockerfile
+              path: web
+              identifier: NGINX
+
           - run:
               name: Build docker images
               command: |
-                if gcloud container images list-tags $DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/${CIRCLE_PROJECT_REPONAME,,}-nginx | grep -q $NGINX_HASH;
-                then
-                  echo "This nginx image has already been built, the existing image from the Docker repository will be used"
-                else
-                  # Build the Nginx image and push it to the repository.
-                  docker build -t $DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/${CIRCLE_PROJECT_REPONAME,,}-nginx:$NGINX_HASH -f silta/nginx.Dockerfile web
-                  docker push $DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/${CIRCLE_PROJECT_REPONAME,,}-nginx:$NGINX_HASH
-                fi
 
                 if gcloud container images list-tags $DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/${CIRCLE_PROJECT_REPONAME,,}-php | grep -q $PHP_HASH;
                 then

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,6 +43,9 @@ orbs:
           - get-docker-file-hash:
               path: web
               identifier: NGINX
+          - run:
+              command: |
+                echo $NGINX_HASH
           - drupal-docker-build
 
       drupal-deploy:
@@ -127,9 +130,9 @@ orbs:
         steps:
           - run:
               command: |
-                <<parameters.identifier>>_HASH=`tar --sort=name --exclude-from=<<parameters.path>>/.dockerignore --mtime='2000-01-01 00:00Z' --clamp-mtime -cf - <<parameters.path>> | sha1sum`
+                HASH=`tar --sort=name --exclude-from=<<parameters.path>>/.dockerignore --mtime='2000-01-01 00:00Z' --clamp-mtime -cf - <<parameters.path>> | sha1sum`
 
-                echo $<<parameters.identifier>>_HASH >> $BASH_ENV
+                echo "export <<parameters.identifier>>_HASH='$HASH'" >> $BASH_ENV
 
 
       drupal-docker-build:

--- a/.dockerignore
+++ b/.dockerignore
@@ -16,3 +16,4 @@ vendor/**/Tests
 web/sites/**/files
 web/.dockerignore
 Dockerfile
+composer.lock


### PR DESCRIPTION
It required quite a few iterations to get there, but I'm pretty happy with what we got.

The main change is the introduction of the `build-docker-image` custom CircleCI command which builds and push a specific image, taking a dockerfile location, a path (the docker context) and an id. Before building the image, a hash of the folder that gets copied into the docker image is created and we check the google cloud docker registry for an image with that tag (once the docker 2.0 api is established we can switch over to that) and only build the image if needed.

Now that the entire build and deployment can run in about 1 minute (with a warm cache), it makes more sense to combine both steps into one, saving the time needed to spin up a new docker container, and also avoiding the complexity of passing information around between CircleCI jobs.

Note that the original build and deploy jobs have been left, so we don't break existing projects and have the option to update existing CircleCI configurations without stress.