### PR TITLE
Bugfix/slt 240

### DIFF
--- a/chart/templates/elasticsearch-deployment.yaml
+++ b/chart/templates/elasticsearch-deployment.yaml
@@ -71,7 +71,7 @@ spec:
         - name: ES_JAVA_OPTS
           value: -Xms{{ .Values.elasticsearch.heapSize }} -Xmx{{ .Values.elasticsearch.heapSize }}
         - name: xpack.security.enabled
-          value: 'false'
+          value: {{ .Values.elasticsearch.xpack.enabled | default "false" | quote }}
         volumeMounts:
         - mountPath: "/usr/share/elasticsearch/data"
           name: {{ .Release.Name }}-elastic-volume

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -186,7 +186,7 @@ referenceData:
 # Override the default values of the MariaDB subchart.
 # These settings are optimised for development environments.
 mariadb:
-  enabled: true
+  enabled: false
   replication:
     enabled: false
   db:
@@ -200,11 +200,22 @@ mariadb:
         cpu: 100m
         memory: 256M
 
+
+cloudsql:
+  enabled: true
+  db:
+    name: drupal
+    user: drupal
+    instanceName: 
+
+
 elasticsearch:
   enabled: false
   #Choose versions in https://www.docker.elastic.co/ from "Elasticsearch" list
   version: 6.5.0
   heapSize: 256m
+  xpack:
+    enabled: false
   persistence:
     size: 512Mi
     storageClassName: nfs

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -186,7 +186,7 @@ referenceData:
 # Override the default values of the MariaDB subchart.
 # These settings are optimised for development environments.
 mariadb:
-  enabled: false
+  enabled: true
   replication:
     enabled: false
   db:
@@ -199,15 +199,6 @@ mariadb:
       requests:
         cpu: 100m
         memory: 256M
-
-
-cloudsql:
-  enabled: true
-  db:
-    name: drupal
-    user: drupal
-    instanceName: 
-
 
 elasticsearch:
   enabled: false


### PR DESCRIPTION
X-Pack is an optional plugin. 
Testable by running dry-run with toggled elasticsearch.xpack.enabled.
Output in an environment variables should be a string of "true" or "false", not the boolean.