### PR TITLE
Feature/slt233 memcache fix

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -220,7 +220,7 @@ elasticsearch:
       memory: 512Mi
 
 memcached:
-  enabled: false
+  enabled: true
   maxItemMemory: 128
 
 # Configure ambassador for routing inbound traffic. We typically enable ambassador on development 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -219,9 +219,14 @@ elasticsearch:
       cpu: 25m
       memory: 512Mi
 
+# Memcache service overrides
+# see: https://github.com/helm/charts/blob/master/stable/memcached/values.yaml
 memcached:
   enabled: true
-  maxItemMemory: 128
+  replicaCount: 1
+  pdbMinAvailable: 1
+  memcached:
+    maxItemMemory: 128
 
 # Configure ambassador for routing inbound traffic. We typically enable ambassador on development 
 # environments, but disable it and instead use a dedicated ingress resource on production; some 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -222,7 +222,7 @@ elasticsearch:
 # Memcache service overrides
 # see: https://github.com/helm/charts/blob/master/stable/memcached/values.yaml
 memcached:
-  enabled: true
+  enabled: false
   replicaCount: 1
   pdbMinAvailable: 1
   memcached:


### PR DESCRIPTION
Fixes https://github.com/wunderio/drupal-project-k8s/issues/94 

- replicaCount decreased to 1, 
- memcached context change for `maxItemMemory` parameter 

Tested:
```
$ kubectl get pods -n drupal-project-k8s | grep memcache
drupal-project-k8s--feature-slt233-c145-memcached-0               1/1       Running            0          1m
drupal-project-k8s--feature-slt233-c145-memcached-1               1/1       Running            0          1m
drupal-project-k8s--feature-slt233-c145-memcached-2               1/1       Running            0          23s
```

vs

```
$ kubectl get pods -n drupal-project-k8s | grep memcache
drupal-project-k8s--feature-slt233-c145-memcached-0               1/1       Running   0          28
```