### PR TITLE
Disable autoscale for dev environments

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -30,10 +30,6 @@ autoscaling:
       resource:
         name: cpu
         targetAverageUtilization: 80
-    - type: Resource
-      resource:
-        name: memory
-        targetAverageUtilization: 80
 
 # Domain names that will be mapped to this deployment.
 #

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -22,7 +22,7 @@ replicas: 1
 
 # Enable autoscaling using HorizontalPodAutoscaler
 autoscaling:
-  enabled: true
+  enabled: false
   minReplicas: 1
   maxReplicas: 3
   metrics:


### PR DESCRIPTION
When environments have very low resources, as we set them for development environments, any load easily triggers the autoscaler and memory usage is sufficient to keep the deployment from scaling down.