### PR TITLE
SLT-308: Use bash when executing commands in the php container.

### DIFF
--- a/chart/templates/drupal-cron.yaml
+++ b/chart/templates/drupal-cron.yaml
@@ -21,7 +21,7 @@ spec:
             {{- include "drupal.php-container" $ | nindent 12 }}
             volumeMounts:
               {{- include "drupal.volumeMounts" $ | nindent 14 }}
-            command: ["/bin/sh", "-c"]
+            command: ["/bin/bash", "-c"]
             args:
               - |
                  if [ ! {{ include "drupal.deployment-in-progress-test" . }} ]

--- a/chart/templates/drupal-deployment.yaml
+++ b/chart/templates/drupal-deployment.yaml
@@ -21,7 +21,7 @@ spec:
       initContainers:
       - name: wait-for-db
         {{ include "drupal.php-container" . | nindent 8 }}
-        command: ["/bin/sh", "-c"]
+        command: ["/bin/bash", "-c"]
         args:
         - {{ include "drupal.wait-for-db-command" . | quote }}
       containers:
@@ -35,7 +35,7 @@ spec:
             port: 9000
         readinessProbe:
           exec:
-            command: ['/bin/sh', '-c', 'if [ {{ include "drupal.deployment-in-progress-test" . }} ]; then exit 1; fi']
+            command: ['/bin/bash', '-c', 'if [ {{ include "drupal.deployment-in-progress-test" . }} ]; then exit 1; fi']
         resources:
           {{- .Values.php.resources | toYaml | nindent 10 }}
 

--- a/chart/templates/post-release.yaml
+++ b/chart/templates/post-release.yaml
@@ -19,7 +19,7 @@ spec:
       containers:
       - name: post-release
         {{- include "drupal.php-container" . | nindent 8 }}
-        command: ["/bin/sh", "-c"]
+        command: ["/bin/bash", "-c"]
         args:
         - {{ include "drupal.post-release-command" . | quote }}
         volumeMounts:

--- a/chart/templates/reference-data-cron.yaml
+++ b/chart/templates/reference-data-cron.yaml
@@ -20,7 +20,7 @@ spec:
               {{- include "drupal.volumeMounts" . | nindent 14 }}
               - name: reference-data-volume
                 mountPath: /app/reference-data
-            command: ["/bin/sh", "-c"]
+            command: ["/bin/bash", "-c"]
             args:
               - {{ .Values.referenceData.command | quote }}
             resources:


### PR DESCRIPTION
Drush assumes `bash` as the default shell, and `sh` is quite restrictive and has caused a few issues with unsupported syntax.