### PR TITLE
SLT-256: loop and expose exposeDomains values

### DIFF
--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -1,6 +1,9 @@
 Your site is available here:
 
   http://{{- template "drupal.domain" . }}
+  {{- range $index, $domain := .Values.exposeDomains }}
+  {{ $domain }}
+  {{- end }}
 
 {{ if .Values.nginx.basicauth.enabled -}}
 Basicauth username: {{ .Values.nginx.basicauth.credentials.username }}

--- a/chart/templates/drupal-service.yaml
+++ b/chart/templates/drupal-service.yaml
@@ -14,6 +14,15 @@ metadata:
       service: {{ .Release.Name }}-drupal.{{ .Release.Namespace }}.svc.cluster.local:80
       {{- .Values.ambassador.config | toYaml | nindent 6 }}
 {{- end }}
+{{- range $index, $domain := .Values.exposeDomains }}
+      ---
+      apiVersion: ambassador/v0
+      kind: Mapping
+      name: {{ $.Release.Name }}-drupal-{{ $index }}
+      host: {{ $domain }}
+      service: {{ $.Release.Name }}-drupal.{{ $.Release.Namespace }}.svc.cluster.local:80
+      {{- $.Values.ambassador.config | toYaml | nindent 6 }}
+{{- end }}
     domain: {{ template "drupal.domain" . }}
 spec:
   type: NodePort

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -20,6 +20,9 @@ app: drupal
 # Multiple pods make sense for high availability.
 replicas: 1
 
+# Domain names that will be mapped to this deployment.
+exposeDomains: []
+
 # These variables are build-specific and should be passed via the --set parameter.
 nginx:
   image: 'you need to pass in a value for nginx.image to your helm chart'


### PR DESCRIPTION
Allows mapping selected domain names (`Values.cexposeDomains`) in ambassador to current deployment.

Proof of concept and branch targetting demo is done in `feature/SLT-256-domains` branch, specifially, this commit:
https://github.com/wunderio/drupal-project-k8s/commit/cd6afae821f3ac3188b9e896f69820b4c5653bed

You should be able to open http://domain-demo.wdr.io/ (delete the domain from DNS zone, please, when You merge this PR).

All available domain names visible in release notes, https://circleci.com/gh/wunderio/drupal-project-k8s/5931

Drupal chart PR: https://github.com/wunderio/charts/pull/26