### PR TITLE
SLT-268: Change the application root to /app.

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -139,7 +139,7 @@ done
 
 {{- define "drupal.wait-for-ref-fs-command" }}
 TIME_WAITING=0
-until touch /var/www/html/reference-data/_fs-test; do
+until touch /app/reference-data/_fs-test; do
   echo "Waiting for reference-data fs..."; sleep 2
   TIME_WAITING=$((TIME_WAITING+2))
 
@@ -148,11 +148,11 @@ until touch /var/www/html/reference-data/_fs-test; do
     exit 1
   fi
 done
-rm /var/www/html/reference-data/_fs-test
+rm /app/reference-data/_fs-test
 {{- end }}
 
 {{- define "drupal.deployment-in-progress-test" -}}
--f /var/www/html/web/sites/default/files/_deployment
+-f /app/web/sites/default/files/_deployment
 {{- end -}}
 
 {{- define "drupal.post-release-command" -}}
@@ -165,9 +165,9 @@ set -e
 {{ include "drupal.wait-for-db-command" . }}
 
 {{ if .Release.IsInstall }}
-touch /var/www/html/web/sites/default/files/_deployment
+touch /app/web/sites/default/files/_deployment
 {{ .Values.php.postinstall.command}}
-rm /var/www/html/web/sites/default/files/_deployment
+rm /app/web/sites/default/files/_deployment
 {{ else }}
 {{ .Values.php.postupgrade.command}}
 {{ end }}

--- a/chart/templates/drupal-configmap-nginx.yaml
+++ b/chart/templates/drupal-configmap-nginx.yaml
@@ -86,7 +86,7 @@ data:
         server_name drupal;                          
         listen 80;          
                                         
-        root /var/www/html/web;                                     
+        root /app/web;
         index index.php;
                                                                               
         include fastcgi.conf;

--- a/chart/templates/post-release.yaml
+++ b/chart/templates/post-release.yaml
@@ -26,7 +26,7 @@ spec:
           {{- include "drupal.volumeMounts" . | nindent 10 }}
           {{- if .Values.referenceData.enabled }}
           - name: reference-data-volume
-            mountPath: /var/www/html/reference-data
+            mountPath: /app/reference-data
             {{- if ne .Values.referenceData.referenceEnvironment .Values.environmentName }}
             readOnly: true
             {{- end }}

--- a/chart/templates/reference-data-cron.yaml
+++ b/chart/templates/reference-data-cron.yaml
@@ -19,7 +19,7 @@ spec:
             volumeMounts:
               {{- include "drupal.volumeMounts" . | nindent 14 }}
               - name: reference-data-volume
-                mountPath: /var/www/html/reference-data
+                mountPath: /app/reference-data
             command: ["/bin/sh", "-c"]
             args:
               - {{ .Values.referenceData.command | quote }}

--- a/chart/tests/drupal_cron_test.yaml
+++ b/chart/tests/drupal_cron_test.yaml
@@ -56,11 +56,11 @@ tests:
           count: 2
       - equal:
           path: spec.jobTemplate.spec.template.spec.containers[0].args[0]
-          value: 'if [ ! -f /var/www/html/web/sites/default/files/_deployment ]; then foo; else exit 1; fi'
+          value: 'if [ ! -f /app/web/sites/default/files/_deployment ]; then foo; else exit 1; fi'
         documentIndex: 0
       - equal:
           path: spec.jobTemplate.spec.template.spec.containers[0].args[0]
-          value: 'if [ ! -f /var/www/html/web/sites/default/files/_deployment ]; then bar; else exit 1; fi'
+          value: 'if [ ! -f /app/web/sites/default/files/_deployment ]; then bar; else exit 1; fi'
         documentIndex: 1
       - equal:
           path: spec.schedule

