### PR TITLE
SLT-255: Disallow robots in robots.txt

### DIFF
--- a/chart/templates/drupal-configmap-nginx.yaml
+++ b/chart/templates/drupal-configmap-nginx.yaml
@@ -310,10 +310,15 @@ data:
             fastcgi_param SCRIPT_FILENAME $document_root/update.php;                                                                                       
             fastcgi_pass php;                                                                                                                              
         }                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     
-                                                                                                                                                          
-        location = /robots.txt {                                                                        
-            access_log off;                                                                                                                                
-            try_files $uri @drupal-no-args;                                                                                                                
+
+        location = /robots.txt {
+          access_log off;
+          {{- if not .Values.nginx.robotsTxt.allow }}
+            add_header Content-Type text/plain;
+            return 200 'User-agent: *\nDisallow: /';
+          {{- else }}
+            try_files $uri @drupal-no-args;
+          {{- end}}
         } 
                                                                                                                                                                                                   
         location ~* ^/.well-known/ {                                                                                                                       

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -48,6 +48,10 @@ nginx:
     noauthips:
       - 10.0.0.0/8 # GKE internal IPs
 
+  # Robots txt file blocked by default
+  robotsTxt:
+    allow: false
+
 # Configuration for everything that runs in php containers.
 php:
   # The docker image to be used. This is typically passed by your CI system using the --set parameter.


### PR DESCRIPTION
Moving robots.txt rewrite from `silta-cluster` to deployments. Denied by default.

Related PR's: 
- robots.txt nginx rewrite in drupal chart (k8s test): 
  https://github.com/wunderio/drupal-project-k8s/pull/111
- Removing ambassador robots.txt mapping from silta-cluster. robots.txt nginx rewrite in drupal and simple charts:
  https://github.com/wunderio/charts/pull/27
- Removing robots.txt file from container: 
  https://github.com/wunderio/silta-splash/pull/4