### PR TITLE
SLT-285: Use objects instead of arrays in silta.yml for easier overrides

### DIFF
--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -20,7 +20,7 @@ Importing a database dump:
   ssh {{ include "drupal.shellHost" . }} -J {{ include "drupal.jumphost" . }} "drush sql-cli" < my_database_dump.sql
 
 {{ range $index, $mount := .Values.mounts -}}
-Importing files to {{ $mount.name }}:
+Importing files to {{ $index }}:
 
   rsync -azv -e 'ssh -A -J {{ include "drupal.jumphost" $ }}' local_folder {{ include "drupal.shellHost" $ }}:{{ $mount.mountPath }}
 

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -13,8 +13,10 @@ ports:
 
 {{- define "drupal.volumeMounts" -}}
 {{- range $index, $mount := $.Values.mounts }}
+{{- if eq $mount.enabled true }}
 - name: drupal-{{ $mount.name }}
   mountPath: {{ $mount.mountPath }}
+{{- end }}
 {{- end }}
 - name: php-conf
   mountPath: /etc/php7/php.ini
@@ -32,9 +34,11 @@ ports:
 
 {{- define "drupal.volumes" -}}
 {{- range $index, $mount := $.Values.mounts }}
+{{- if eq $mount.enabled true }}
 - name: drupal-{{ $mount.name }}
   persistentVolumeClaim:
     claimName: {{ $.Release.Name }}-{{ $mount.name }}
+{{- end }}
 {{- end }}
 - name: php-conf
   configMap:

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -14,7 +14,7 @@ ports:
 {{- define "drupal.volumeMounts" -}}
 {{- range $index, $mount := $.Values.mounts }}
 {{- if eq $mount.enabled true }}
-- name: drupal-{{ $mount.name }}
+- name: drupal-{{ $index }}
   mountPath: {{ $mount.mountPath }}
 {{- end }}
 {{- end }}
@@ -35,9 +35,9 @@ ports:
 {{- define "drupal.volumes" -}}
 {{- range $index, $mount := $.Values.mounts }}
 {{- if eq $mount.enabled true }}
-- name: drupal-{{ $mount.name }}
+- name: drupal-{{ $index }}
   persistentVolumeClaim:
-    claimName: {{ $.Release.Name }}-{{ $mount.name }}
+    claimName: {{ $.Release.Name }}-{{ $index }}
 {{- end }}
 {{- end }}
 - name: php-conf
@@ -93,7 +93,7 @@ imagePullSecrets:
   value: {{ $val | quote }}
 {{- end }}
 {{- range $index, $mount := $.Values.mounts }}
-- name: {{ regexReplaceAll "[^[:alnum:]]" $mount.name "_" | upper }}_PATH
+- name: {{ regexReplaceAll "[^[:alnum:]]" $index "_" | upper }}_PATH
   value: {{ $mount.mountPath }}
 {{- end }}
 {{- end }}

--- a/chart/templates/drupal-deployment.yaml
+++ b/chart/templates/drupal-deployment.yaml
@@ -48,9 +48,11 @@ spec:
           name: drupal
         volumeMounts:
         {{- range $index, $mount := $.Values.mounts }}
+        {{- if eq $mount.enabled true }}
         - name: drupal-{{ $mount.name }}
           mountPath: {{ $mount.mountPath }}
           readOnly: true
+        {{- end }}
         {{- end }}
         - name: nginx-conf
           mountPath: /etc/nginx/nginx.conf # mount nginx-conf configmap volume to /etc/nginx

--- a/chart/templates/drupal-deployment.yaml
+++ b/chart/templates/drupal-deployment.yaml
@@ -49,7 +49,7 @@ spec:
         volumeMounts:
         {{- range $index, $mount := $.Values.mounts }}
         {{- if eq $mount.enabled true }}
-        - name: drupal-{{ $mount.name }}
+        - name: drupal-{{ $index }}
           mountPath: {{ $mount.mountPath }}
           readOnly: true
         {{- end }}

--- a/chart/templates/drupal-volumes.yaml
+++ b/chart/templates/drupal-volumes.yaml
@@ -1,5 +1,7 @@
 {{- range $index, $mount := .Values.mounts }}
+{{- if eq $mount.enabled true }}
 {{- if eq $mount.storageClassName "silta-shared" }}
+# Mount-enabled: {{ $mount.enabled  }}
 apiVersion: v1
 kind: PersistentVolume
 metadata:
