### PR TITLE
SLT-109: backup functionality

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -30,10 +30,12 @@ ports:
   mountPath: /etc/php7/php-fpm.d/www.conf
   readOnly: true
   subPath: www_conf
+{{ if ne $.Template.Name "drupal/templates/backup-cron.yaml" -}}
 - name: gdpr-dump
   mountPath: /etc/my.cnf.d/gdpr-dump.cnf
   readOnly: true
   subPath: gdpr-dump
+{{- end }}
 - name: settings
   mountPath: /app/web/sites/default/settings.silta.php
   readOnly: true
@@ -51,9 +53,11 @@ ports:
 - name: php-conf
   configMap:
     name: {{ .Release.Name }}-php-conf
+{{ if ne $.Template.Name "drupal/templates/backup-cron.yaml" -}}
 - name: gdpr-dump
   configMap:
     name: {{ .Release.Name }}-gdpr-dump
+{{- end }}
 - name: settings
   configMap:
     name: {{ .Release.Name }}-settings

--- a/chart/templates/backup-cron.yaml
+++ b/chart/templates/backup-cron.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "drupal.release_labels" . | nindent 4 }}
 spec:
-  schedule: {{ .Values.backup.schedule | quote }}
+  schedule: {{ .Values.backup.schedule | replace "~" (randNumeric 1) | quote }}
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:

--- a/chart/templates/backup-cron.yaml
+++ b/chart/templates/backup-cron.yaml
@@ -1,0 +1,48 @@
+{{- if .Values.backup.enabled }}
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: {{ .Release.Name }}-backup
+  labels:
+    {{- include "drupal.release_labels" . | nindent 4 }}
+spec:
+  schedule: {{ .Values.backup.schedule | quote }}
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: backup
+            {{- include "drupal.php-container" . | nindent 12 }}
+            volumeMounts:
+              {{- include "drupal.volumeMounts" . | nindent 14 }}
+              - name: reference-data-volume
+                mountPath: /app/reference-data
+            command: ["/bin/bash", "-c"]
+            args:
+              - |
+                # Generate the id of the backup.
+                BACKUP_ID=`date +”%Y-%m-%d”`
+
+                # Create a folder for the backup
+                mkdir /backups/$BACKUP_ID
+
+                # Take a database dump.
+                drush sql-dump --gzip --result-file /backups/$BACKUP_ID/db.sql
+
+                # List content of backup folder
+                ls -lh /backups/$BACKUP_ID/
+            resources:
+              {{- .Values.php.resources | toYaml | nindent 14 }}
+          restartPolicy: OnFailure
+          volumes:
+            {{- include "drupal.volumes" . | nindent 12 }}
+            - name: backup
+              persistentVolumeClaim:
+                claimName: backup
+
+
+          {{- include "drupal.imagePullSecrets" . | nindent 10 }}
+{{- end }}
+---

--- a/chart/templates/backup-cron.yaml
+++ b/chart/templates/backup-cron.yaml
@@ -29,9 +29,21 @@ spec:
                 # Create a folder for the backup
                 mkdir -p $BACKUP_LOCATION
 
-                # Take a database dump.
-                # TODO: take unsanitized dump
-                drush sql-dump --gzip --result-file $BACKUP_LOCATION/db.sql
+                # Figure out which tables to skip.
+                IGNORE_TABLES=""
+                for TABLE in `drush sql-query "show tables;" | grep -E '{{ .Values.backup.ignoreTables }}'` ;
+                do
+                  IGNORE_TABLES="$IGNORE_TABLES --ignore-table=$DB_NAME.$TABLE";
+                done
+
+                # Take a database dump. We use the full path to bypass gdpr-dump
+                /usr/bin/mysqldump -u $DB_USER --password=$DB_PASS -h $DB_HOST --skip-lock-tables --single-transaction --quick $DB_NAME $IGNORE_TABLES > /tmp/db.sql
+                /usr/bin/mysqldump -u $DB_USER --password=$DB_PASS -h $DB_HOST --skip-lock-tables --single-transaction --quick --force --no-data $DB_NAME $IGNORE_TABLES >> /tmp/db.sql
+
+                # Compress the database dump and copy it into the backup folder.
+                # We don't do this directly on the volume mount to avoid sending the uncompressed dump across the network.
+                gzip -9 /tmp/db.sql
+                cp /tmp/db.sql.gz $BACKUP_LOCATION/db.sql.gz
 
                 {{ range $index, $mount := .Values.mounts -}}
                 {{- if eq $mount.enabled true -}}

--- a/chart/templates/backup-cron.yaml
+++ b/chart/templates/backup-cron.yaml
@@ -31,7 +31,7 @@ spec:
 
                 # Figure out which tables to skip.
                 IGNORE_TABLES=""
