### PR TITLE
SLT-95 resource optimisation

### DIFF
--- a/chart/templates/drupal-deployment.yaml
+++ b/chart/templates/drupal-deployment.yaml
@@ -33,13 +33,6 @@ spec:
         livenessProbe:
           tcpSocket:
             port: 9000
-        readinessProbe:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - if [ ! {{ include "drupal.deployment-in-progress-test" . }} ]; then timeout -t 3 drush check-bootstrap; else exit 1; fi
-          periodSeconds: 3
         resources:
           {{- .Values.php.resources | toYaml | nindent 10 }}
 
@@ -74,12 +67,6 @@ spec:
         livenessProbe:
           tcpSocket:
             port: 80
-        readinessProbe:
-          httpGet:
-            path: /robots.txt
-            port: 80
-          periodSeconds: 3
-          timeoutSeconds: 3
         resources:
           {{- .Values.nginx.resources | toYaml | nindent 10 }}
 

--- a/chart/templates/drupal-deployment.yaml
+++ b/chart/templates/drupal-deployment.yaml
@@ -33,6 +33,9 @@ spec:
         livenessProbe:
           tcpSocket:
             port: 9000
+        readinessProbe:
+          exec:
+            command: ['/bin/sh', '-c', 'if [ {{ include "drupal.deployment-in-progress-test" . }} ]; then exit 1; fi']
         resources:
           {{- .Values.php.resources | toYaml | nindent 10 }}
 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -28,7 +28,7 @@ nginx:
   # These values are optimised for development environments.
   resources:
     requests:
-      cpu: 10m
+      cpu: 5m
       memory: 10M
   
   # Set of values to enable and use http basic authentication
@@ -57,7 +57,7 @@ php:
   # These values are optimised for development environments.
   resources:
     requests:
-      cpu: 100m
+      cpu: 50m
       memory: 128M
 
   # Cron tasks, each of which will be run into a dedicated temporary pod.
@@ -197,8 +197,8 @@ mariadb:
       size: 1G
     resources:
       requests:
-        cpu: 100m
-        memory: 256M
+        cpu: 50m
+        memory: 128M
 
 elasticsearch:
   enabled: false


### PR DESCRIPTION
I did some testing, and if we have more resources for the post-release job (see https://github.com/wunderio/drupal-project-k8s/pull/99) we can reduce the requested memory for the other containers. 

As discussed in Slack, I would also recommend removing the readiness checks. They are creating a considerable load on the service by themselves and prevent us from being able to lower the resources without the checks failing due to timeouts. They have also been responsible for a few confusing issues for developers, in the end we are better off without them.

Note that the deployment is a bit slower because in this branch the post-release job doesn't yet get additional resources.