### PR TITLE
SLT-321: Show errors by default for dev environments

### DIFF
--- a/chart/files/settings.silta.php
+++ b/chart/files/settings.silta.php
@@ -47,3 +47,11 @@ $settings['php_storage']['twig']['directory'] = '../generated-php';
  * Other hostnames wouldn't reach the pod in silta anyway.
  */
 $settings['trusted_host_patterns'][] = '^.*$';
+
+/**
+ * Show all error messages, with backtrace information.
+ *
+ * In case the error level could not be fetched from the database, as for
+ * example the database connection failed, we rely only on this value.
+ */
+$config['system.logging']['error_level'] = getenv('ERROR_LEVEL');

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -86,6 +86,8 @@ imagePullSecrets:
       name: {{ .Release.Name }}-mariadb
       key: mariadb-password
 {{- end }}
+- name: ERROR_LEVEL
+  value: {{ .Values.php.errorLevel }}
 {{- if .Values.memcached.enabled }}
 - name: MEMCACHED_HOST
   value: {{ .Release.Name }}-memcached

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -142,6 +142,10 @@ php:
   # users to log in. If not provided, a random value will be used.
   hashsalt: "template-hash-salt"
 
+  # Set whether Drupal errors are displayed.
+  # This is a useful override for development environments.
+  errorLevel: "verbose"
+
   # Custom php settings.
   php_ini:
     loglevel: notice # Possible Values: alert, error, warning, notice, debug

--- a/silta/silta-prod.yml
+++ b/silta/silta-prod.yml
@@ -22,6 +22,9 @@ php:
       cpu: 200m
       memory: 256m
 
+  # Don't show errors in production.
+  errorLevel: "hide"
+
 # Connect to an externally hosted database.
 #  env:
 #    DB_HOST: 'hosted.database.server.com'


### PR DESCRIPTION
When something is going wrong, especially while setting up new environments, it's a lot more helpful to show errors rather than Drupal's generic message "There was a problem...".