-                for TABLE in `drush sql-query "show tables;" | grep -E '{{ .Values.backup.ignoreTables }}'` ;
+                for TABLE in `drush sql-query "show tables;" | grep -E '{{ .Values.backup.ignoreTableContent }}'` ;
                 do
                   IGNORE_TABLES="$IGNORE_TABLES --ignore-table=$DB_NAME.$TABLE";
                 done

--- a/chart/templates/backup-cron.yaml
+++ b/chart/templates/backup-cron.yaml
@@ -17,8 +17,8 @@ spec:
             {{- include "drupal.php-container" . | nindent 12 }}
             volumeMounts:
               {{- include "drupal.volumeMounts" . | nindent 14 }}
-              - name: reference-data-volume
-                mountPath: /app/reference-data
+              - name: backup
+                mountPath: /backup
             command: ["/bin/bash", "-c"]
             args:
               - |

--- a/chart/templates/backup-cron.yaml
+++ b/chart/templates/backup-cron.yaml
@@ -18,21 +18,33 @@ spec:
             volumeMounts:
               {{- include "drupal.volumeMounts" . | nindent 14 }}
               - name: backup
-                mountPath: /backup
+                mountPath: /backups
             command: ["/bin/bash", "-c"]
             args:
               - |
                 # Generate the id of the backup.
-                BACKUP_ID=`date +”%Y-%m-%d”`
+                BACKUP_ID=`date +%Y-%m-%d`
+                BACKUP_LOCATION="/backups/$BACKUP_ID-{{ .Values.environmentName }}"
 
                 # Create a folder for the backup
-                mkdir /backups/$BACKUP_ID
+                mkdir -p $BACKUP_LOCATION
 
                 # Take a database dump.
-                drush sql-dump --gzip --result-file /backups/$BACKUP_ID/db.sql
+                # TODO: take unsanitized dump
+                drush sql-dump --gzip --result-file $BACKUP_LOCATION/db.sql
+
+                {{ range $index, $mount := .Values.mounts -}}
+                {{- if eq $mount.enabled true -}}
+                # File backup for {{ $index }} volume.
+                tar -czP --exclude=css --exclude=js --exclude=styles -f $BACKUP_LOCATION/{{ $index }}.tar.gz {{ $mount.mountPath }}
+                {{- end -}}
+                {{- end }}
+
+                # Delete old backups
+                find /backups/ -mtime +{{ .Values.backup.retention }} -exec rm -r {} \;
 
                 # List content of backup folder
