### PR TITLE
SLT-313: Use v1 of the ambassador API.

### DIFF
--- a/chart/templates/drupal-service.yaml
+++ b/chart/templates/drupal-service.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
 {{- if .Values.ambassador.enabled }}
     getambassador.io/config: |
-      apiVersion: ambassador/v0
+      apiVersion: ambassador/v1
       kind:  Mapping
       name:  {{ .Release.Name }}-drupal
       host: {{ template "drupal.domain" . }}

--- a/chart/tests/drupal_service_test.yaml
+++ b/chart/tests/drupal_service_test.yaml
@@ -33,7 +33,7 @@ tests:
     asserts:
       - matchRegex:
           path: metadata.annotations.getambassador\.io/config
-          pattern: 'apiVersion: ambassador/v0'
+          pattern: 'apiVersion: ambassador/v1'
 
   - it: adds ambassador config values
     set:


### PR DESCRIPTION
The v0 API is deprecated (just happened to see an entry in the log), and for what we use the v1 API is compatible.