### PR TITLE
SLT-203: Dynamic volume generation

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -28,11 +28,10 @@ ports:
 {{- end }}
 
 {{- define "drupal.volumeMounts" -}}
-- name: drupal-public-files
-  mountPath: /var/www/html/web/sites/default/files
-{{- if .Values.privateFiles.enabled }}
-- name: drupal-private-files
-  mountPath: /var/www/html/private
+{{- range $index, $mount := $.Values.mounts }}
+- name: drupal-{{ $mount.name }}
+  mountPath: {{ $mount.mountPath }}
+  readOnly: {{ $mount.readOnly | default false }}
 {{- end }}
 - name: php-conf
   mountPath: /etc/php7/php.ini
@@ -49,13 +48,10 @@ ports:
 {{- end }}
 
 {{- define "drupal.volumes" -}}
-- name: drupal-public-files
+{{- range $index, $mount := $.Values.mounts }}
+- name: drupal-{{ $mount.name }}
   persistentVolumeClaim:
-    claimName: {{ .Release.Name }}-public-files
-{{- if .Values.privateFiles.enabled }}
-- name: drupal-private-files
-  persistentVolumeClaim:
-    claimName: {{ .Release.Name }}-private-files
+    claimName: {{ $.Release.Name }}-{{ $mount.name }}
 {{- end }}
 - name: php-conf
   configMap:
@@ -109,9 +105,9 @@ imagePullSecrets:
 - name: {{ $key }}
   value: {{ $val | quote }}
 {{- end }}
-{{- if .Values.privateFiles.enabled }}
-- name: PRIVATE_FILES_PATH
-  value: '/var/www/html/private'
+{{- range $index, $mount := $.Values.mounts }}
+- name: {{ regexReplaceAll "[^[:alnum:]]" $mount.name "_" | upper }}_PATH
+  value: {{ $mount.mountPath }}
 {{- end }}
 {{- end }}
 

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -31,7 +31,6 @@ ports:
 {{- range $index, $mount := $.Values.mounts }}
 - name: drupal-{{ $mount.name }}
   mountPath: {{ $mount.mountPath }}
-  readOnly: {{ $mount.readOnly | default false }}
 {{- end }}
 - name: php-conf
   mountPath: /etc/php7/php.ini

--- a/chart/templates/drupal-deployment.yaml
+++ b/chart/templates/drupal-deployment.yaml
@@ -47,9 +47,11 @@ spec:
         - containerPort: 80
           name: drupal
         volumeMounts:
-        - name: drupal-public-files
-          mountPath: /var/www/html/web/sites/default/files
+        {{- range $index, $mount := $.Values.mounts }}
+        - name: drupal-{{ $mount.name }}
+          mountPath: {{ $mount.mountPath }}
           readOnly: true
+        {{- end }}
         - name: nginx-conf
           mountPath: /etc/nginx/nginx.conf # mount nginx-conf configmap volume to /etc/nginx
           readOnly: true

--- a/chart/templates/drupal-volumes.yaml
+++ b/chart/templates/drupal-volumes.yaml
@@ -1,74 +1,43 @@
+{{- range $index, $mount := .Values.mounts }}
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: {{ .Release.Name }}-public-files
+  name: {{ $.Release.Name }}-{{ $mount.name }}
   labels:
-    name: {{ .Release.Name }}-public-files
+    name: {{ $.Release.Name }}-{{ $mount.name }}
 spec:
   accessModes:
     - ReadWriteMany
   capacity:
-    storage: {{ .Values.publicFiles.storage }}
-  storageClassName: {{ .Values.publicFiles.storageClassName }}
-  {{- if .Values.publicFiles.csiDriverName }}
+    storage: {{ $mount.storage }}
+  storageClassName: {{ $mount.storageClassName }}
+  {{- if $mount.csiDriverName }}
   csi:
-    driver: {{ .Values.publicFiles.csiDriverName }}
-    volumeHandle: {{ .Release.Name }}-public-files
+    driver: {{ $mount.csiDriverName }}
+    volumeHandle: {{ $.Release.Name }}-{{ $mount.name }}
     volumeAttributes:
-      remotePathSuffix: /{{ .Release.Namespace }}/{{ .Values.environmentName }}/public-files
+      remotePathSuffix: /{{ $.Release.Namespace }}/{{ $.Values.environmentName }}/{{ $mount.name }}
   {{- end }}
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ .Release.Name }}-public-files
+  name: {{ $.Release.Name }}-{{ $mount.name }}
   labels:
-    {{- include "drupal.release_labels" . | nindent 4 }}
+    {{- include "drupal.release_labels" $ | nindent 4 }}
 spec:
-  storageClassName: {{ .Values.publicFiles.storageClassName }}
+  storageClassName: {{ $mount.storageClassName }}
   accessModes:
     - ReadWriteMany
   resources:
     requests:
