### PR TITLE
When using a dynamic provisioner, the pvc should not include a selector.

### DIFF
--- a/chart/templates/drupal-volumes.yaml
+++ b/chart/templates/drupal-volumes.yaml
@@ -81,9 +81,11 @@ spec:
   resources:
     requests:
       storage: {{ .Values.referenceData.storage }}
+{{- if eq .Values.referenceData.storageClassName "silta-shared" }}
   selector:
     matchLabels:
       name: {{ .Release.Name }}-reference-data
+{{- end }}
 {{- end }}
 {{- end }}
 ---

--- a/chart/templates/drupal-volumes.yaml
+++ b/chart/templates/drupal-volumes.yaml
@@ -36,9 +36,11 @@ spec:
   resources:
     requests:
       storage: {{ $mount.storage }}
+{{- if eq $mount.storageClassName "silta-shared" }}
   selector:
     matchLabels:
       name: {{ $.Release.Name }}-{{ $index }}
+{{- end }}
 ---
 {{- end -}}
 {{- end }}


### PR DESCRIPTION
The selector parameter prevents the usage of other storageClasses which might have a dynamic volume driver. Tested in the test/nfs-client-volume branch.