### PR TITLE
SLT-240: Disabling X-Pack plugin to allow ES 5.x work

### DIFF
--- a/chart/templates/elasticsearch-deployment.yaml
+++ b/chart/templates/elasticsearch-deployment.yaml
@@ -70,6 +70,8 @@ spec:
           value: {{ .Release.Name }}-search
         - name: ES_JAVA_OPTS
           value: -Xms{{ .Values.elasticsearch.heapSize }} -Xmx{{ .Values.elasticsearch.heapSize }}
+        - name: xpack.security.enabled
+          value: 'false'
         volumeMounts:
         - mountPath: "/usr/share/elasticsearch/data"
           name: {{ .Release.Name }}-elastic-volume


### PR DESCRIPTION
Added environment variable to disable X-Pack plugin for Elasticsearch.
Probes were dying as they couldnt query ES container, since it required authentication.

For testing - deploy a release with ES5.x, 6.x - ES container is reachable from drupal php container.