--- a/chart/tests/reference_data_test.yaml
+++ b/chart/tests/reference_data_test.yaml
@@ -35,7 +35,7 @@ tests:
         path: spec.template.spec.containers[0].volumeMounts
         content:
           name: "reference-data-volume"
-          mountPath: "/var/www/html/reference-data"
+          mountPath: "/app/reference-data"
           readOnly: true
 
   - it: is not mounted on the main deployment
@@ -52,7 +52,7 @@ tests:
         path: spec.template.spec.containers[0].volumeMounts
         content:
           name: "reference-data-volume"
-          mountPath: "/var/www/html/reference-data"
+          mountPath: "/app/reference-data"
             
   - it: takes reference data information
     set:
@@ -118,7 +118,7 @@ tests:
         path: spec.template.spec.containers[0].volumeMounts
         content:
           name: "reference-data-volume"
-          mountPath: "/var/www/html/reference-data"
+          mountPath: "/app/reference-data"
 
   - it: can be disabled
     set:
@@ -148,4 +148,4 @@ tests:
         path: spec.template.spec.containers[0].volumeMounts
         content:
           name: "reference-data-volume"
-          mountPath: "/var/www/html/reference-data"  
+          mountPath: "/app/reference-data"

--- a/chart/tests/volumes_test.yaml
+++ b/chart/tests/volumes_test.yaml
@@ -8,7 +8,7 @@ tests:
         - name: public-files
           storage: 123Gi
           storageClassName: foo
-          mountPath: /var/www/html/web/sites/default/files
+          mountPath: /app/web/sites/default/files
 
     asserts:
       - documentIndex: 1

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -149,12 +149,12 @@ shell:
 mounts:
   - name: public-files
     storage: 1G
-    mountPath: /var/www/html/web/sites/default/files
+    mountPath: /app/web/sites/default/files
     storageClassName: silta-shared
     csiDriverName: csi-rclone
   # - name: private-files
   #   storage: 1G
-  #   mountPath: /var/www/html/private
+  #   mountPath: /app/private
   #   storageClassName: silta-shared
   #   csiDriverName: csi-rclone
   

--- a/silta/nginx.Dockerfile
+++ b/silta/nginx.Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for building nginx.
 FROM wunderio/drupal-nginx:v0.1
 
-COPY . /var/www/html/web
+COPY . /app/web
 

--- a/silta/nginx.Dockerfile
+++ b/silta/nginx.Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for building nginx.
-FROM wunderio/drupal-nginx:v0.1
+FROM wunderio/drupal-nginx:v0.1.2
 
 COPY . /app/web
 

--- a/silta/php.Dockerfile
+++ b/silta/php.Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for the Drupal container.
 FROM wunderio/drupal-php-fpm:v0.1
 
-COPY --chown=www-data:www-data . /var/www/html
+COPY --chown=www-data:www-data . /app
 

--- a/silta/php.Dockerfile
+++ b/silta/php.Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for the Drupal container.
-FROM wunderio/drupal-php-fpm:v0.1
+FROM wunderio/drupal-php-fpm:v0.1.4
 
 COPY --chown=www-data:www-data . /app
 

--- a/silta/shell.Dockerfile
+++ b/silta/shell.Dockerfile
@@ -1,4 +1,4 @@
 # Dockerfile for the Drupal container.
 FROM wunderio/drupal-shell:v0.1
 
-COPY --chown=www-data:www-data . /var/www/html
+COPY --chown=www-data:www-data . /app

--- a/silta/shell.Dockerfile
+++ b/silta/shell.Dockerfile
@@ -1,4 +1,4 @@
 # Dockerfile for the Drupal container.
-FROM wunderio/drupal-shell:v0.1
+FROM wunderio/drupal-shell:v0.1.4
 
 COPY --chown=www-data:www-data . /app


### PR DESCRIPTION
The base docker images have been changed so that `/app` is a symlink to `/var/www/html`. Renaming the paths in the chart should work without issues. When all projects have been updated, the symlink will be removed.