### PR TITLE
Remove outdated example and fix application root

### DIFF
--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -1,5 +1,5 @@
 
 # Values in this file override the default values of our helm chart.
 #
-# See https://github.com/wunderio/charts/blob/master/drupal/README.md
+# See https://github.com/wunderio/charts/blob/master/drupal/values.yaml
 # for all possible options.


### PR DESCRIPTION
The way volumes are specified in silta.yml is now more flexible, and the given example
does not work anymore. See https://github.com/wunderio/charts/blob/master/drupal/values.yaml 
for an example of adding a volume for private files.

The application root within the container is now /app, it is more consistent across different 
types of applications and is also commonly used by other container-based hosting providers.

This pull request was created with https://github.com/wunderio/internal-mass-updater.