### PR TITLE
SLT-274: make project migration more intuitive

### DIFF
--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -15,4 +15,8 @@ SSH connection:
 
   ssh www-admin@{{ template "drupal.environment.hostname" . }}-shell.{{ .Release.Namespace }} -J www-admin@ssh.{{ .Values.clusterDomain }}
 
+Importing a database dump:
+
+  ssh www-admin@{{ template "drupal.environment.hostname" . }}-shell.{{ .Release.Namespace }} -J www-admin@ssh.{{ .Values.clusterDomain }} "drush sql-cli" < my_database_dump.sql
+
 {{- end }}

--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -19,4 +19,8 @@ Importing a database dump:
 
   ssh www-admin@{{ template "drupal.environment.hostname" . }}-shell.{{ .Release.Namespace }} -J www-admin@ssh.{{ .Values.clusterDomain }} "drush sql-cli" < my_database_dump.sql
 
+Importing files with rsync:
+
+  rsync -azv -e 'ssh -A -J www-admin@ssh.{{ .Values.clusterDomain }}' local_folder www-admin@{{ template "drupal.environment.hostname" . }}-shell.{{ .Release.Namespace }}:remote_folder
+
 {{- end }}

--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -10,7 +10,7 @@ Basicauth username: {{ .Values.nginx.basicauth.credentials.username }}
 Basicauth password: {{ .Values.nginx.basicauth.credentials.password }}
 {{- end }}
 
-{{- if .Values.shell.enabled }}
+{{ if .Values.shell.enabled }}
 SSH connection:
 
   ssh {{ include "drupal.shellHost" . }} -J {{ include "drupal.jumphost" . }}
@@ -19,8 +19,10 @@ Importing a database dump:
 
   ssh {{ include "drupal.shellHost" . }} -J {{ include "drupal.jumphost" . }} "drush sql-cli" < my_database_dump.sql
 
-Importing files with rsync:
+{{ range $index, $mount := .Values.mounts -}}
+Importing files to {{ $mount.name }}:
 
-  rsync -azv -e 'ssh -A -J {{ include "drupal.jumphost" . }}' local_folder {{ include "drupal.shellHost" . }}:remote_folder
+  rsync -azv -e 'ssh -A -J {{ include "drupal.jumphost" $ }}' local_folder {{ include "drupal.shellHost" $ }}:{{ $mount.mountPath }}
 
-{{- end }}
+{{ end -}}
+{{- end -}}

--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -13,14 +13,14 @@ Basicauth password: {{ .Values.nginx.basicauth.credentials.password }}
 {{- if .Values.shell.enabled }}
 SSH connection:
 
-  ssh www-admin@{{ template "drupal.environment.hostname" . }}-shell.{{ .Release.Namespace }} -J www-admin@ssh.{{ .Values.clusterDomain }}
+  ssh {{ include "drupal.shellHost" . }} -J {{ include "drupal.jumphost" . }}
 
 Importing a database dump:
 
-  ssh www-admin@{{ template "drupal.environment.hostname" . }}-shell.{{ .Release.Namespace }} -J www-admin@ssh.{{ .Values.clusterDomain }} "drush sql-cli" < my_database_dump.sql
+  ssh {{ include "drupal.shellHost" . }} -J {{ include "drupal.jumphost" . }} "drush sql-cli" < my_database_dump.sql
 
 Importing files with rsync:
 
-  rsync -azv -e 'ssh -A -J www-admin@ssh.{{ .Values.clusterDomain }}' local_folder www-admin@{{ template "drupal.environment.hostname" . }}-shell.{{ .Release.Namespace }}:remote_folder
+  rsync -azv -e 'ssh -A -J {{ include "drupal.jumphost" . }}' local_folder {{ include "drupal.shellHost" . }}:remote_folder
 
 {{- end }}

--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -15,7 +15,4 @@ SSH connection:
 
   ssh www-admin@{{ template "drupal.environment.hostname" . }}-shell.{{ .Release.Namespace }} -J www-admin@ssh.{{ .Values.clusterDomain }}
 
