### PR TITLE
SLT-235 dedicated resources for the post-release job

### DIFF
--- a/chart/templates/drupal-deployment.yaml
+++ b/chart/templates/drupal-deployment.yaml
@@ -46,9 +46,6 @@ spec:
       # Nginx container
       - name: nginx
         image: {{ .Values.nginx.image | quote }}
-        resources:
-          requests:
-            cpu: "50m"
         env:
         ports:
         - containerPort: 80

--- a/chart/templates/post-release.yaml
+++ b/chart/templates/post-release.yaml
@@ -32,7 +32,7 @@ spec:
             {{- end }}
           {{- end }}
         resources:
-          {{- .Values.php.resources | toYaml | nindent 10 }}
+          {{- .Values.php.postinstall.resources | toYaml | nindent 10 }}
       {{- include "drupal.imagePullSecrets" . | nindent 6 }}
       volumes:
         {{- include "drupal.volumes" . | nindent 8 }}

--- a/chart/templates/post-release.yaml
+++ b/chart/templates/post-release.yaml
@@ -31,6 +31,8 @@ spec:
             readOnly: true
             {{- end }}
           {{- end }}
+        resources:
+          {{- .Values.php.resources | toYaml | nindent 10 }}
       {{- include "drupal.imagePullSecrets" . | nindent 6 }}
       volumes:
         {{- include "drupal.volumes" . | nindent 8 }}

--- a/chart/tests/drupal_postinstall_test.yaml
+++ b/chart/tests/drupal_postinstall_test.yaml
@@ -73,25 +73,25 @@ tests:
             persistentVolumeClaim:
               claimName: RELEASE-NAME-public-files
 
-  - it: takes resource requests and limits
+  - it: can override default php resource requests and limits
     set:
-      php.resources:
+      php.postinstall.resources:
         requests:
-          cpu: 123m
-          memory: 1G
-        limits:
-          cpu: 234m
+          cpu: 124m
           memory: 2G
+        limits:
+          cpu: 235m
+          memory: 4G
     asserts:
       - equal:
           path: spec.template.spec.containers[0].resources.requests.cpu
-          value: 123m
+          value: 124m
       - equal:
           path: spec.template.spec.containers[0].resources.requests.memory
-          value: 1G
+          value: 2G
       - equal:
           path: spec.template.spec.containers[0].resources.limits.cpu
-          value: 234m
+          value: 235m
       - equal:
           path: spec.template.spec.containers[0].resources.limits.memory
-          value: 2G
+          value: 4G

--- a/chart/tests/drupal_postinstall_test.yaml
+++ b/chart/tests/drupal_postinstall_test.yaml
@@ -72,3 +72,26 @@ tests:
             name: "drupal-public-files"
             persistentVolumeClaim:
               claimName: RELEASE-NAME-public-files
+
+  - it: takes resource requests and limits
+    set:
+      php.resources:
+        requests:
+          cpu: 123m
+          memory: 1G
+        limits:
+          cpu: 234m
+          memory: 2G
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: 123m
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.memory
+          value: 1G
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.cpu
+          value: 234m
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.memory
+          value: 2G

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -95,6 +95,10 @@ php:
         echo "No configuration found, installing a plain drupal site"
         drush site-install -n standard
       fi
+    resources:
+      requests:
+        cpu: 500m
+        memory: 256M
 
   # Post-upgrade hook.
   # This is run every time a new environment is upgraded.


### PR DESCRIPTION
This is a first step towards being able to lower the general resource usage and being able to place more environments in the same cluster while still running everything smoothly. The one place where we need a peak of dedicated resources is for the post-release job, which runs both site installation and configuration imports. Once this one has dedicated resources, we can easily lower the resource utilisation for the always-on pods.

The load tests showed that 500m is about right for a fast installation, more CPU doesn't change much after that.