### PR TITLE
Speed up pod creation

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -140,8 +140,8 @@ TIME_WAITING=0
 done
 {{- end }}
 
-{{- define "drupal.deployment-in-progress-test" -}}
--f /app/web/sites/default/files/_deployment
+{{- define "drupal.installation-in-progress-test" -}}
+-f /app/web/sites/default/files/_installing
 {{- end -}}
 
 {{- define "drupal.post-release-command" -}}
@@ -150,9 +150,9 @@ set -e
 {{ include "drupal.wait-for-db-command" . }}
 
 {{ if .Release.IsInstall }}
-touch /app/web/sites/default/files/_deployment
+touch /app/web/sites/default/files/_installing
 {{ .Values.php.postinstall.command}}
-rm /app/web/sites/default/files/_deployment
+rm /app/web/sites/default/files/_installing
 {{ else }}
 {{ .Values.php.postupgrade.command}}
 {{ end }}

--- a/chart/templates/drupal-cron.yaml
+++ b/chart/templates/drupal-cron.yaml
@@ -24,7 +24,7 @@ spec:
             command: ["/bin/bash", "-c"]
             args:
               - |
-                 if [ ! {{ include "drupal.deployment-in-progress-test" . }} ]
+                 if [ ! {{ include "drupal.installation-in-progress-test" . }} ]
                  then
                   {{ $job.command | nindent 18 -}}
                  else

--- a/chart/templates/drupal-deployment.yaml
+++ b/chart/templates/drupal-deployment.yaml
@@ -35,7 +35,8 @@ spec:
             port: 9000
         readinessProbe:
           exec:
-            command: ['/bin/bash', '-c', 'if [ {{ include "drupal.deployment-in-progress-test" . }} ]; then exit 1; fi']
+            # Prevent coming in during the installation process.
+            command: ['/bin/bash', '-c', 'if [ {{ include "drupal.installation-in-progress-test" . }} ]; then exit 1; fi']
         resources:
           {{- .Values.php.resources | toYaml | nindent 10 }}
 

--- a/chart/templates/drupal-deployment.yaml
+++ b/chart/templates/drupal-deployment.yaml
@@ -18,12 +18,6 @@ spec:
         {{- include "drupal.release_labels" . | nindent 8 }}
         deployment: drupal
     spec:
-      initContainers:
-      - name: wait-for-db
-        {{ include "drupal.php-container" . | nindent 8 }}
-        command: ["/bin/bash", "-c"]
-        args:
-        - {{ include "drupal.wait-for-db-command" . | quote }}
       containers:
       # php-fpm container.
       - name: php


### PR DESCRIPTION
We needed the initContainer to wait for the database when the liveness probe required a running database, but we changed the liveness probe to only check the tcp port, so the initContainer is not needed anymore.

A quick manual test showed that with the initContainer, a pod takes about 30 seconds to respawn when deleted, whereas it took about 10 seconds after this change. This doesn't only affect deployment, but anytime when a pod gets created: upscaling, restarting in case of failure, cluster upgrades, etc.