-SSH connection (alternative):
-
-  ssh www-admin@{{ template "drupal.environment.hostname" . }}-shell.{{ .Release.Namespace }} -o ProxyCommand="ssh -W %h:%p www-admin@ssh.{{ .Values.clusterDomain }}"
 {{- end }}

--- a/chart/templates/_domains.tpl
+++ b/chart/templates/_domains.tpl
@@ -1,0 +1,24 @@
+{{- define "drupal.domain" -}}
+{{ include "drupal.environmentName" . }}.{{ .Release.Namespace }}.{{ .Values.clusterDomain }}
+{{- end -}}
+
+{{- define "drupal.environmentName" -}}
+{{ regexReplaceAll "[^[:alnum:]]" (.Values.environmentName | default .Release.Name) "-" | lower | trunc 50 | trimSuffix "-" }}
+{{- end -}}
+
+{{- define "drupal.referenceEnvironment" -}}
+{{ regexReplaceAll "[^[:alnum:]]" .Values.referenceData.referenceEnvironment "-" | lower | trunc 50 | trimSuffix "-" }}
+{{- end -}}
+
+{{- define "drupal.environment.hostname" -}}
+{{ regexReplaceAll "[^[:alnum:]]" (.Values.environmentName | default .Release.Name) "-" | lower | trunc 50 | trimSuffix "-" }}
+{{- end -}}
+
+# SSH-related hosts
+{{- define "drupal.jumphost" -}}
+www-admin@ssh.{{ .Values.clusterDomain }}
+{{- end -}}
+
+{{- define "drupal.shellHost" -}}
+www-admin@{{ template "drupal.environment.hostname" . }}-shell.{{ .Release.Namespace }}
+{{- end -}}

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -3,22 +3,6 @@ app: {{ .Values.app | quote }}
 release: {{ .Release.Name }}
 {{- end }}
 
-{{- define "drupal.domain" -}}
-{{ include "drupal.environmentName" . }}.{{ .Release.Namespace }}.{{ .Values.clusterDomain }}
-{{- end -}}
-
-{{- define "drupal.environmentName" -}}
-{{ regexReplaceAll "[^[:alnum:]]" (.Values.environmentName | default .Release.Name) "-" | lower | trunc 50 | trimSuffix "-" }}
-{{- end -}}
-
-{{- define "drupal.referenceEnvironment" -}}
-{{ regexReplaceAll "[^[:alnum:]]" .Values.referenceData.referenceEnvironment "-" | lower | trunc 50 | trimSuffix "-" }}
-{{- end -}}
-
-{{- define "drupal.environment.hostname" -}}
-{{ regexReplaceAll "[^[:alnum:]]" (.Values.environmentName | default .Release.Name) "-" | lower | trunc 50 | trimSuffix "-" }}
-{{- end -}}
-
 {{- define "drupal.php-container" -}}
 image: {{ .Values.php.image | quote }}
 env: {{ include "drupal.env" . }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -94,7 +94,7 @@ php:
           drush config-import -y
         fi
       else
-        echo "No reference data found, please install Drupal or import a database dump. See release information for instructions."
+        printf "\e[33mNo reference data found, please install Drupal or import a database dump. See release information for instructions.\e[0m\n"
       fi
     resources:
       requests:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -93,14 +93,8 @@ php:
         if [ -f config/sync/core.extension.yml ]; then
           drush config-import -y
         fi
-
-      elif [ -f config/sync/core.extension.yml ]; then
-        echo "Installing Drupal from existing configuration"
-        drush site-install -y config_installer
-
       else
-        echo "No configuration found, installing a plain drupal site"
-        drush site-install -y standard
+        echo "No reference data found, please install Drupal or import a database dump. See release information for instructions."
       fi
     resources:
       requests:


### PR DESCRIPTION
Installing Drupal automatically often fails with an existing codebase, making it impossible for a deployment to be successful. This PR replaces the automatic installation with some instructions.

The Helm notes now also include instructions on how to import a database dump or importing files into each of the mounted volumes.

See the last step of https://circleci.com/gh/wunderio/drupal-project-k8s/6237 for the result.