-                ls -lh /backups/$BACKUP_ID/
+                ls -lh /backups/*
             resources:
               {{- .Values.php.resources | toYaml | nindent 14 }}
           restartPolicy: OnFailure

--- a/chart/templates/backup-volume.yaml
+++ b/chart/templates/backup-volume.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.backup.enabled }}
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: backup
+  labels:
+    name: backup
+spec:
+  accessModes:
+    - ReadWriteMany
+  capacity:
+    storage: {{ .Values.backup.storage }}
+  storageClassName: {{ .Values.backup.storageClassName }}
+  {{- if .Values.backup.csiDriverName }}
+  csi:
+    driver: {{ .Values.backup.csiDriverName }}
+    volumeHandle: {{ .Release.Namespace }}-backup
+    volumeAttributes:
+      remotePathSuffix: /{{ .Release.Namespace }}/backup
+  {{- end }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: backup
+  labels:
+    app: {{ .Values.app | quote }}
+    release: {{ .Release.Name }}
+spec:
+  storageClassName: {{ .Values.backup.storageClassName }}
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: {{ .Values.backup.storage }}
+{{- if eq .Values.backup.storageClassName "silta-shared" }}
+  selector:
+    matchLabels:
+      name: backup
+{{- end }}
+{{- end }}

--- a/chart/templates/drupal-cron.yaml
+++ b/chart/templates/drupal-cron.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "drupal.release_labels" $ | nindent 4 }}
 spec:
-  schedule: {{ $job.schedule | quote }}
+  schedule: {{ $job.schedule | replace "~" (randNumeric 1) | quote }}
   concurrencyPolicy: Forbid
   backOffLimit: 3
   jobTemplate:

--- a/chart/tests/backup_test.yaml
+++ b/chart/tests/backup_test.yaml
@@ -1,0 +1,38 @@
+suite: reference data
+templates:
+  - backup-cron.yaml
+  - backup-volume.yaml
+tests:
+
+  - it: By default no backup cron job or volume is created
+    asserts:
+    - hasDocuments:
+        count: 0
+    - hasDocuments:
+        count: 0
+      template: backup-volume.yaml
+
+  - it: creates a backup cron job and volume
+    set:
+      backup:
+        enabled: true
+    asserts:
+    - hasDocuments:
+        count: 1
+    - isKind:
+        of: CronJob
+    - hasDocuments:
+        count: 2
+      template: backup-volume.yaml
+
+  - it: has no gdpr-dump configuration
+    set:
+      backup.enabled: true
+    asserts:
+    - notContains:
+        path: spec.jobTemplate.spec.template.spec.containers[0].volumeMounts
+        content:
+          name: gdpr-dump
+          mountPath: /etc/my.cnf.d/gdpr-dump.cnf
+          readOnly: true
+          subPath: gdpr-dump

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -247,6 +247,10 @@ backup:
   restoreCommand: |
     # figure out how to restore
 
+  storage: 10G
+  storageClassName: silta-shared
+  csiDriverName: csi-rclone
+
 # Override the default values of the MariaDB subchart.
 # These settings are optimised for development environments.
 mariadb:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -251,6 +251,9 @@ backup:
   storageClassName: silta-shared
   csiDriverName: csi-rclone
 
+  # These tables will have their content ignored from the backups.
+  ignoreTables: '(cache|cache_.*)'
+
 # Override the default values of the MariaDB subchart.
 # These settings are optimised for development environments.
 mariadb:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -254,7 +254,7 @@ backup:
   csiDriverName: csi-rclone
 
   # These tables will have their content ignored from the backups.
-  ignoreTables: '(cache|cache_.*)'
+  ignoreTableContent: '(cache|cache_.*)'
 
 # Override the default values of the MariaDB subchart.
 # These settings are optimised for development environments.

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -230,6 +230,23 @@ gdprDump:
     init:
       formatter: clear
 
+backup:
+  # Whether backups should be taken for the current environment
+  enabled: false
+
+  # Cron schedule when backups should be taken
+  schedule: '0 2 * * *'
+
+  # How many daily backups to preserve.
+  retention: 7
+
+  # If specified, replace environment content with the given backup
+  restoreId: null
+
+  # Specify how to restore a backup
+  restoreCommand: |
+    # figure out how to restore
+
 # Override the default values of the MariaDB subchart.
 # These settings are optimised for development environments.
 mariadb:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -231,19 +231,19 @@ gdprDump:
       formatter: clear
 
 backup:
-  # Whether backups should be taken for the current environment
+  # Whether backups should be taken for the current environment.
   enabled: false
 
-  # Cron schedule when backups should be taken
+  # Cron schedule when backups should be taken, this is expected to take place daily.
   schedule: '0 2 * * *'
 
   # How many daily backups to preserve.
   retention: 7
 
-  # If specified, replace environment content with the given backup
+  # If specified, replace environment content with the given backup.
   restoreId: null
 
-  # Specify how to restore a backup
+  # Specify how to restore a backup.
   restoreCommand: |
     # figure out how to restore
 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -92,7 +92,8 @@ php:
   # When overriding this value, make sure to include the `drush cron` command.
   cron:
     drupal:
-      schedule: '0 * * * *'
+      # ~ gets replaced with a random digit between 0 and 9 to prevent having all cron jobs at once.
+      schedule: '~ * * * *'
       command: |
         if [[ "$(drush status --fields=bootstrap)" = *'Successful'* ]] ; then
           drush cron;
@@ -235,7 +236,8 @@ backup:
   enabled: false
 
   # Cron schedule when backups should be taken, this is expected to take place daily.
-  schedule: '0 2 * * *'
+  # ~ gets replaced with a random digit between 0 and 9 to prevent having all cron jobs at once.
+  schedule: '~ 2 * * *'
 
   # How many daily backups to preserve.
   retention: 7

--- a/silta/silta-prod.yml
+++ b/silta/silta-prod.yml
@@ -6,6 +6,10 @@ autoscaling:
   minReplicas: 2
   maxReplicas: 5
 
+# Enable daily backups.
+backup:
+  enabled: true
+
 # Uncomment these lines to disable basic auth protection.
 #nginx:
 # basicauth:


### PR DESCRIPTION
The backup functionality is disabled by default, but I created a test project `test-project-backup` which has backups enabled, and we can see the cron job working, here's the output (edited to show what we would get with older backups):

```
[success] Database dump saved to /backups/2019-08-05-master/db.sql.gz
 
 /backups/2019-08-05-master:
 total 4338
 -rw-r--r--    1 root     root        4.2M Aug  5 10:49 db.sql.gz
 -rw-r--r--    1 root     root       65.0K Aug  5 10:49 public-files.tar.gz
 
 /backups/2019-08-04-master:
 total 3798
 -rw-r--r--    1 root     root        4.1M Aug  4 10:49 db.sql.gz
 -rw-r--r--    1 root     root       65.0K Aug  4 10:49 public-
 ```