### PR TITLE
SLT-292: Make the Drupal config path configurable.

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -98,6 +98,8 @@ imagePullSecrets:
     secretKeyRef:
       name: {{ .Release.Name }}-secrets-drupal
       key: hashsalt
+- name: DRUPAL_CONFIG_PATH
+  value: {{ .Values.php.drupalConfigPath }}
 {{- range $key, $val := .Values.php.env }}
 - name: {{ $key }}
   value: {{ $val | quote }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -97,7 +97,7 @@ php:
 
         drush cr
         drush updatedb -y
-        if [ -f config/sync/core.extension.yml ]; then
+        if [ -f $DRUPAL_CONFIG_PATH/core.extension.yml ]; then
           drush config-import -y
         fi
       else
@@ -114,7 +114,7 @@ php:
     command: |
       if [[ "$(drush status --fields=bootstrap)" = *'Successful'* ]] ; then
         drush updatedb -y
-        if [ -f config/sync/core.extension.yml ]; then
+        if [ -f $DRUPAL_CONFIG_PATH/core.extension.yml ]; then
           drush config-import -y
         fi
       fi
@@ -131,6 +131,10 @@ php:
     loglevel: notice # Possible Values: alert, error, warning, notice, debug
     upload_max_filesize: 60M
     post_max_size: 60M
+
+  # Define the location of the Drupal config files relative to the composer root.
+  # This variable is exposed as $DRUPAL_CONFIG_PATH in the container.
+  drupalConfigPath: "config/sync"
 
 
 # Configuration for everything that runs in shell container.


### PR DESCRIPTION
Many projects have inconsistent paths for the config folder (config, config/sync, sync, drupal_config, etc), and requiring to change that path for a migration could cause issues for existing setups. Making this configurable means we can import those projects without modifications.