@@ -38,6 +40,7 @@ spec:
     matchLabels:
       name: {{ $.Release.Name }}-{{ $mount.name }}
 ---
+{{- end -}}
 {{- end }}
 
 {{- if .Values.referenceData.enabled }}

--- a/chart/templates/drupal-volumes.yaml
+++ b/chart/templates/drupal-volumes.yaml
@@ -5,9 +5,9 @@
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: {{ $.Release.Name }}-{{ $mount.name }}
+  name: {{ $.Release.Name }}-{{ $index }}
   labels:
-    name: {{ $.Release.Name }}-{{ $mount.name }}
+    name: {{ $.Release.Name }}-{{ $index }}
 spec:
   accessModes:
     - ReadWriteMany
@@ -17,16 +17,16 @@ spec:
   {{- if $mount.csiDriverName }}
   csi:
     driver: {{ $mount.csiDriverName }}
-    volumeHandle: {{ $.Release.Name }}-{{ $mount.name }}
+    volumeHandle: {{ $.Release.Name }}-{{ $index }}
     volumeAttributes:
-      remotePathSuffix: /{{ $.Release.Namespace }}/{{ $.Values.environmentName }}/{{ $mount.name }}
+      remotePathSuffix: /{{ $.Release.Namespace }}/{{ $.Values.environmentName }}/{{ $index }}
   {{- end }}
 ---
 {{- end }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ $.Release.Name }}-{{ $mount.name }}
+  name: {{ $.Release.Name }}-{{ $index }}
   labels:
     {{- include "drupal.release_labels" $ | nindent 4 }}
 spec:
@@ -38,7 +38,7 @@ spec:
       storage: {{ $mount.storage }}
   selector:
     matchLabels:
-      name: {{ $.Release.Name }}-{{ $mount.name }}
+      name: {{ $.Release.Name }}-{{ $index }}
 ---
 {{- end -}}
 {{- end }}

--- a/chart/tests/drupal_cron_test.yaml
+++ b/chart/tests/drupal_cron_test.yaml
@@ -30,12 +30,6 @@ tests:
             value: bar
 
   - it: has public files mounted
-    set:
-      mounts:
-        - name: public-files
-          storage: 123Gi
-          storageClassName: silta-shared
-          mountPath: /foo/bar/files
     asserts:
       - contains:
           path: spec.jobTemplate.spec.template.spec.volumes

--- a/chart/tests/drupal_cron_test.yaml
+++ b/chart/tests/drupal_cron_test.yaml
@@ -47,9 +47,11 @@ tests:
   - it: runs multiple jobs
     set:
       php.cron:
-        - command: foo
+        drupal-cron:
+          command: foo
           schedule: "0 * * * *"
-        - command: bar
+        project-cron:
+          command: bar
           schedule: "30 * * * *"
     asserts:
       - hasDocuments:

--- a/chart/tests/drupal_postinstall_test.yaml
+++ b/chart/tests/drupal_postinstall_test.yaml
@@ -65,12 +65,6 @@ tests:
             value: bar
 
   - it: has public files mounted
-    set:
-      mounts:
-        - name: public-files
-          storage: 123Gi
-          storageClassName: silta-shared
-          mountPath: /foo/bar/files
     asserts:
       - contains:
           path: spec.template.spec.volumes

--- a/chart/tests/private_files_test.yaml
+++ b/chart/tests/private_files_test.yaml
@@ -24,7 +24,6 @@ tests:
       mounts:
         private-files:
           enabled: true
-          name: private-files
           storage: 123Gi
           storageClassName: silta-shared
           mountPath: /foo/bar/private

--- a/chart/tests/private_files_test.yaml
+++ b/chart/tests/private_files_test.yaml
@@ -6,12 +6,6 @@ templates:
   - drupal-cron.yaml
 tests:
   - it: private files should be disabled by default
-    set:
-      mounts:
-        - name: public-files
-          storage: 123Gi
-          storageClassName: silta-shared
-          mountPath: /foo/bar/files
     asserts:
       # No private files volume is mounted.
       - notContains:
@@ -28,14 +22,12 @@ tests:
   - it: private files should work when enabled
     set:
       mounts:
-        - name: private-files
+        private-files:
+          enabled: true
+          name: private-files
           storage: 123Gi
           storageClassName: silta-shared
           mountPath: /foo/bar/private
-        - name: public-files
-          storage: 123Gi
-          storageClassName: silta-shared
-          mountPath: /foo/bar/files
     asserts:
       # A private files volume is mounted
       - contains:
