### PR TITLE
SLT-301: Enable autoscaling for the Drupal deployment

### DIFF
--- a/chart/templates/drupal-deployment.yaml
+++ b/chart/templates/drupal-deployment.yaml
@@ -94,21 +94,20 @@ spec:
         {{- end }}
       {{- include "drupal.imagePullSecrets" . | nindent 6 }}
 ---
-apiVersion: autoscaling/v1
+{{- if and .Values.autoscaling.enabled (not .Values.daemonSet) }}
+apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ .Release.Name }}-drupal
+  labels:
+    {{- include "drupal.release_labels" . | nindent 4 }}
 spec:
-  maxReplicas: 3
-  minReplicas: 1
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
     name: {{ .Release.Name }}-drupal
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
   metrics:
-  - type: Resource
-    resource:
-      name: cpu
-      target:
-        type: Utilization
-        averageUtilization: 80
+    {{- toYaml .Values.autoscaling.metrics | nindent 4 }}
+{{- end }}

--- a/chart/templates/drupal-deployment.yaml
+++ b/chart/templates/drupal-deployment.yaml
@@ -93,3 +93,16 @@ spec:
                 path: .htaccess
         {{- end }}
       {{- include "drupal.imagePullSecrets" . | nindent 6 }}
+---
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ .Release.Name }}-drupal
+spec:
+  maxReplicas: 3
+  minReplicas: 1
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ .Release.Name }}-drupal
+  targetCPUUtilizationPercentage: 80

--- a/chart/templates/drupal-deployment.yaml
+++ b/chart/templates/drupal-deployment.yaml
@@ -105,4 +105,10 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: {{ .Release.Name }}-drupal
-  targetCPUUtilizationPercentage: 80
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 80

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -20,6 +20,21 @@ app: drupal
 # Multiple pods make sense for high availability.
 replicas: 1
 
+# Enable autoscaling using HorizontalPodAutoscaler
+autoscaling:
+  enabled: true
+  minReplicas: 1
+  maxReplicas: 3
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: 60
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: 60
+
 # Domain names that will be mapped to this deployment.
 #
 # Note that the key is only used for documentation purposes, for example:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -29,11 +29,11 @@ autoscaling:
     - type: Resource
       resource:
         name: cpu
-        targetAverageUtilization: 60
+        targetAverageUtilization: 80
     - type: Resource
       resource:
         name: memory
-        targetAverageUtilization: 60
+        targetAverageUtilization: 80
 
 # Domain names that will be mapped to this deployment.
 #

--- a/silta/silta-prod.yml
+++ b/silta/silta-prod.yml
@@ -1,6 +1,10 @@
 
-# Provide a high-availability deployment.
+# Provide a high-availability, autoscaling deployment.
 replicas: 2
+autoscaling:
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 5
 
 # Uncomment these lines to disable basic auth protection.
 #nginx:


### PR DESCRIPTION
Steps to test:

The deployment should only have one replica:
```
kubectl get deployment -n drupal-project-k8s drupal-project-k8s--feature-slt-301-drupal
```

Generate some load on the feature branch environment: 
```
siege -c10 --header="Authorization:Basic c2lsdGE6ZGVtbw==" http://feature-slt-301.drupal-project-k8s.silta.wdr.io/
```

Then, while siege is still running check with the first command again to see that the deployment scaled up to 3 replica.