### PR TITLE
SLT-307: Add fastcgi configuration from WunderMachina.

### DIFF
--- a/chart/templates/drupal-configmap-nginx.yaml
+++ b/chart/templates/drupal-configmap-nginx.yaml
@@ -72,6 +72,58 @@ data:
     }     
 
   drupal_conf: |
+
+    fastcgi_param  QUERY_STRING       $query_string;
+    fastcgi_param  REQUEST_METHOD     $request_method;
+    fastcgi_param  CONTENT_TYPE       $content_type;
+    fastcgi_param  CONTENT_LENGTH     $content_length;
+
+    fastcgi_param  SCRIPT_NAME        /index.php;
+    fastcgi_param  SCRIPT_FILENAME    $document_root/index.php;
+    fastcgi_param  REQUEST_URI        $request_uri;
+    fastcgi_param  DOCUMENT_URI       $document_uri;
+    fastcgi_param  DOCUMENT_ROOT      $document_root;
+    fastcgi_param  SERVER_PROTOCOL    $server_protocol;
+    fastcgi_param  HTTPS              $https if_not_empty;
+
+    fastcgi_param  GATEWAY_INTERFACE  CGI/1.1;
+    fastcgi_param  SERVER_SOFTWARE    nginx;
+
+    fastcgi_param  REMOTE_ADDR        $remote_addr;
+    fastcgi_param  REMOTE_PORT        $remote_port;
+    fastcgi_param  SERVER_ADDR        $server_addr;
+    fastcgi_param  SERVER_PORT        $server_port;
+    fastcgi_param  SERVER_NAME        $server_name;
+
+    fastcgi_param  REDIRECT_STATUS    200;
+
+    fastcgi_param  HTTPS              $fe_https;
+
+    ## Nginx FCGI specific directives.
+    fastcgi_buffer_size 32k;
+    fastcgi_buffers 64 8k;
+    #   - fastcgi_busy_buffers_size >= max(fastcgi_buffer_size, one fastcgi_buffers.size)
+    #   - fastcgi_busy_buffers_size =< fastcgi_buffers.size * (fastcgi_buffers.number - 1)
+    fastcgi_busy_buffers_size 32k;
+    fastcgi_intercept_errors on;
+
+    fastcgi_request_buffering off;
+
+    # We timeout after 30s if the application cannot start processing the request.
+    fastcgi_connect_timeout 30s;
+    # Once the application started processing pass timeout responsibility to upstream.
+    fastcgi_read_timeout 14400s;
+    fastcgi_send_timeout 14400s;
+    fastcgi_index index.php;
+    ## Hide the Drupal 7 header X-Generator.
+    fastcgi_hide_header 'X-Generator';
+    ## Hide the PHP X-Powered-By header.
+    fastcgi_hide_header 'X-Powered-By';
+
+    # Mitigate HTTPoxy
+    # https://httpoxy.org/
+    fastcgi_param HTTP_PROXY "";
+
     upstream php {                                                  
         server localhost:9000;                   
     }                            


### PR DESCRIPTION
We ran into an issue where the `fastcgi_buffers` defaults were too low, something that commonly happens with D8 and for which we have an existing configuration in WunderMachina. There are more settings that could be very useful (for example hiding the `x-generator` header), it probably makes sense to have all of them.