@@ -81,7 +73,8 @@ tests:
           path: spec.storageClassName
           value: silta-shared
       - template: drupal-volumes.yaml
-        documentIndex: 3
+        # Note that object attributes are iterated alphabetically, so "private-files" comes before "public-files"
+        documentIndex: 1
         equal:
           path: spec.resources.requests.storage
           value: 123Gi

--- a/chart/tests/reference_data_test.yaml
+++ b/chart/tests/reference_data_test.yaml
@@ -60,11 +60,6 @@ tests:
         command: "echo Hello World"
       php.env:
         foo: bar
-      mounts:
-        - name: public-files
-          storage: 123Gi
-          storageClassName: silta-shared
-          mountPath: /foo/bar/files
     asserts:
     - hasDocuments:
         count: 5

--- a/chart/tests/volumes_test.yaml
+++ b/chart/tests/volumes_test.yaml
@@ -5,10 +5,9 @@ tests:
   - it: public files volume should be configurable
     set:
       mounts:
-        - name: public-files
+        public-files:
           storage: 123Gi
           storageClassName: silta-shared
-          mountPath: /app/web/sites/default/files
 
     asserts:
       - documentIndex: 1

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -151,17 +151,19 @@ shell:
 # Configure the dynamically mounted volumes
 mounts:
   public-files:
+    enabled: true
     name: public-files
     storage: 1G
     mountPath: /app/web/sites/default/files
     storageClassName: silta-shared
     csiDriverName: csi-rclone
-  # private-files:
-  #   name: private-files
-  #   storage: 1G
-  #   mountPath: /app/private
-  #   storageClassName: silta-shared
-  #   csiDriverName: csi-rclone
+  private-files:
+    enabled: false
+    name: private-files
+    storage: 1G
+    mountPath: /app/private
+    storageClassName: silta-shared
+    csiDriverName: csi-rclone
 
 # Configure reference data that will be used when creating new environments.
 referenceData:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -21,7 +21,12 @@ app: drupal
 replicas: 1
 
 # Domain names that will be mapped to this deployment.
-exposeDomains: []
+#
+# Note that the key is only used for documentation purposes, for example:
+#
+#   production: example.com
+#   www:        www.example.com
+exposeDomains: {}
 
 # These variables are build-specific and should be passed via the --set parameter.
 nginx:
@@ -47,9 +52,10 @@ nginx:
     # Trust X-Forwarded-For from these hosts for getting external IP 
     realipfrom: 10.0.0.0/8
 
-    # Add IP addresses that should be excluded from basicauth
+    # Add IP addresses that should be excluded from basicauth.
+    # Note that the key is only used for documentation purposes.
     noauthips:
-      - 10.0.0.0/8 # GKE internal IPs
+      gke-internal: 10.0.0.0/8
 
   # Robots txt file blocked by default
   robotsTxt:
@@ -70,7 +76,8 @@ php:
   # Cron tasks, each of which will be run into a dedicated temporary pod.
   # When overriding this value, make sure to include the `drush cron` command.
   cron:
-    - schedule: '0 * * * *'
+    drupal-cron:
+      schedule: '0 * * * *'
       command: |
         if [[ "$(drush status --fields=bootstrap)" = *'Successful'* ]] ; then
           drush cron;
@@ -143,12 +150,14 @@ shell:
 
 # Configure the dynamically mounted volumes
 mounts:
-  - name: public-files
+  public-files:
+    name: public-files
     storage: 1G
     mountPath: /app/web/sites/default/files
     storageClassName: silta-shared
     csiDriverName: csi-rclone
-  # - name: private-files
+  # private-files:
+  #   name: private-files
   #   storage: 1G
   #   mountPath: /app/private
   #   storageClassName: silta-shared

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -152,14 +152,12 @@ shell:
 mounts:
   public-files:
     enabled: true
-    name: public-files
     storage: 1G
     mountPath: /app/web/sites/default/files
     storageClassName: silta-shared
     csiDriverName: csi-rclone
   private-files:
     enabled: false
-    name: private-files
     storage: 1G
     mountPath: /app/private
     storageClassName: silta-shared


### PR DESCRIPTION
We use arrays in few places in values.yaml file (cron tasks, whitelisted ip addresses, volume mounts). Helm can iterate over objects, so turning those arrays into objects with arbitrary keys still works the same way. The advantage is that it is then a lot easier to override individual parameters or to add additional items without needing to duplicate the entire array.