### PR TITLE
SLT-289: Enable to skip mounting reference data volume

### DIFF
--- a/chart/templates/post-release.yaml
+++ b/chart/templates/post-release.yaml
@@ -25,19 +25,24 @@ spec:
         volumeMounts:
           {{- include "drupal.volumeMounts" . | nindent 10 }}
           {{- if .Values.referenceData.enabled }}
+          {{- if or (eq .Values.referenceData.referenceEnvironment .Values.environmentName) (not .Values.referenceData.skipMount) }}
           - name: reference-data-volume
             mountPath: /app/reference-data
             {{- if ne .Values.referenceData.referenceEnvironment .Values.environmentName }}
             readOnly: true
             {{- end }}
+          {{- end -}}
           {{- end }}
         resources:
           {{- .Values.php.postinstall.resources | toYaml | nindent 10 }}
       {{- include "drupal.imagePullSecrets" . | nindent 6 }}
       volumes:
         {{- include "drupal.volumes" . | nindent 8 }}
-        {{- if .Values.referenceData.enabled }}
+
+        {{- if .Values.referenceData.enabled -}}
+        {{- if or (eq .Values.referenceData.referenceEnvironment .Values.environmentName) (not .Values.referenceData.skipMount) }}
         - name: reference-data-volume
           persistentVolumeClaim:
             claimName: {{ include "drupal.referenceEnvironment" . }}-reference-data
-        {{- end }}
+        {{- end -}}
+        {{- end -}}

--- a/chart/tests/reference_data_test.yaml
+++ b/chart/tests/reference_data_test.yaml
@@ -149,3 +149,50 @@ tests:
         content:
           name: "reference-data-volume"
           mountPath: "/app/reference-data"
+
+  - it: can skip mounting on non-reference environments
+    set:
+      environmentName: 'BAR'
+      referenceData:
+        skipMount: true
+        referenceEnvironment: 'FOO'
+    asserts:
+    - template: drupal-volumes.yaml
+      hasDocuments:
+        count: 3
+    - template: reference-data-cron.yaml
+      hasDocuments:
+        count: 0
+    - notContains:
+        path: spec.template.spec.volumes
+        content:
+          name: "reference-data-volume"
+          persistentVolumeClaim:
+            claimName: foo-reference-data
+    - notContains:
+        path: spec.template.spec.containers[0].volumeMounts
+        content:
+          name: "reference-data-volume"
+          mountPath: "/app/reference-data"
+
+  - it: does not skip mounting on the reference environments
+    set:
+      environmentName: 'FOO'
+      referenceData:
+        skipMount: true
+        referenceEnvironment: 'FOO'
+    asserts:
+    - template: drupal-volumes.yaml
+      hasDocuments:
+        count: 5
+    - contains:
+        path: spec.template.spec.volumes
+        content:
+          name: "reference-data-volume"
+          persistentVolumeClaim:
+            claimName: foo-reference-data
+    - contains:
+        path: spec.template.spec.containers[0].volumeMounts
+        content:
+          name: "reference-data-volume"
+          mountPath: "/app/reference-data"

--- a/chart/tests/reference_data_test.yaml
+++ b/chart/tests/reference_data_test.yaml
@@ -10,11 +10,6 @@ tests:
     set:
       referenceData:
         referenceEnvironment: 'FOO'
-      mounts:
-        - name: public-files
-          storage: 123Gi
-          storageClassName: silta-shared
-          mountPath: /foo/bar/files
     asserts:
     # Only public files PVC is defined.
     - hasDocuments:
@@ -126,11 +121,6 @@ tests:
       referenceData:
         enabled: false
         referenceEnvironment: 'FOO'
-      mounts:
-        - name: public-files
-          storage: 123Gi
-          storageClassName: silta-shared
-          mountPath: /foo/bar/files
     asserts:
     - template: drupal-volumes.yaml
       hasDocuments:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -192,6 +192,9 @@ referenceData:
   storageClassName: silta-shared
   csiDriverName: csi-rclone
 
+  # Skips mounting the volume outside of the reference environment, only used programmatically.
+  skipMounting: false
+
 # Override the default values of the MariaDB subchart.
 # These settings are optimised for development environments.
 mariadb:


### PR DESCRIPTION
We want to be able to skip mounting the reference data volume, but only for branches other than the reference environment. This adds another parameter, which can then be used here: https://github.com/wunderio/silta-circleci/blob/2ca22c3685ed370953858f4cb6c843d5dc0015cd/orb.yml#L422