### PR TITLE
SLT-242: Optimise the composer autoloader.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,7 +171,7 @@ orbs:
 
           - run:
               name: composer install
-              command: composer install -n --prefer-dist --ignore-platform-reqs --no-dev
+              command: composer install -n --prefer-dist --ignore-platform-reqs --no-dev --optimize-autoloader
 
           - save_cache:
               paths:


### PR DESCRIPTION
According to https://getcomposer.org/doc/articles/autoloader-optimization.md, this option should always be used in production.