-      storage: {{ .Values.publicFiles.storage }}
+      storage: {{ $mount.storage }}
+  selector:
+    matchLabels:
+      name: {{ $.Release.Name }}-{{ $mount.name }}
 ---
-{{- if .Values.privateFiles.enabled }}
-apiVersion: v1
-kind: PersistentVolume
-metadata:
-  name: {{ .Release.Name }}-private-files
-  labels:
-    name: {{ .Release.Name }}-private-files
-spec:
-  accessModes:
-    - ReadWriteMany
-  capacity:
-    storage: {{ .Values.privateFiles.storage }}
-  storageClassName: {{ .Values.privateFiles.storageClassName }}
-  {{- if .Values.privateFiles.csiDriverName }}
-  csi:
-    driver: {{ .Values.privateFiles.csiDriverName }}
-    volumeHandle: {{ .Release.Name }}-private-files
-    volumeAttributes:
-      remotePathSuffix: /{{ .Release.Namespace }}/{{ .Values.environmentName }}/private-files
-  {{- end }}
----
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: {{ .Release.Name }}-private-files
-  labels:
-    app: {{ .Values.app | quote }}
-    release: {{ .Release.Name }}
-spec:
-  storageClassName: {{ .Values.privateFiles.storageClassName }}
-  accessModes:
-    - ReadWriteMany
-  resources:
-    requests:
-      storage: {{ .Values.privateFiles.storage }}
 {{- end }}
----
+
 {{- if .Values.referenceData.enabled }}
 {{- if eq .Values.referenceData.referenceEnvironment .Values.environmentName }}
 apiVersion: v1
@@ -105,6 +74,9 @@ spec:
   resources:
     requests:
       storage: {{ .Values.referenceData.storage }}
+  selector:
+    matchLabels:
+      name: {{ .Release.Name }}-reference-data
 {{- end }}
 {{- end }}
 ---

--- a/chart/tests/drupal_cron_test.yaml
+++ b/chart/tests/drupal_cron_test.yaml
@@ -30,6 +30,12 @@ tests:
             value: bar
 
   - it: has public files mounted
+    set:
+      mounts:
+        - name: public-files
+          storage: 123Gi
+          storageClassName: foo
+          mountPath: /foo/bar/files
     asserts:
       - contains:
           path: spec.jobTemplate.spec.template.spec.volumes

--- a/chart/tests/drupal_postinstall_test.yaml
+++ b/chart/tests/drupal_postinstall_test.yaml
@@ -65,6 +65,12 @@ tests:
             value: bar
 
   - it: has public files mounted
+    set:
+      mounts:
+        - name: public-files
+          storage: 123Gi
+          storageClassName: foo
+          mountPath: /foo/bar/files
     asserts:
       - contains:
           path: spec.template.spec.volumes

--- a/chart/tests/private_files_test.yaml
+++ b/chart/tests/private_files_test.yaml
@@ -6,6 +6,12 @@ templates:
   - drupal-cron.yaml
 tests:
   - it: private files should be disabled by default
+    set:
+      mounts:
+        - name: public-files
+          storage: 123Gi
+          storageClassName: foo
+          mountPath: /foo/bar/files
     asserts:
       # No private files volume is mounted.
       - notContains:
@@ -21,10 +27,15 @@ tests:
 
   - it: private files should work when enabled
     set:
-      privateFiles:
-        enabled: true
-        storage: 123Gi
-        storageClassName: foo
+      mounts:
+        - name: private-files
+          storage: 123Gi
+          storageClassName: foo
+          mountPath: /foo/bar/private
+        - name: public-files
+          storage: 123Gi
+          storageClassName: foo
+          mountPath: /foo/bar/files
     asserts:
       # A private files volume is mounted
       - contains:
@@ -39,7 +50,7 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: PRIVATE_FILES_PATH
-            value: '/var/www/html/private'
+            value: '/foo/bar/private'
 
       # There are two volumes defined.
       - template: drupal-volumes.yaml

--- a/chart/tests/reference_data_test.yaml
+++ b/chart/tests/reference_data_test.yaml
@@ -10,6 +10,11 @@ tests:
     set:
       referenceData:
         referenceEnvironment: 'FOO'
+      mounts:
+        - name: public-files
+          storage: 123Gi
+          storageClassName: foo
+          mountPath: /foo/bar/files
     asserts:
     # Only public files PVC is defined.
     - hasDocuments:
@@ -60,6 +65,11 @@ tests:
         command: "echo Hello World"
       php.env:
         foo: bar
+      mounts:
+        - name: public-files
+          storage: 123Gi
+          storageClassName: foo
+          mountPath: /foo/bar/files
     asserts:
     - hasDocuments:
         count: 5
@@ -116,6 +126,11 @@ tests:
       referenceData:
         enabled: false
         referenceEnvironment: 'FOO'
+      mounts:
+        - name: public-files
+          storage: 123Gi
+          storageClassName: foo
+          mountPath: /foo/bar/files
     asserts:
     - template: drupal-volumes.yaml
       hasDocuments:

--- a/chart/tests/volumes_test.yaml
+++ b/chart/tests/volumes_test.yaml
@@ -4,9 +4,11 @@ templates:
 tests:
   - it: public files volume should be configurable
     set:
-      publicFiles:
-        storage: 123Gi
-        storageClassName: foo
+      mounts:
+        - name: public-files
+          storage: 123Gi
+          storageClassName: foo
+          mountPath: /var/www/html/web/sites/default/files
 
     asserts:
       - documentIndex: 1

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -157,7 +157,6 @@ mounts:
   #   mountPath: /var/www/html/private
   #   storageClassName: silta-shared
   #   csiDriverName: csi-rclone
-  #   readOnly: false
   
 # Configure reference data that will be used when creating new environments.
 referenceData:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -145,19 +145,20 @@ shell:
     repositoryUrl: 'you need to pass in a value for repositoryUrl to your helm chart'
     apiToken: 'you need to pass in a value for shell.gitAuth.apiToken to your helm chart'
 
-# Configure the volume used for Drupal public files.
-publicFiles:
-  storage: 1Gi
-  storageClassName: silta-shared
-  csiDriverName: csi-rclone
-
-# Configure an optional volume used for Drupal private files.
-privateFiles:
-  enabled: false
-  storage: 1G
-  storageClassName: silta-shared
-  csiDriverName: csi-rclone
-
+# Configure the dynamically mounted volumes
+mounts:
+  - name: public-files
+    storage: 1G
+    mountPath: /var/www/html/web/sites/default/files
+    storageClassName: silta-shared
+    csiDriverName: csi-rclone
+  # - name: private-files
+  #   storage: 1G
+  #   mountPath: /var/www/html/private
+  #   storageClassName: silta-shared
+  #   csiDriverName: csi-rclone
+  #   readOnly: false
+  
 # Configure reference data that will be used when creating new environments.
 referenceData:
   enabled: true

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -3,27 +3,3 @@
 #
 # See https://github.com/wunderio/charts/blob/master/drupal/README.md
 # for all possible options.
-
-# Example: enable private files for Drupal.
-#privateFiles:
-#  enabled: true
-
-# Testing mounts
-mounts:
-  - name: public-files
-    storage: 1G
-    mountPath: /var/www/html/web/sites/default/files
-    storageClassName: silta-shared
-    csiDriverName: csi-rclone
-  - name: private-files
-    storage: 1G
-    mountPath: /var/www/html/private
-    storageClassName: silta-shared
-    csiDriverName: csi-rclone
-    readOnly: false
-  - name: custom-mount
-    storage: 1G
-    mountPath: /var/www/html/custom-mount
-    storageClassName: silta-shared
-    csiDriverName: csi-rclone
-    readOnly: false

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -7,3 +7,23 @@
 # Example: enable private files for Drupal.
 #privateFiles:
 #  enabled: true
+
+# Testing mounts
+mounts:
+  - name: public-files
+    storage: 1G
+    mountPath: /var/www/html/web/sites/default/files
+    storageClassName: silta-shared
+    csiDriverName: csi-rclone
+  - name: private-files
+    storage: 1G
+    mountPath: /var/www/html/private
+    storageClassName: silta-shared
+    csiDriverName: csi-rclone
+    readOnly: false
+  - name: custom-mount
+    storage: 1G
+    mountPath: /var/www/html/custom-mount
+    storageClassName: silta-shared
+    csiDriverName: csi-rclone
+    readOnly: false


### PR DESCRIPTION
Dynamic file mounts. File mount is defined by default, can override "mounts" section to add more.

```
mounts:
  - name: public-files
    storage: 1G
    mountPath: /var/www/html/web/sites/default/files
    storageClassName: silta-shared
    csiDriverName: csi-rclone
  - name: private-files
    storage: 1G
    mountPath: /var/www/html/private
    storageClassName: silta-shared
    csiDriverName: csi-rclone
    readOnly: false
  - name: custom-mount
    storage: 1G
    mountPath: /var/www/html/custom-mount
    storageClassName: silta-shared
    csiDriverName: csi-rclone
    readOnly: false
```
Tests changed accordingly.

No storage migration neccessary - i kept the naming schema `drupal-public-files` and `drupal-private-files` when they are generated. Also, the `PRIVATE_FILES_PATH` env variable also works. All mounts have their env variables now.

Things to consider:
 - Legacy definitions of `.Values.publicFiles` and `.Values.privateFiles`. Maybe we need a temp resource that prints a message if anything is defined in those. Or not. Public is on by default now anyway.
 - Defining `readOnly` could be unnecessary in that scope. nginx pod could just set all dynamic mounts to false by default.
 - Probably ommiting `csiDriverName`. It could be just injected into PV, assuming that we're only going to use `csi-rclone` driver for storage. Or defaulting to `csi-rclone`.
 - Nginx now mounts all storages. It mounted only the public storage before. 