### PR TITLE
SLT-217: Use local phpcs 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -198,6 +198,7 @@ orbs:
               command: |
                 if [ -f vendor/bin/phpcs ]
                 then
+                  vendor/bin/phpcs --config-set installed_paths vendor/drupal/coder/coder_sniffer
                   vendor/bin/phpcs --standard=phpcs.xml -s --colors
                 else
                   phpcs --standard=phpcs.xml -s --colors

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -196,14 +196,28 @@ orbs:
               command: phpcs --standard=phpcs.xml -s
 
       drupal-composer-install:
+        parameters:
+          install-dev-dependencies:
+            type: boolean
+            default: false
         steps:
           - restore_cache:
               keys:
-                - v1-dependencies-{{ checksum "composer.lock" }}
+                - v1-dependencies-{{ checksum "composer.lock" }}-<<parameters.install-dev-dependencies>>
 
-          - run:
-              name: composer install
-              command: composer install -n --prefer-dist --ignore-platform-reqs --no-dev --optimize-autoloader
+          - when:
+              condition: <<parameters.install-dev-dependencies>>
+              steps:
+                - run:
+                    name: composer install
+                    command: composer install -n --prefer-dist --ignore-platform-reqs --optimize-autoloader
+
+          - unless:
+              condition: <<parameters.install-dev-dependencies>>
+              steps:
+                - run:
+                    name: composer install
+                    command: composer install -n --prefer-dist --ignore-platform-reqs --no-dev --optimize-autoloader
 
           - save_cache:
               paths:
@@ -213,7 +227,7 @@ orbs:
                 - ./web/themes/contrib
                 - ./web/profiles/contrib
                 - ./web/libraries
-              key: v1-dependencies-{{ checksum "composer.lock" }}
+              key: v1-dependencies-{{ checksum "composer.lock" }}-<<parameters.install-dev-dependencies>>
 
       yarn-install:
         steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -195,7 +195,13 @@ orbs:
         steps:
           - run:
               name: phpcs validation
-              command: phpcs --standard=phpcs.xml -s
+              command: |
+                if [ -f vendor/bin/phpcs ]
+                then
+                  vendor/bin/phpcs --standard=phpcs.xml -s --colors
+                else
+                  phpcs --standard=phpcs.xml -s --colors
+                fi
 
       drupal-composer-install:
         parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,8 @@ orbs:
         steps:
           - checkout:
               path: ~/project
+          - drupal-composer-install:
+              install-dev-dependencies: true
           - phpcs
           - run:
               name: Silta basic checks

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -206,6 +206,7 @@ orbs:
           - restore_cache:
               keys:
                 - v1-dependencies-{{ checksum "composer.lock" }}-<<parameters.install-dev-dependencies>>
+                - v1-dependencies-{{ checksum "composer.lock" }}
 
           - when:
               condition: <<parameters.install-dev-dependencies>>


### PR DESCRIPTION
We have had some cases where an updated global version of phpcs caused issues. It would be safer to use a project-specific version of phpcs (which turns out to be already installed as a dev dependency of Drupal core). 

We don't want to remove the globally installed phpcs yet as that could break a lot of sites, but it's nice to use the local one if present already.

As a follow-up, these changes need to be integrated in the silta-circleci orb.