### PR TITLE
Only create explicit drupal PVs if using silta-shared storageClassName

### DIFF
--- a/chart/templates/drupal-volumes.yaml
+++ b/chart/templates/drupal-volumes.yaml
@@ -1,4 +1,5 @@
 {{- range $index, $mount := .Values.mounts }}
+{{- if eq $mount.storageClassName "silta-shared" }}
 apiVersion: v1
 kind: PersistentVolume
 metadata:
@@ -19,6 +20,7 @@ spec:
       remotePathSuffix: /{{ $.Release.Namespace }}/{{ $.Values.environmentName }}/{{ $mount.name }}
   {{- end }}
 ---
+{{- end }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/chart/tests/drupal_cron_test.yaml
+++ b/chart/tests/drupal_cron_test.yaml
@@ -34,7 +34,7 @@ tests:
       mounts:
         - name: public-files
           storage: 123Gi
-          storageClassName: foo
+          storageClassName: silta-shared
           mountPath: /foo/bar/files
     asserts:
       - contains:

--- a/chart/tests/drupal_postinstall_test.yaml
+++ b/chart/tests/drupal_postinstall_test.yaml
@@ -69,7 +69,7 @@ tests:
       mounts:
         - name: public-files
           storage: 123Gi
-          storageClassName: foo
+          storageClassName: silta-shared
           mountPath: /foo/bar/files
     asserts:
       - contains:

--- a/chart/tests/private_files_test.yaml
+++ b/chart/tests/private_files_test.yaml
@@ -10,7 +10,7 @@ tests:
       mounts:
         - name: public-files
           storage: 123Gi
-          storageClassName: foo
+          storageClassName: silta-shared
           mountPath: /foo/bar/files
     asserts:
       # No private files volume is mounted.
@@ -30,11 +30,11 @@ tests:
       mounts:
         - name: private-files
           storage: 123Gi
-          storageClassName: foo
+          storageClassName: silta-shared
           mountPath: /foo/bar/private
         - name: public-files
           storage: 123Gi
-          storageClassName: foo
+          storageClassName: silta-shared
           mountPath: /foo/bar/files
     asserts:
       # A private files volume is mounted
@@ -79,7 +79,7 @@ tests:
         documentIndex: 3
         equal:
           path: spec.storageClassName
-          value: foo
+          value: silta-shared
       - template: drupal-volumes.yaml
         documentIndex: 3
         equal:

--- a/chart/tests/reference_data_test.yaml
+++ b/chart/tests/reference_data_test.yaml
@@ -13,7 +13,7 @@ tests:
       mounts:
         - name: public-files
           storage: 123Gi
-          storageClassName: foo
+          storageClassName: silta-shared
           mountPath: /foo/bar/files
     asserts:
     # Only public files PVC is defined.
@@ -60,7 +60,7 @@ tests:
       referenceData:
         referenceEnvironment: 'feature/FOO'
         storage: 123Gi
-        storageClassName: foo
+        storageClassName: silta-shared
         schedule: '0 1 2 3 *'
         command: "echo Hello World"
       php.env:
@@ -68,7 +68,7 @@ tests:
       mounts:
         - name: public-files
           storage: 123Gi
-          storageClassName: foo
+          storageClassName: silta-shared
           mountPath: /foo/bar/files
     asserts:
     - hasDocuments:
@@ -78,7 +78,7 @@ tests:
       documentIndex: 3
       equal:
         path: spec.storageClassName
-        value: foo
+        value: silta-shared
     - template: drupal-volumes.yaml
       documentIndex: 3
       equal:
@@ -129,7 +129,7 @@ tests:
       mounts:
         - name: public-files
           storage: 123Gi
-          storageClassName: foo
+          storageClassName: silta-shared
           mountPath: /foo/bar/files
     asserts:
     - template: drupal-volumes.yaml

--- a/chart/tests/volumes_test.yaml
+++ b/chart/tests/volumes_test.yaml
@@ -7,14 +7,14 @@ tests:
       mounts:
         - name: public-files
           storage: 123Gi
-          storageClassName: foo
+          storageClassName: silta-shared
           mountPath: /app/web/sites/default/files
 
     asserts:
       - documentIndex: 1
         equal:
           path: spec.storageClassName
-          value: foo
+          value: silta-shared
       - documentIndex: 1
         equal:
           path: spec.resources.requests.storage


### PR DESCRIPTION
Related issue: https://github.com/wunderio/charts/pull/29