### PR TITLE
Varnish support

### DIFF
--- a/chart/files/settings.silta.php
+++ b/chart/files/settings.silta.php
@@ -61,7 +61,6 @@ $config['system.logging']['error_level'] = getenv('ERROR_LEVEL');
  */
 if (getenv('VARNISH_ADMIN_HOST')) {
   $settings['reverse_proxy'] = TRUE;
-  // $settings['reverse_proxy_addresses']
 
   $config['varnish.settings']['varnish_version'] = 4;
   $config['varnish.settings']['varnish_control_terminal'] = getenv('VARNISH_ADMIN_HOST') . ':' . getenv('VARNISH_ADMIN_PORT');

--- a/chart/files/settings.silta.php
+++ b/chart/files/settings.silta.php
@@ -55,3 +55,15 @@ $settings['trusted_host_patterns'][] = '^.*$';
  * example the database connection failed, we rely only on this value.
  */
 $config['system.logging']['error_level'] = getenv('ERROR_LEVEL');
+
+/**
+ * Override varnish config when varnish environment variables are defined.
+ */
+if (getenv('VARNISH_ADMIN_HOST')) {
+  $settings['reverse_proxy'] = TRUE;
+  // $settings['reverse_proxy_addresses']
+
+  $config['varnish.settings']['varnish_version'] = 4;
+  $config['varnish.settings']['varnish_control_terminal'] = getenv('VARNISH_ADMIN_HOST') . ':' . getenv('VARNISH_ADMIN_PORT');
+  $config['varnish.settings']['varnish_control_key'] = trim(getenv('VARNISH_CONTROL_KEY'));
+}

--- a/chart/templates/_domains.tpl
+++ b/chart/templates/_domains.tpl
@@ -24,7 +24,7 @@ www-admin@{{ template "drupal.environment.hostname" . }}-shell.{{ .Release.Names
 {{- end -}}
 
 {{- define "drupal.endpoint" -}}
-{{- if .Values.ambassador.enabled -}}
+{{- if .Values.varnish.enabled -}}
 {{ .Release.Name }}-varnish.{{ .Release.Namespace }}.svc.cluster.local:80
 {{- else -}}
 {{ .Release.Name }}-drupal.{{ .Release.Namespace }}.svc.cluster.local:80

--- a/chart/templates/_domains.tpl
+++ b/chart/templates/_domains.tpl
@@ -22,3 +22,11 @@ www-admin@ssh.{{ .Values.clusterDomain }}
 {{- define "drupal.shellHost" -}}
 www-admin@{{ template "drupal.environment.hostname" . }}-shell.{{ .Release.Namespace }}
 {{- end -}}
+
+{{- define "drupal.endpoint" -}}
+{{- if .Values.ambassador.enabled -}}
+{{ .Release.Name }}-varnish.{{ .Release.Namespace }}.svc.cluster.local:80
+{{- else -}}
+{{ .Release.Name }}-drupal.{{ .Release.Namespace }}.svc.cluster.local:80
+{{- end -}}
+{{- end -}}

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -100,12 +100,12 @@ imagePullSecrets:
 - name: VARNISH_ADMIN_HOST
   value: {{ .Release.Name }}-varnish
 - name: VARNISH_ADMIN_PORT
-  value: 6082
-- name: VARNISH_SECRET
+  value: "6082"
+- name: VARNISH_CONTROL_KEY
   valueFrom:
     secretKeyRef:
       name: {{ .Release.Name }}-secrets-varnish
-      key: secret
+      key: control_key
 {{- end }}
 - name: HASH_SALT
   valueFrom:

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -117,7 +117,7 @@ imagePullSecrets:
   {{- if .Values.nginx.basicauth.enabled }}
   satisfy any;
   allow 127.0.0.1;
-  {{- range .Values.nginx.basicauth.noauthips }}
+  {{- range .Values.nginx.internalACL }}
   allow {{ . }};
   {{- end }}
   deny all;

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -96,6 +96,17 @@ imagePullSecrets:
 - name: ELASTICSEARCH_HOST
   value: {{ .Release.Name }}-elastic
 {{- end }}
+{{- if .Values.varnish.enabled }}
+- name: VARNISH_ADMIN_HOST
+  value: {{ .Release.Name }}-varnish
+- name: VARNISH_ADMIN_PORT
+  value: 6082
+- name: VARNISH_SECRET
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Release.Name }}-secrets-varnish
+      key: secret
+{{- end }}
 - name: HASH_SALT
   valueFrom:
     secretKeyRef:

--- a/chart/templates/drupal-configmap-nginx.yaml
+++ b/chart/templates/drupal-configmap-nginx.yaml
@@ -18,7 +18,7 @@ data:
                                                                                           
     http {
 
-        set_real_ip_from                {{ .Values.nginx.basicauth.realipfrom }};
+        set_real_ip_from                {{ .Values.nginx.realipfrom }};
         real_ip_header                  X-Forwarded-For;
 
         include                     /etc/nginx/mime.types;                                 

--- a/chart/templates/drupal-service.yaml
+++ b/chart/templates/drupal-service.yaml
@@ -11,7 +11,7 @@ metadata:
       kind:  Mapping
       name:  {{ .Release.Name }}-drupal
       host: {{ template "drupal.domain" . }}
-      service: {{ .Release.Name }}-drupal.{{ .Release.Namespace }}.svc.cluster.local:80
+      service: {{- include "drupal.endpoint" . }}
       {{- .Values.ambassador.config | toYaml | nindent 6 }}
 {{- end }}
 {{- range $index, $domain := .Values.exposeDomains }}
@@ -20,7 +20,7 @@ metadata:
       kind: Mapping
       name: {{ $.Release.Name }}-drupal-{{ $index }}
       host: {{ $domain }}
-      service: {{ $.Release.Name }}-drupal.{{ $.Release.Namespace }}.svc.cluster.local:80
+      service: {{- include "drupal.endpoint" $ }}
       {{- $.Values.ambassador.config | toYaml | nindent 6 }}
 {{- end }}
     domain: {{ template "drupal.domain" . }}

--- a/chart/templates/drupal-service.yaml
+++ b/chart/templates/drupal-service.yaml
@@ -9,14 +9,14 @@ metadata:
     getambassador.io/config: |
       apiVersion: ambassador/v1
       kind:  Mapping
-      name:  {{ .Release.Name }}-drupal
+      name:  {{ .Release.Name }}-{{ include "drupal.endpoint" . }}
       host: {{ template "drupal.domain" . }}
-      service: {{- include "drupal.endpoint" . }}
+      service: {{ include "drupal.endpoint" . }}
       {{- .Values.ambassador.config | toYaml | nindent 6 }}
 {{- end }}
 {{- range $index, $domain := .Values.exposeDomains }}
       ---
-      apiVersion: ambassador/v0
+      apiVersion: ambassador/v1
       kind: Mapping
       name: {{ $.Release.Name }}-drupal-{{ $index }}
       host: {{ $domain }}

--- a/chart/templates/varnish-configmap-vcl.yaml
+++ b/chart/templates/varnish-configmap-vcl.yaml
@@ -33,7 +33,7 @@ data:
     # These are used below to allow internal access to certain files
     # from trusted locations while not allowing access from the public internet.
     acl internal {
-      {{- range .Values.nginx.internalACL }}
+      {{- range .Values.nginx.noauthips }}
       {{ . | quote }};
       {{- end }}
     }

--- a/chart/templates/varnish-configmap-vcl.yaml
+++ b/chart/templates/varnish-configmap-vcl.yaml
@@ -32,7 +32,9 @@ data:
     # These are used below to allow internal access to certain files
     # from trusted locations while not allowing access from the public internet.
     acl internal {
-      {{ .Values.varnish.internalACL }}
+      {{- range .Values.nginx.internalACL }}
+      {{ . | quote }};
+      {{- end }}
     }
 
     # Define the purge network access.
@@ -43,9 +45,8 @@ data:
 
     # List of upstream proxies we trust to set X-Forwarded-For correctly.
     acl upstream_proxy {
-        "127.0.0.1";
-        # TODO: trust all
-      }
+      {{ .Values.nginx.realipfrom | quote }};
+    }
 
     sub vcl_init {
       # Called when VCL is loaded, before any requests pass through it.
@@ -89,12 +90,16 @@ data:
       }
       
       # Add a unique header containing the client address
-      if (client.ip ~ upstream_proxy && req.http.X-Forwarded-For) {
+      if (client.ip ~ upstream_proxy && req.http.X-Envoy-External-Address) {
+        set req.http.X-Forwarded-For = req.http.X-Envoy-External-Address;
+      } 
+      elseif (client.ip ~ upstream_proxy && req.http.X-Forwarded-For) {
         set req.http.X-Forwarded-For = req.http.X-Real-IP;
-      } else {
+      } 
+      else {
         set req.http.X-Forwarded-For = client.ip;
       }
-
+      
       # Only deal with "normal" types
       if (req.method != "GET" &&
           req.method != "HEAD" &&

--- a/chart/templates/varnish-configmap-vcl.yaml
+++ b/chart/templates/varnish-configmap-vcl.yaml
@@ -1,0 +1,519 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-varnish-vcl
+  labels:
+    {{- include "drupal.release_labels" . | nindent 4 }}
+data:
+  default.vcl: |
+    vcl 4.1;
+
+    import std;
+    import directors;
+
+    backend prod1_http1 {
+      .host = "{{ .Release.Name }}-drupal";
+      .port = "80";
+      .max_connections = 300;
+
+      .probe = {
+        .interval  = 30s; # check the health of each backend every n seconds
+        .timeout   = 2s; # timing out after n seconds
+        .window    = 5;  # If 3 out of the last 5 polls succeeded the backend is
+        .threshold = 3;  # considered healthy, otherwise it will be marked as sick
+      }
+
+      .first_byte_timeout     = 300s;    # How long to wait before we receive a first byte from our backend?
+      .connect_timeout        = 10s;     # How long to wait for a backend connection?
+      .between_bytes_timeout  = 10s;     # How long to wait between bytes received from our backend?
+    }
+ 
+    # Define the internal network access.
+    # These are used below to allow internal access to certain files
+    # from trusted locations while not allowing access from the public internet.
+    acl internal {
+      {{ .Values.varnish.internalACL }}
+    }
+
+    # Define the purge network access.
+    # These are used below to allow cache purging via BAN.
+    # acl purge {
+    #   "127.0.0.1";
+    # }
+
+    # List of upstream proxies we trust to set X-Forwarded-For correctly.
+    acl upstream_proxy {
+        "127.0.0.1";
+        # TODO: trust all
+      }
+
+    sub vcl_init {
+      # Called when VCL is loaded, before any requests pass through it.
+      # Typically used to initialize VMODs.
+      new prod1 = directors.hash();
+      prod1.add_backend(prod1_http1, 1);
+    }
+
+    # Backend placeholder
+
+    sub vcl_recv {
+      # Called at the beginning of a request, after the complete request has been received and parsed.
+      # Its purpose is to decide whether or not to serve the request, how to do it, and, if applicable,
+      # which backend to use.
+      # also used to modify the request
+
+      if (req.url == "/monit-check-url-happy") {
+        return (synth(200, "Varnish up"));
+      }
+
+      # Only allow BAN requests from IP addresses in the 'purge' ACL.
+      if (req.method == "BAN") {
+        # Admin port is only exposed to internal network
+        #     if (!client.ip ~ purge) {
+        #     return (synth(403, "Not allowed."));
+        # }
+        
+        # Logic for the ban, using the cache tags headers. For more info
+        # see https://github.com/geerlingguy/drupal-vm/issues/397.
+        if (req.http.X-Drupal-Cache-Tags) {
+            ban("obj.http.X-Drupal-Cache-Tags ~ " + req.http.X-Drupal-Cache-Tags);
+        }
+        elseif (req.http.Cache-Tags) {
+            ban("obj.http.Cache-Tags ~ " + req.http.Cache-Tags);
+        }
+        else {
+            return (synth(403, "Cache tags headers not present."));
+        }
+        # Throw a synthetic page so the request won't go to the backend.
+        return (synth(200, "Ban added."));
+      }
+      
+      # Add a unique header containing the client address
+      if (client.ip ~ upstream_proxy && req.http.X-Forwarded-For) {
+        set req.http.X-Forwarded-For = req.http.X-Real-IP;
+      } else {
+        set req.http.X-Forwarded-For = client.ip;
+      }
+
+      # Only deal with "normal" types
+      if (req.method != "GET" &&
+          req.method != "HEAD" &&
+          req.method != "PUT" &&
+          req.method != "POST" &&
+          req.method != "TRACE" &&
+          req.method != "OPTIONS" &&
+          req.method != "PATCH" &&
+          req.method != "DELETE") {
+        /* Non-RFC2616 or CONNECT which is weird. */
+        return (pipe);
+      }
+
+      # Implementing websocket support (https://www.varnish-cache.org/docs/4.0/users-guide/vcl-example-websockets.html)
+      if (req.http.Upgrade ~ "(?i)websocket") {
+        return (pipe);
+      }
+
+      # Slow connections with big file uploads may lead to 503 errors, regardless of timeout
+      # settings. We can avoid problems by piping those POST uploads.
+      # More info: https://www.varnish-cache.org/lists/pipermail/varnish-bugs/2011-April/003684.html
+      # Unresolved ticket : https://www.varnish-cache.org/trac/ticket/849
+      if (req.method == "POST" && req.http.Content-Type ~ "multipart/form-data") {
+        return (pipe);
+      }
+
+      # Only cache GET or HEAD requests. This makes sure the POST requests are always passed.
+      if (req.method != "GET" && req.method != "HEAD") {
+        return (pass);
+      }
+
+      // No varnish for ping file (for monitoring tools)
+      if (req.url ~ "_ping.php") {
+        return (pass);
+      }
+
+      if (req.url ~ "^/(?:user|admin|cart|checkout|logout|abuse|flag|.*\?rate=)" && req.http.user-agent ~ "(?:crawl|goog|yahoo|spider|bot|Yandex|bing|tracker|click|parser|ltx71|urllib)") {
+        return (synth( 403, "Forbidden"));
+      }
+
+      if (req.url ~ "\.(png|gif|jpg|tif|tiff|ico|swf|css|js|pdf|doc|xls|ppt|zip)(\?.*)?$") {
+        // Forcing a lookup with static file requests
+        return (hash);
+      }
+
+      # Do not allow public access to cron.php , update.php or install.php.
+      if (req.url ~ "^(|/core)/(cron|install|update)\.php$" && !client.ip ~ internal) {
+        # Have Varnish throw the error directly.
+        return (synth( 404, "Page not found."));
+      }
+
+      # Do not cache these paths.
+      if (req.url ~ "^/update\.php$" ||
+          req.url ~ "^/install\.php$" ||
+          req.url ~ "^/cron\.php$" ||
+          req.url ~ "^/ooyala/ping$" ||
+          req.url ~ "^/admin/build/features" ||
+          req.url ~ "^/info/.*$" ||
+          req.url ~ "^/flag/.*$" ||
+          //req.url ~ "^.*/ajax/.*$" ||
+          //req.url ~ "^.*/ahah/.*$" ||
+          req.url ~ "^/radioactivity_node.php$") {
+          return (pass);
+      }
+
+      if (req.http.Cookie) {
+        if (req.url ~ "\.(png|gif|jpg|svg|tif|tiff|ico|swf|css|js|pdf|doc|xls|ppt|zip|woff|eot|ttf|bmp|bz2)$") {
+          # Static file request do not vary on cookies
+          unset req.http.Cookie;
+          return (hash);
+        }
+        elseif (req.http.Cookie ~ "(SESS[a-z0-9]+|SSESS[a-z0-9]+)") {
+          # Authenticated users should not be cached
+          return (pass);
+        }
+            else {
+          # Non-authenticated requests do not vary on cookies
+          unset req.http.Cookie;
+        }
+      }
+
+      if (req.http.Accept-Encoding) {
+        if (req.url ~ "\.(jpg|png|gif|svg|tif|tiff|ico|gz|tgz|bz2|tbz|mp3|ogg|swf|zip|pdf|woff|eot|ttf)(\?.*)?$") {
+            # No point in compressing these
+            unset req.http.Accept-Encoding;
+        } elsif (req.http.Accept-Encoding ~ "gzip") {
+            set req.http.Accept-Encoding = "gzip";
+        } elsif (req.http.Accept-Encoding ~ "deflate") {
+            set req.http.Accept-Encoding = "deflate";
+        } else {
+            # unkown algorithm
+            unset req.http.Accept-Encoding;
+        }
+      }
+
+      // Keep multiple cache objects to a minimum
+      # -> NOT. We dont Vary cache per these headers.
+      #unset req.http.Accept-Language;
+      #unset req.http.user-agent;
+
+      if (req.http.host == "docs.local.ansibleref.com") {
+        return (pass);
+      }
+
+      # Large static files are delivered directly to the end-user without
+      # waiting for Varnish to fully read the file first.
+      # Varnish 4 fully supports Streaming, so set do_stream in vcl_backend_response()
+      if (req.url ~ "^[^?]*\.(mp[34]|rar|tar|tgz|gz|wav|zip|bz2|xz|7z|avi|mov|ogm|mpe?g|mk[av]|webm)(\?.*)?$") {
+        unset req.http.Cookie;
+        return (hash);
+      }
+
+      # Send Surrogate-Capability headers to announce ESI support to backend
+      set req.http.Surrogate-Capability = "key=ESI/1.0";
+
+      if (req.http.Authorization) {
+        # Not cacheable by default
+        return (pass);
+      }
+
+      return (hash);
+    }
+
+    sub vcl_pipe {
+      # Called upon entering pipe mode.
+      # In this mode, the request is passed on to the backend, and any further data from both the client
+      # and backend is passed on unaltered until either end closes the connection. Basically, Varnish will
+      # degrade into a simple TCP proxy, shuffling bytes back and forth. For a connection in pipe mode,
+      # no other VCL subroutine will ever get called after vcl_pipe.
+
+      # Note that only the first request to the backend will have
+      # X-Forwarded-For set.  If you use X-Forwarded-For and want to
+      # have it set for all requests, make sure to have:
+      # set bereq.http.connection = "close";
+      # here.  It is not set by default as it might break some broken web
+      # applications, like IIS with NTLM authentication.
+      set bereq.http.Connection = "Close";
+
+      # Implementing websocket support (https://www.varnish-cache.org/docs/4.0/users-guide/vcl-example-websockets.html)
+      if (req.http.upgrade) {
+        set bereq.http.upgrade = req.http.upgrade;
+      }
+
+      return (pipe);
+    }
+
+    sub vcl_pass {
+      # Called upon entering pass mode. In this mode, the request is passed on to the backend, and the
+      # backend's response is passed on to the client, but is not entered into the cache. Subsequent
+      # requests submitted over the same client connection are handled normally.
+
+      # return (pass);
+    }
+
+    # The data on which the hashing will take place
+    sub vcl_hash {
+      # Called after vcl_recv to create a hash value for the request. This is used as a key
+      # to look up the object in Varnish.
+
+      hash_data(req.url);
+
+      if (req.http.host) {
+        hash_data(req.http.host);
+      } else {
+        hash_data(server.ip);
+      }
+
+      # Make sure HTTPS request (X-Forwarded-Proto=https) are cached separately
+      if (req.http.HTTPS) {
+        hash_data(req.http.HTTPS);
+      }
+
+      # hash cookies for requests that have them
+      if (req.http.Cookie) {
+        hash_data(req.http.Cookie);
+      }
+    }
+
+    sub vcl_hit {
+        if (obj.ttl >= 0s) {
+            # normal hit
+            return (deliver);
+        }
+        # We have no fresh fish. Lets look at the stale ones.
+        if (std.healthy(req.backend_hint)) {
+            # Backend is healthy. If the object is not older then 30secs, deliver it to the client
+            # and automatically create a separate backend request to warm the cache for this request.
+            if (obj.ttl + 30s > 0s) {
+                set req.http.grace = "normal(limited)";
+                return (deliver);
+            } else {
+                # No candidate for grace. Fetch a fresh object.
+                return(miss);
+            }
+        } else {
+            # backend is sick - use full grace
+            if (obj.ttl + obj.grace > 0s) {
+                set req.http.grace = "full";
+                return (deliver);
+            } else {
+                # no graced object.
+                return (miss);
+            }
+        }
+    }
+
+    # sub vcl_miss {
+    #   # Called after a cache lookup if the requested document was not found in the cache. Its purpose
+    #   # is to decide whether or not to attempt to retrieve the document from the backend, and which
+    #   # backend to use.
+
+    #   return (fetch);
+    # }
+
+    # Handle the HTTP request coming from our backend
+    sub vcl_backend_response {
+      # Called after the response headers has been successfully retrieved from the backend.
+
+      # Pause ESI request and remove Surrogate-Control header
+      if (beresp.http.Surrogate-Control ~ "ESI/1.0") {
+        unset beresp.http.Surrogate-Control;
+        set beresp.do_esi = true;
+      }
+
+      # Store the request url in cached item
+      # See "Smart banning" https://www.varnish-software.com/static/book/Cache_invalidation.html
+      set beresp.http.x-url = bereq.url;
+      set beresp.http.x-host = bereq.http.host;
+
+      # gzip is by default on for (easily) compressable transfer types
+      if (beresp.http.content-type ~ "text/html" || beresp.http.content-type ~ "css" || beresp.http.content-type ~ "javascript") {
+        set beresp.do_gzip = true;
+      }
+
+      # If Drupal page cache is enabled, it will send a X-Drupal-Cache header, and for anonymous "Cache-Control: public, max-age=x."-headers.
+      # In those cases, Varnish normally  uses the max-age value directly for do determine how long it is cached (ttl).
+      # We can set the TTL for all content to 12h. Lets do it only if Varnish already thinks it is cacheable, and not a page-cache-item.
+      if(beresp.status == 200 && beresp.ttl > 0s && !beresp.http.X-Drupal-Cache){
+        # Default TTL for all content is 10m
+        set beresp.ttl = 10m;
+        set beresp.http.x-ttl = "10m";
+      }
+
+      if (bereq.url ~ "\.(jpg|jpeg|gif|png|svg|ico|css|zip|tgz|gz|rar|bz2|pdf|txt|tar|wav|bmp|rtf|flv|swf|html|htm|otf)\??.*$") {
+        # Strip any cookies before static files are inserted into cache.
+        unset beresp.http.set-cookie;
+        if(beresp.status == 200){
+          set beresp.ttl = 7d;
+          set beresp.http.isstatic = "1";
+        } else{
+          # Dont cache broken images etc for more than 30s, and not at all clientside.
+          set beresp.ttl = 30s;
+          set beresp.http.Cache-control = "max-age=0, must-revalidate";
+        }
+      }
+
+      # Large static files are delivered directly to the end-user without
+      # waiting for Varnish to fully read the file first.
+      # Varnish 4 fully supports Streaming, so use streaming here to avoid locking.
+      if (bereq.url ~ "^[^?]*\.(mp[34]|rar|tar|tgz|gz|pdf|wav|zip|bz2|xz|7z|avi|mov|ogm|mpe?g|mk[av]|webm)(\?.*)?$") {
+        unset beresp.http.set-cookie;
+        set beresp.do_stream = true;  # Check memory usage it'll grow in fetch_chunksize blocks (128k by default) if the backend doesn't send a Content-Length header, so only enable it for big objects
+        set beresp.do_gzip = false;   # Don't try to compress it for storage
+      }
+
+      if (beresp.status == 404) {
+        if (beresp.http.isstatic) {
+          /*
+          * 404s for static files might include profile data since they're actually Drupal pages.
+          * See sites/default/settings.php for how 404s are implemented "the fast way"
+          */
+          set beresp.ttl = 0s;
+        }
+      }
+
+      // Making theme development a bit faster on local envs.
+      if (bereq.url ~ "\.(css|js)\??.*$" && bereq.http.host ~ "^local") {
+        set beresp.ttl = 0s;
+        set beresp.http.X-Noncached-Static = 1;
+        set beresp.http.Cache-control = "no-cache, max-age=0, must-revalidate";
+      }
+
+      if(beresp.status >= 500){
+        // Cache (public) internal errors, but for only 1s. Never cache client side.
+        set beresp.ttl = 1s;
+        set beresp.http.Cache-control = "no-cache, max-age=0, must-revalidate";
+      }
+
+      # Allow items to be stale if needed.
+      set beresp.grace = 2h;
+
+      return (deliver);
+    }
+
+    sub vcl_backend_error {
+      return(retry);
+    }
+
+
+    # The routine when we deliver the HTTP request to the user
+    # Last chance to modify headers that are sent to the client
+    sub vcl_deliver {
+      # Called before a cached object is delivered to the client.
+
+      if (obj.hits > 0) { # Add debug header to see if it's a HIT/MISS and the number of hits, disable when not needed
+        set resp.http.X-W-Cache = "HIT";
+      } else {
+        set resp.http.X-W-Cache = "MISS";
+      }
+
+      # Please note that obj.hits behaviour changed in 4.0, now it counts per objecthead, not per object
+      # and obj.hits may not be reset in some cases where bans are in use. See bug 1492 for details.
+      # So take hits with a grain of salt
+      set resp.http.X-W-Cache-Hits = obj.hits;
+
+      # Remove some headers: PHP version
+      unset resp.http.X-Powered-By;
+
+      # Remove some headers: Apache version & OS
+      unset resp.http.Server;
+      unset resp.http.X-Varnish;
+      unset resp.http.Via;
+      unset resp.http.Link;
+      unset resp.http.X-Generator;
+      unset resp.http.X-Proxy;
+      unset resp.http.X-Powered-By;
+      unset resp.http.x-do-esi;
+      unset resp.http.X-Forced-Gzip;
+
+      # deliver can return synth, but we must avoid a potential loop.
+      # This GET-param can be used to see the real backend error:
+      # error-debug=randomvar (used for convenient debugging).
+      if(resp.status >= 500 && req.url !~ "error-debug=randomvar"){
+        return (synth(resp.status, "Internal Error"));
+      }
+
+      # Remove the request url from the cached item's headers
+      # See "Smart banning" https://www.varnish-software.com/static/book/Cache_invalidation.html
+      unset resp.http.x-url;
+      unset resp.http.x-host;
+
+      # Comment these for easier Drupal cache tag debugging in development.
+      unset resp.http.cache-tags;
+      unset resp.http.X-Drupal-Cache-Tags;
+      unset resp.http.X-Drupal-Cache-Contexts;
+
+      return (deliver);
+    }
+
+    sub vcl_purge {
+      # Only handle actual PURGE HTTP methods, everything else is discarded
+      if (req.method != "PURGE") {
+        # restart request
+        set req.http.X-Purge = "Yes";
+        return(restart);
+      }
+    }
+
+    sub vcl_synth {
+      if (resp.status == 720) {
+        # We use this special error status 720 to force redirects with 301 (permanent) redirects
+        # To use this, call the following from anywhere in vcl_recv: return (synth(720, "http://host/new.html"));
+        set resp.http.Location = resp.reason;
+        set resp.status = 301;
+        return (deliver);
+      } elseif (resp.status == 721) {
+        # And we use error status 721 to force redirects with a 302 (temporary) redirect
+        # To use this, call the following from anywhere in vcl_recv: return (synth(720, "http://host/new.html"));
+        set resp.http.Location = resp.reason;
+        set resp.status = 302;
+        return (deliver);
+      } elseif (resp.status == 722) {
+        # Use special error status when hotlinking to resource is forbidden.
+        # This is used in hotlink sub
+
+        # Do no cache
+        set resp.http.Cache-control = "max-age=0, must-revalidate";
+        set resp.status = 403;
+        return (deliver);
+      } elseif(resp.status >= 500) {
+          // Custom error
+          set resp.http.Cache-Control = "no-cache, max-age: 0, must-revalidate";
+          set resp.http.x-sitename = "silta";
+          set resp.http.x-sitetitle = "silta";
+
+          synthetic( {"
+            <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+            <html xmlns="http://www.w3.org/1999/xhtml">
+            <head>
+            <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+            <link href="https://wunder.io/sites/default/files/error_page/style.css" rel="stylesheet" type="text/css">
+            <title>"} + resp.http.x-sitetitle + {" - Error loading the page</title>
+
+            </head>
+
+            <body>
+              <div id="error-box">
+                &nbsp
+                <div id="error-message">
+                  <h1>Our best people are on the case!</h1>
+                  <h2>Please check back shortly</h2>
+                  <h3>Error loading the page</h3>
+                </div>
+              </div>
+
+              <!--"} + resp.status + {"-->
+
+            </body>
+            </html>
+          "} );
+                return (deliver);
+        }
+
+      return (deliver);
+    }
+
+    sub vcl_fini {
+      # Called when VCL is discarded only after all requests have exited the VCL.
+      # Typically used to clean up VMODs.
+
+      return (ok);
+    }

--- a/chart/templates/varnish-configmap-vcl.yaml
+++ b/chart/templates/varnish-configmap-vcl.yaml
@@ -306,13 +306,13 @@ data:
         }
     }
 
-    # sub vcl_miss {
-    #   # Called after a cache lookup if the requested document was not found in the cache. Its purpose
-    #   # is to decide whether or not to attempt to retrieve the document from the backend, and which
-    #   # backend to use.
+    sub vcl_miss {
+      # Called after a cache lookup if the requested document was not found in the cache. Its purpose
+      # is to decide whether or not to attempt to retrieve the document from the backend, and which
+      # backend to use.
 
-    #   return (fetch);
-    # }
+      return (fetch);
+    }
 
     # Handle the HTTP request coming from our backend
     sub vcl_backend_response {

--- a/chart/templates/varnish-configmap-vcl.yaml
+++ b/chart/templates/varnish-configmap-vcl.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.varnish.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -55,173 +56,7 @@ data:
       prod1.add_backend(prod1_http1, 1);
     }
 
-    # Backend placeholder
-
-    sub vcl_recv {
-      # Called at the beginning of a request, after the complete request has been received and parsed.
-      # Its purpose is to decide whether or not to serve the request, how to do it, and, if applicable,
-      # which backend to use.
-      # also used to modify the request
-
-      if (req.url == "/monit-check-url-happy") {
-        return (synth(200, "Varnish up"));
-      }
-
-      # Only allow BAN requests from IP addresses in the 'purge' ACL.
-      if (req.method == "BAN") {
-        # Admin port is only exposed to internal network
-        #     if (!client.ip ~ purge) {
-        #     return (synth(403, "Not allowed."));
-        # }
-        
-        # Logic for the ban, using the cache tags headers. For more info
-        # see https://github.com/geerlingguy/drupal-vm/issues/397.
-        if (req.http.X-Drupal-Cache-Tags) {
-            ban("obj.http.X-Drupal-Cache-Tags ~ " + req.http.X-Drupal-Cache-Tags);
-        }
-        elseif (req.http.Cache-Tags) {
-            ban("obj.http.Cache-Tags ~ " + req.http.Cache-Tags);
-        }
-        else {
-            return (synth(403, "Cache tags headers not present."));
-        }
-        # Throw a synthetic page so the request won't go to the backend.
-        return (synth(200, "Ban added."));
-      }
-      
-      # Add a unique header containing the client address
-      if (client.ip ~ upstream_proxy && req.http.X-Envoy-External-Address) {
-        set req.http.X-Forwarded-For = req.http.X-Envoy-External-Address;
-      } 
-      elseif (client.ip ~ upstream_proxy && req.http.X-Forwarded-For) {
-        set req.http.X-Forwarded-For = req.http.X-Real-IP;
-      } 
-      else {
-        set req.http.X-Forwarded-For = client.ip;
-      }
-      
-      # Only deal with "normal" types
-      if (req.method != "GET" &&
-          req.method != "HEAD" &&
-          req.method != "PUT" &&
-          req.method != "POST" &&
-          req.method != "TRACE" &&
-          req.method != "OPTIONS" &&
-          req.method != "PATCH" &&
-          req.method != "DELETE") {
-        /* Non-RFC2616 or CONNECT which is weird. */
-        return (pipe);
-      }
-
-      # Implementing websocket support (https://www.varnish-cache.org/docs/4.0/users-guide/vcl-example-websockets.html)
-      if (req.http.Upgrade ~ "(?i)websocket") {
-        return (pipe);
-      }
-
-      # Slow connections with big file uploads may lead to 503 errors, regardless of timeout
-      # settings. We can avoid problems by piping those POST uploads.
-      # More info: https://www.varnish-cache.org/lists/pipermail/varnish-bugs/2011-April/003684.html
-      # Unresolved ticket : https://www.varnish-cache.org/trac/ticket/849
-      if (req.method == "POST" && req.http.Content-Type ~ "multipart/form-data") {
-        return (pipe);
-      }
-
-      # Only cache GET or HEAD requests. This makes sure the POST requests are always passed.
-      if (req.method != "GET" && req.method != "HEAD") {
-        return (pass);
-      }
-
-      // No varnish for ping file (for monitoring tools)
-      if (req.url ~ "_ping.php") {
-        return (pass);
-      }
-
-      if (req.url ~ "^/(?:user|admin|cart|checkout|logout|abuse|flag|.*\?rate=)" && req.http.user-agent ~ "(?:crawl|goog|yahoo|spider|bot|Yandex|bing|tracker|click|parser|ltx71|urllib)") {
-        return (synth( 403, "Forbidden"));
-      }
-
-      if (req.url ~ "\.(png|gif|jpg|tif|tiff|ico|swf|css|js|pdf|doc|xls|ppt|zip)(\?.*)?$") {
-        // Forcing a lookup with static file requests
-        return (hash);
-      }
-
-      # Do not allow public access to cron.php , update.php or install.php.
-      if (req.url ~ "^(|/core)/(cron|install|update)\.php$" && !client.ip ~ internal) {
-        # Have Varnish throw the error directly.
-        return (synth( 404, "Page not found."));
-      }
-
-      # Do not cache these paths.
-      if (req.url ~ "^/update\.php$" ||
-          req.url ~ "^/install\.php$" ||
-          req.url ~ "^/cron\.php$" ||
-          req.url ~ "^/ooyala/ping$" ||
-          req.url ~ "^/admin/build/features" ||
-          req.url ~ "^/info/.*$" ||
-          req.url ~ "^/flag/.*$" ||
-          //req.url ~ "^.*/ajax/.*$" ||
-          //req.url ~ "^.*/ahah/.*$" ||
-          req.url ~ "^/radioactivity_node.php$") {
-          return (pass);
-      }
-
-      if (req.http.Cookie) {
-        if (req.url ~ "\.(png|gif|jpg|svg|tif|tiff|ico|swf|css|js|pdf|doc|xls|ppt|zip|woff|eot|ttf|bmp|bz2)$") {
-          # Static file request do not vary on cookies
-          unset req.http.Cookie;
-          return (hash);
-        }
-        elseif (req.http.Cookie ~ "(SESS[a-z0-9]+|SSESS[a-z0-9]+)") {
-          # Authenticated users should not be cached
-          return (pass);
-        }
-            else {
-          # Non-authenticated requests do not vary on cookies
-          unset req.http.Cookie;
-        }
-      }
-
-      if (req.http.Accept-Encoding) {
-        if (req.url ~ "\.(jpg|png|gif|svg|tif|tiff|ico|gz|tgz|bz2|tbz|mp3|ogg|swf|zip|pdf|woff|eot|ttf)(\?.*)?$") {
-            # No point in compressing these
-            unset req.http.Accept-Encoding;
-        } elsif (req.http.Accept-Encoding ~ "gzip") {
-            set req.http.Accept-Encoding = "gzip";
-        } elsif (req.http.Accept-Encoding ~ "deflate") {
-            set req.http.Accept-Encoding = "deflate";
-        } else {
-            # unkown algorithm
-            unset req.http.Accept-Encoding;
-        }
-      }
-
-      // Keep multiple cache objects to a minimum
-      # -> NOT. We dont Vary cache per these headers.
-      #unset req.http.Accept-Language;
-      #unset req.http.user-agent;
-
-      if (req.http.host == "docs.local.ansibleref.com") {
-        return (pass);
-      }
-
-      # Large static files are delivered directly to the end-user without
-      # waiting for Varnish to fully read the file first.
-      # Varnish 4 fully supports Streaming, so set do_stream in vcl_backend_response()
-      if (req.url ~ "^[^?]*\.(mp[34]|rar|tar|tgz|gz|wav|zip|bz2|xz|7z|avi|mov|ogm|mpe?g|mk[av]|webm)(\?.*)?$") {
-        unset req.http.Cookie;
-        return (hash);
-      }
-
-      # Send Surrogate-Capability headers to announce ESI support to backend
-      set req.http.Surrogate-Capability = "key=ESI/1.0";
-
-      if (req.http.Authorization) {
-        # Not cacheable by default
-        return (pass);
-      }
-
-      return (hash);
-    }
+    include "includes/vcl_recv.vcl";
 
     sub vcl_pipe {
       # Called upon entering pipe mode.
@@ -399,6 +234,226 @@ data:
     }
 
 
+    include "includes/vcl_deliver.vcl";
+
+    sub vcl_purge {
+      # Only handle actual PURGE HTTP methods, everything else is discarded
+      if (req.method != "PURGE") {
+        # restart request
+        set req.http.X-Purge = "Yes";
+        return(restart);
+      }
+    }
+
+    sub vcl_synth {
+      if (resp.status == 720) {
+        # We use this special error status 720 to force redirects with 301 (permanent) redirects
+        # To use this, call the following from anywhere in vcl_recv: return (synth(720, "http://host/new.html"));
+        set resp.http.Location = resp.reason;
+        set resp.status = 301;
+        return (deliver);
+      } elseif (resp.status == 721) {
+        # And we use error status 721 to force redirects with a 302 (temporary) redirect
+        # To use this, call the following from anywhere in vcl_recv: return (synth(720, "http://host/new.html"));
+        set resp.http.Location = resp.reason;
+        set resp.status = 302;
+        return (deliver);
+      } elseif (resp.status == 722) {
+        # Use special error status when hotlinking to resource is forbidden.
+        # This is used in hotlink sub
+
+        # Do no cache
+        set resp.http.Cache-control = "max-age=0, must-revalidate";
+        set resp.status = 403;
+        return (deliver);
+      } elseif(resp.status >= 500) {
+        include "includes/vcl_synth_500.vcl";
+      }
+
+      return (deliver);
+    }
+
+    sub vcl_fini {
+      # Called when VCL is discarded only after all requests have exited the VCL.
+      # Typically used to clean up VMODs.
+
+      return (ok);
+    }
+
+  vcl_recv.vcl: |
+    sub vcl_recv {
+      # Called at the beginning of a request, after the complete request has been received and parsed.
+      # Its purpose is to decide whether or not to serve the request, how to do it, and, if applicable,
+      # which backend to use.
+      # also used to modify the request
+
+      if (req.url == "/monit-check-url-happy") {
+        return (synth(200, "Varnish up"));
+      }
+
+      # Only allow BAN requests from IP addresses in the 'purge' ACL.
+      if (req.method == "BAN") {
+        # Admin port is only exposed to internal network
+        #     if (!client.ip ~ purge) {
+        #     return (synth(403, "Not allowed."));
+        # }
+        
+        # Logic for the ban, using the cache tags headers. For more info
+        # see https://github.com/geerlingguy/drupal-vm/issues/397.
+        if (req.http.X-Drupal-Cache-Tags) {
+            ban("obj.http.X-Drupal-Cache-Tags ~ " + req.http.X-Drupal-Cache-Tags);
+        }
+        elseif (req.http.Cache-Tags) {
+            ban("obj.http.Cache-Tags ~ " + req.http.Cache-Tags);
+        }
+        else {
+            return (synth(403, "Cache tags headers not present."));
+        }
+        # Throw a synthetic page so the request won't go to the backend.
+        return (synth(200, "Ban added."));
+      }
+      
+      # Add a unique header containing the client address
+      if (client.ip ~ upstream_proxy && req.http.X-Envoy-External-Address) {
+        set req.http.X-Forwarded-For = req.http.X-Envoy-External-Address;
+      } 
+      elseif (client.ip ~ upstream_proxy && req.http.X-Forwarded-For) {
+        set req.http.X-Forwarded-For = req.http.X-Real-IP;
+      } 
+      else {
+        set req.http.X-Forwarded-For = client.ip;
+      }
+      
+      # Only deal with "normal" types
+      if (req.method != "GET" &&
+          req.method != "HEAD" &&
+          req.method != "PUT" &&
+          req.method != "POST" &&
+          req.method != "TRACE" &&
+          req.method != "OPTIONS" &&
+          req.method != "PATCH" &&
+          req.method != "DELETE") {
+        /* Non-RFC2616 or CONNECT which is weird. */
+        return (pipe);
+      }
+
+      # Implementing websocket support (https://www.varnish-cache.org/docs/4.0/users-guide/vcl-example-websockets.html)
+      if (req.http.Upgrade ~ "(?i)websocket") {
+        return (pipe);
+      }
+
+      # Slow connections with big file uploads may lead to 503 errors, regardless of timeout
+      # settings. We can avoid problems by piping those POST uploads.
+      # More info: https://www.varnish-cache.org/lists/pipermail/varnish-bugs/2011-April/003684.html
+      # Unresolved ticket : https://www.varnish-cache.org/trac/ticket/849
+      if (req.method == "POST" && req.http.Content-Type ~ "multipart/form-data") {
+        return (pipe);
+      }
+
+      # Only cache GET or HEAD requests. This makes sure the POST requests are always passed.
+      if (req.method != "GET" && req.method != "HEAD") {
+        return (pass);
+      }
+
+      // No varnish for ping file (for monitoring tools)
+      if (req.url ~ "_ping.php") {
+        return (pass);
+      }
+
+      if (req.url ~ "^/(?:user|admin|cart|checkout|logout|abuse|flag|.*\?rate=)" && req.http.user-agent ~ "(?:crawl|goog|yahoo|spider|bot|Yandex|bing|tracker|click|parser|ltx71|urllib)") {
+        return (synth( 403, "Forbidden"));
+      }
+
+      if (req.url ~ "\.(png|gif|jpg|tif|tiff|ico|swf|css|js|pdf|doc|xls|ppt|zip)(\?.*)?$") {
+        // Forcing a lookup with static file requests
+        return (hash);
+      }
+
+      # Do not allow public access to cron.php , update.php or install.php.
+      if (req.url ~ "^(|/core)/(cron|install|update)\.php$" && !client.ip ~ internal) {
+        # Have Varnish throw the error directly.
+        return (synth( 404, "Page not found."));
+      }
+
+      # Do not cache these paths.
+      if (req.url ~ "^/update\.php$" ||
+          req.url ~ "^/install\.php$" ||
+          req.url ~ "^/cron\.php$" ||
+          req.url ~ "^/ooyala/ping$" ||
+          req.url ~ "^/admin/build/features" ||
+          req.url ~ "^/info/.*$" ||
+          req.url ~ "^/flag/.*$" ||
+          //req.url ~ "^.*/ajax/.*$" ||
+          //req.url ~ "^.*/ahah/.*$" ||
+          req.url ~ "^/radioactivity_node.php$") {
+          return (pass);
+      }
+
+      if (req.http.Cookie) {
+        if (req.url ~ "\.(png|gif|jpg|svg|tif|tiff|ico|swf|css|js|pdf|doc|xls|ppt|zip|woff|eot|ttf|bmp|bz2)$") {
+          # Static file request do not vary on cookies
+          unset req.http.Cookie;
+          return (hash);
+        }
+        elseif (req.http.Cookie ~ "(SESS[a-z0-9]+|SSESS[a-z0-9]+)") {
+          # Authenticated users should not be cached
+          return (pass);
+        }
+            else {
+          # Non-authenticated requests do not vary on cookies
+          unset req.http.Cookie;
+        }
+      }
+
+      if (req.http.Accept-Encoding) {
+        if (req.url ~ "\.(jpg|png|gif|svg|tif|tiff|ico|gz|tgz|bz2|tbz|mp3|ogg|swf|zip|pdf|woff|eot|ttf)(\?.*)?$") {
+            # No point in compressing these
+            unset req.http.Accept-Encoding;
+        } elsif (req.http.Accept-Encoding ~ "gzip") {
+            set req.http.Accept-Encoding = "gzip";
+        } elsif (req.http.Accept-Encoding ~ "deflate") {
+            set req.http.Accept-Encoding = "deflate";
+        } else {
+            # unkown algorithm
+            unset req.http.Accept-Encoding;
+        }
+      }
+
+      // Keep multiple cache objects to a minimum
+      # -> NOT. We dont Vary cache per these headers.
+      #unset req.http.Accept-Language;
+      #unset req.http.user-agent;
+
+      if (req.http.host == "docs.local.ansibleref.com") {
+        return (pass);
+      }
+
+      # Large static files are delivered directly to the end-user without
+      # waiting for Varnish to fully read the file first.
+      # Varnish 4 fully supports Streaming, so set do_stream in vcl_backend_response()
+      if (req.url ~ "^[^?]*\.(mp[34]|rar|tar|tgz|gz|wav|zip|bz2|xz|7z|avi|mov|ogm|mpe?g|mk[av]|webm)(\?.*)?$") {
+        unset req.http.Cookie;
+        return (hash);
+      }
+
+      # Send Surrogate-Capability headers to announce ESI support to backend
+      set req.http.Surrogate-Capability = "key=ESI/1.0";
+
+      if (req.http.Authorization) {
+        # Not cacheable by default
+        return (pass);
+      }
+
+      // Allow pasing custom rules
+      {{- if .Values.varnish.vcl_recv_extra }}
+{{ .Values.varnish.vcl_recv_extra | indent 6 }}
+      {{- end }}
+      
+      return (hash);
+    }
+    
+  vcl_deliver.vcl: |
+
     # The routine when we deliver the HTTP request to the user
     # Last chance to modify headers that are sent to the client
     sub vcl_deliver {
@@ -449,76 +504,36 @@ data:
       return (deliver);
     }
 
-    sub vcl_purge {
-      # Only handle actual PURGE HTTP methods, everything else is discarded
-      if (req.method != "PURGE") {
-        # restart request
-        set req.http.X-Purge = "Yes";
-        return(restart);
-      }
-    }
+  vcl_synth_500.vcl: |
+    // Custom error
+    set resp.http.Cache-Control = "no-cache, max-age: 0, must-revalidate";
+    set resp.http.x-sitename = "silta";
+    set resp.http.x-sitetitle = "silta";
 
-    sub vcl_synth {
-      if (resp.status == 720) {
-        # We use this special error status 720 to force redirects with 301 (permanent) redirects
-        # To use this, call the following from anywhere in vcl_recv: return (synth(720, "http://host/new.html"));
-        set resp.http.Location = resp.reason;
-        set resp.status = 301;
-        return (deliver);
-      } elseif (resp.status == 721) {
-        # And we use error status 721 to force redirects with a 302 (temporary) redirect
-        # To use this, call the following from anywhere in vcl_recv: return (synth(720, "http://host/new.html"));
-        set resp.http.Location = resp.reason;
-        set resp.status = 302;
-        return (deliver);
-      } elseif (resp.status == 722) {
-        # Use special error status when hotlinking to resource is forbidden.
-        # This is used in hotlink sub
+    synthetic( {"
+      <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+      <html xmlns="http://www.w3.org/1999/xhtml">
+      <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+      <link href="https://wunder.io/sites/default/files/error_page/style.css" rel="stylesheet" type="text/css">
+      <title>"} + resp.http.x-sitetitle + {" - Error loading the page</title>
 
-        # Do no cache
-        set resp.http.Cache-control = "max-age=0, must-revalidate";
-        set resp.status = 403;
-        return (deliver);
-      } elseif(resp.status >= 500) {
-          // Custom error
-          set resp.http.Cache-Control = "no-cache, max-age: 0, must-revalidate";
-          set resp.http.x-sitename = "silta";
-          set resp.http.x-sitetitle = "silta";
+      </head>
 
-          synthetic( {"
-            <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-            <html xmlns="http://www.w3.org/1999/xhtml">
-            <head>
-            <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-            <link href="https://wunder.io/sites/default/files/error_page/style.css" rel="stylesheet" type="text/css">
-            <title>"} + resp.http.x-sitetitle + {" - Error loading the page</title>
+      <body>
+        <div id="error-box">
+          &nbsp;
+          <div id="error-message">
+            <h1>Our best people are on the case!</h1>
+            <h2>Please check back shortly</h2>
+            <h3>Error loading the page</h3>
+          </div>
+        </div>
 
-            </head>
+        <!--"} + resp.status + {"-->
 
-            <body>
-              <div id="error-box">
-                &nbsp
-                <div id="error-message">
-                  <h1>Our best people are on the case!</h1>
-                  <h2>Please check back shortly</h2>
-                  <h3>Error loading the page</h3>
-                </div>
-              </div>
-
-              <!--"} + resp.status + {"-->
-
-            </body>
-            </html>
-          "} );
-                return (deliver);
-        }
-
-      return (deliver);
-    }
-
-    sub vcl_fini {
-      # Called when VCL is discarded only after all requests have exited the VCL.
-      # Typically used to clean up VMODs.
-
-      return (ok);
-    }
+      </body>
+      </html>
+    "} );
+    return (deliver);
+{{- end }}

--- a/chart/templates/varnish-deployment.yaml
+++ b/chart/templates/varnish-deployment.yaml
@@ -1,10 +1,13 @@
 {{- if .Values.varnish.enabled }}
 
-# TODO: 
-# - Secret
-# - Admin port
+# TODO:
+# + Pass headers for remote_addr correctly
+# + test static resource caching and SESS passtrough
+# + Admin port
+# - Admin secret
 # - PHP ENV with secret and admin port
 # - Tests
+# - Cache type = file + set size
 
 apiVersion: apps/v1
 kind: Deployment
@@ -33,10 +36,12 @@ spec:
     spec:
       containers:
       - name: varnish
-        image: varnish:6.0 #stable
+        image: wunderio/drupal-varnish:v0.1.0
         ports:
         - containerPort: 80
-        #- containerPort: 9200
+          name: web
+        - containerPort: 6082
+          name: admin
         # env:
           # VARNISH_BACKEND_HOST: {{ .Release.Name }}-drupal
           # VARNISH_BACKEND_PORT: 80
@@ -67,8 +72,10 @@ spec:
   type: NodePort
   externalTrafficPolicy: Local
   ports:
-  - port: 80
-  #- port: 9200
+  - name: web
+    port: 80
+  - name: admin
+    port: 6082 
   selector:
     {{- include "drupal.release_labels" . | nindent 4 }}
     service: varnish

--- a/chart/templates/varnish-deployment.yaml
+++ b/chart/templates/varnish-deployment.yaml
@@ -17,10 +17,6 @@ spec:
       labels:
         {{- include "drupal.release_labels" . | nindent 8 }}
         service: varnish
-      annotations:
-        # https://github.com/kubernetes/kubernetes/issues/22368
-        checksum/config: {{ include (print $.Chart.Name "/templates/varnish-configmap-vcl.yaml") . | sha256sum }}
-    #For pod updates, kill the current pod, stand up the new one
     strategy:
       type: Recreate
     spec:
@@ -34,7 +30,6 @@ spec:
           name: admin
         env:
         - name: VARNISH_STORAGE_BACKEND
-          # https://varnish-cache.org/docs/trunk/users-guide/storage-backends.html
           value: {{ .Values.varnish.storageBackend | quote }}
         resources:
 {{ .Values.varnish.resources | toYaml | indent 10 }}

--- a/chart/templates/varnish-deployment.yaml
+++ b/chart/templates/varnish-deployment.yaml
@@ -26,6 +26,9 @@ spec:
         image: amazeeio/varnish-drupal
         ports:
         - containerPort: 9200
+        env:
+          VARNISH_BACKEND_HOST: {{ .Release.Name }}-drupal
+          VARNISH_BACKEND_PORT: 80
         resources:
 {{ .Values.varnish.resources | toYaml | indent 10 }}
 ---

--- a/chart/templates/varnish-deployment.yaml
+++ b/chart/templates/varnish-deployment.yaml
@@ -29,6 +29,7 @@ spec:
         env:
           VARNISH_BACKEND_HOST: {{ .Release.Name }}-drupal
           VARNISH_BACKEND_PORT: 80
+          LAGOON_PROJECT: 'not-a-lagoon-project'
         resources:
 {{ .Values.varnish.resources | toYaml | indent 10 }}
 ---

--- a/chart/templates/varnish-deployment.yaml
+++ b/chart/templates/varnish-deployment.yaml
@@ -7,7 +7,8 @@
 # + Admin secret
 # + PHP ENV with host, secret and admin port
 # - Tests
-# - Cache type = file + set size
+# + Cache type = file + set size
+# - Partial includes for default vcl file that allow passtrough or custom error page
 
 apiVersion: apps/v1
 kind: Deployment
@@ -36,36 +37,38 @@ spec:
     spec:
       containers:
       - name: varnish
-        image: wunderio/drupal-varnish:v0.1.3
+        image: wunderio/drupal-varnish:v0.1.5
         ports:
         - containerPort: 80
           name: web
         - containerPort: 6082
           name: admin
         env:
+        - name: VARNISH_STORAGE_BACKEND
           # https://varnish-cache.org/docs/trunk/users-guide/storage-backends.html
-          VARNISH_STORAGE_BACKEND: {{ .Values.varnish.storageBackend }}
+          value: {{ .Values.varnish.storageBackend | quote }}
         resources:
 {{ .Values.varnish.resources | toYaml | indent 10 }}
         volumeMounts:
         - name: varnish-vcl
-          mountPath: /etc/varnish/default.vcl # mount nginx-conf configmap volume to /etc/nginx
-          readOnly: true
+          mountPath: /etc/varnish/default.vcl
           subPath: default.vcl
+          readOnly: true
         - name: varnish-secret
           mountPath: "/etc/varnish/secret"
-          readOnly: 
+          subPath: control_key
+          readOnly: true
 
       volumes:
-        - name: varnish-vcl
-          configMap:
-            name: {{ .Release.Name }}-varnish-vcl
-            items:
-              - key: default.vcl
-                path: default.vcl
-        - name: varnish-secret
-          secret:
-            secretName: secret
+      - name: varnish-vcl
+        configMap:
+          name: {{ .Release.Name }}-varnish-vcl
+      - name: varnish-secret
+        secret:
+          secretName: {{ .Release.Name }}-secrets-varnish
+      #     items:
+      #       - key: secret
+      #         path: secret
 ---
 apiVersion: v1
 kind: Service

--- a/chart/templates/varnish-deployment.yaml
+++ b/chart/templates/varnish-deployment.yaml
@@ -4,8 +4,8 @@
 # + Pass headers for remote_addr correctly
 # + test static resource caching and SESS passtrough
 # + Admin port
-# - Admin secret
-# - PHP ENV with secret and admin port
+# + Admin secret
+# + PHP ENV with host, secret and admin port
 # - Tests
 # - Cache type = file + set size
 
@@ -52,6 +52,9 @@ spec:
           mountPath: /etc/varnish/default.vcl # mount nginx-conf configmap volume to /etc/nginx
           readOnly: true
           subPath: default.vcl
+        - name: varnish-secret
+          mountPath: "/etc/varnish/secret"
+          readOnly: 
 
       volumes:
         - name: varnish-vcl
@@ -60,6 +63,9 @@ spec:
             items:
               - key: default.vcl
                 path: default.vcl
+        - name: varnish-secret
+          secret:
+            secretName: secret
 ---
 apiVersion: v1
 kind: Service

--- a/chart/templates/varnish-deployment.yaml
+++ b/chart/templates/varnish-deployment.yaml
@@ -1,0 +1,57 @@
+{{- if .Values.varnish.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-varnish
+  labels:
+    {{- include "drupal.release_labels" . | nindent 4 }}
+    service: varnish
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "drupal.release_labels" . | nindent 6 }}
+      service: varnish
+  template:
+    metadata:
+      labels:
+        {{- include "drupal.release_labels" . | nindent 8 }}
+        service: varnish
+    #For pod updates, kill the current pod, stand up the new one
+    strategy:
+      type: Recreate
+    spec:
+      containers:
+      - name: varnish
+        image: amazeeio/varnish-drupal
+        ports:
+        - containerPort: 9200
+        resources:
+{{ .Values.varnish.resources | toYaml | indent 10 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-varnish
+  labels:
+    {{- include "drupal.release_labels" . | nindent 4 }}
+    service: varnish
+  annotations:
+{{- if .Values.ambassador.enabled }}
+    getambassador.io/config: |
+      apiVersion: ambassador/v0
+      kind:  Mapping
+      name:  {{ .Release.Name }}-drupal
+      host: varnish-{{ template "drupal.domain" . }}
+      service: {{ .Release.Name }}-varnish.{{ .Release.Namespace }}.svc.cluster.local:80
+      {{- .Values.ambassador.config | toYaml | nindent 6 }}
+{{- end }}
+spec:
+  type: NodePort
+  ports:
+  - name: varnish
+    port: 9200
+  selector:
+    {{- include "drupal.release_labels" . | nindent 4 }}
+    service: varnish
+{{- end }}

--- a/chart/templates/varnish-deployment.yaml
+++ b/chart/templates/varnish-deployment.yaml
@@ -24,6 +24,9 @@ spec:
       labels:
         {{- include "drupal.release_labels" . | nindent 8 }}
         service: varnish
+      annotations:
+        # https://github.com/kubernetes/kubernetes/issues/22368
+        checksum/config: {{ include (print $.Chart.Name "/templates/varnish-configmap-vcl.yaml") . | sha256sum }}
     #For pod updates, kill the current pod, stand up the new one
     strategy:
       type: Recreate
@@ -60,7 +63,6 @@ metadata:
   labels:
     {{- include "drupal.release_labels" . | nindent 4 }}
     service: varnish
-  annotations:
 spec:
   type: NodePort
   externalTrafficPolicy: Local

--- a/chart/templates/varnish-deployment.yaml
+++ b/chart/templates/varnish-deployment.yaml
@@ -1,15 +1,4 @@
 {{- if .Values.varnish.enabled }}
-
-# TODO:
-# + Pass headers for remote_addr correctly
-# + test static resource caching and SESS passtrough
-# + Admin port
-# + Admin secret
-# + PHP ENV with host, secret and admin port
-# - Tests
-# + Cache type = file + set size
-# - Partial includes for default vcl file that allow passtrough or custom error page
-
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -54,11 +43,22 @@ spec:
           mountPath: /etc/varnish/default.vcl
           subPath: default.vcl
           readOnly: true
+        - name: varnish-vcl
+          mountPath: /etc/varnish/includes/vcl_recv.vcl
+          subPath: vcl_recv.vcl
+          readOnly: true
+        - name: varnish-vcl
+          mountPath: /etc/varnish/includes/vcl_deliver.vcl
+          subPath: vcl_deliver.vcl
+          readOnly: true
+        - name: varnish-vcl
+          mountPath: /etc/varnish/includes/vcl_synth_500.vcl
+          subPath: vcl_synth_500.vcl
+          readOnly: true
         - name: varnish-secret
           mountPath: "/etc/varnish/secret"
           subPath: control_key
           readOnly: true
-
       volumes:
       - name: varnish-vcl
         configMap:
@@ -66,9 +66,7 @@ spec:
       - name: varnish-secret
         secret:
           secretName: {{ .Release.Name }}-secrets-varnish
-      #     items:
-      #       - key: secret
-      #         path: secret
+
 ---
 apiVersion: v1
 kind: Service

--- a/chart/templates/varnish-deployment.yaml
+++ b/chart/templates/varnish-deployment.yaml
@@ -36,15 +36,15 @@ spec:
     spec:
       containers:
       - name: varnish
-        image: wunderio/drupal-varnish:v0.1.0
+        image: wunderio/drupal-varnish:v0.1.3
         ports:
         - containerPort: 80
           name: web
         - containerPort: 6082
           name: admin
-        # env:
-          # VARNISH_BACKEND_HOST: {{ .Release.Name }}-drupal
-          # VARNISH_BACKEND_PORT: 80
+        env:
+          # https://varnish-cache.org/docs/trunk/users-guide/storage-backends.html
+          VARNISH_STORAGE_BACKEND: {{ .Values.varnish.storageBackend }}
         resources:
 {{ .Values.varnish.resources | toYaml | indent 10 }}
         volumeMounts:

--- a/chart/templates/varnish-deployment.yaml
+++ b/chart/templates/varnish-deployment.yaml
@@ -1,4 +1,11 @@
 {{- if .Values.varnish.enabled }}
+
+# TODO: 
+# - Secret
+# - Admin port
+# - PHP ENV with secret and admin port
+# - Tests
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -23,15 +30,28 @@ spec:
     spec:
       containers:
       - name: varnish
-        image: amazeeio/varnish-drupal
+        image: varnish:6.0 #stable
         ports:
-        - containerPort: 9200
-        env:
-          VARNISH_BACKEND_HOST: {{ .Release.Name }}-drupal
-          VARNISH_BACKEND_PORT: 80
-          LAGOON_PROJECT: 'not-a-lagoon-project'
+        - containerPort: 80
+        #- containerPort: 9200
+        # env:
+          # VARNISH_BACKEND_HOST: {{ .Release.Name }}-drupal
+          # VARNISH_BACKEND_PORT: 80
         resources:
 {{ .Values.varnish.resources | toYaml | indent 10 }}
+        volumeMounts:
+        - name: varnish-vcl
+          mountPath: /etc/varnish/default.vcl # mount nginx-conf configmap volume to /etc/nginx
+          readOnly: true
+          subPath: default.vcl
+
+      volumes:
+        - name: varnish-vcl
+          configMap:
+            name: {{ .Release.Name }}-varnish-vcl
+            items:
+              - key: default.vcl
+                path: default.vcl
 ---
 apiVersion: v1
 kind: Service
@@ -41,20 +61,12 @@ metadata:
     {{- include "drupal.release_labels" . | nindent 4 }}
     service: varnish
   annotations:
-{{- if .Values.ambassador.enabled }}
-    getambassador.io/config: |
-      apiVersion: ambassador/v0
-      kind:  Mapping
-      name:  {{ .Release.Name }}-drupal
-      host: varnish-{{ template "drupal.domain" . }}
-      service: {{ .Release.Name }}-varnish.{{ .Release.Namespace }}.svc.cluster.local:80
-      {{- .Values.ambassador.config | toYaml | nindent 6 }}
-{{- end }}
 spec:
   type: NodePort
+  externalTrafficPolicy: Local
   ports:
-  - name: varnish
-    port: 9200
+  - port: 80
+  #- port: 9200
   selector:
     {{- include "drupal.release_labels" . | nindent 4 }}
     service: varnish

--- a/chart/templates/varnish-secret.yaml
+++ b/chart/templates/varnish-secret.yaml
@@ -6,8 +6,8 @@ metadata:
     {{- include "drupal.release_labels" . | nindent 4 }}
 type: Opaque
 data:
-  {{- if .Values.varnish.secret }}
-  secret: "{{ .Values.varnish.secret | b64enc }}"
+  {{ if .Values.varnish.secret }}
+  control_key: {{ .Values.varnish.secret "\n" | b64enc }}
   {{ else }}
-  secret: {{ "not-a-secret-123" | b64enc }}
-  {{- end }}
+  control_key: {{ "not-a-secret-123\n" | b64enc }}
+  {{ end }}

--- a/chart/templates/varnish-secret.yaml
+++ b/chart/templates/varnish-secret.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-secrets-varnish
+  labels:
+    {{- include "drupal.release_labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{- if .Values.varnish.secret }}
+  secret: "{{ .Values.varnish.secret | b64enc }}"
+  {{ else }}
+  secret: {{ "not-a-secret-123" | b64enc }}
+  {{- end }}

--- a/chart/templates/varnish-secret.yaml
+++ b/chart/templates/varnish-secret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.varnish.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -11,3 +12,4 @@ data:
   {{ else }}
   control_key: {{ "not-a-secret-123\n" | b64enc }}
   {{ end }}
+{{- end }}

--- a/chart/tests/drupal_configmap_test.yaml
+++ b/chart/tests/drupal_configmap_test.yaml
@@ -32,9 +32,9 @@ tests:
     set:
       nginx:
         loglevel: 'debug'
+        realipfrom: '1.2.3.4'
         basicauth:
           enabled: true
-          realipfrom: '1.2.3.4'
     asserts:
     - template: drupal-configmap-nginx.yaml
       matchRegex:

--- a/chart/tests/drupal_deployment_test.yaml
+++ b/chart/tests/drupal_deployment_test.yaml
@@ -91,3 +91,49 @@ tests:
       - equal:
           path: spec.template.spec.containers[1].resources.limits.memory
           value: 2G
+ 
+  - it: sets varnish environment variables if varnish is enabled
+    set:
+      varnish.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: VARNISH_ADMIN_HOST
+            value: RELEASE-NAME-varnish
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: VARNISH_ADMIN_PORT
+            value: "6082"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: VARNISH_CONTROL_KEY
+            valueFrom:
+              secretKeyRef:
+                key: control_key
+                name: RELEASE-NAME-secrets-varnish
+  
+  - it: does not have varnish environment variables if varnish is disabled
+    set:
+      varnish.enabled: false
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: VARNISH_ADMIN_HOST
+            value: RELEASE-NAME-varnish
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: VARNISH_ADMIN_PORT
+            value: "6082"
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: VARNISH_CONTROL_KEY
+            valueFrom:
+              secretKeyRef:
+                key: control_key
+                name: RELEASE-NAME-secrets-varnish

--- a/chart/tests/drupal_service_test.yaml
+++ b/chart/tests/drupal_service_test.yaml
@@ -49,3 +49,18 @@ tests:
     asserts:
       - isNull:
           path: metadata.annotations.getambassador\.io/config
+
+  - it: directs ambassador traffic to drupal service by default
+    asserts:
+      - matchRegex:
+          path: metadata.annotations.getambassador\.io/config
+          pattern: 'service: RELEASE-NAME-drupal.NAMESPACE.svc.cluster.local:80'
+
+  - it: directs ambassador traffic to varnish service when varnish is enabled
+    set:
+      varnish.enabled: true
+    asserts:
+      - matchRegex:
+          path: metadata.annotations.getambassador\.io/config
+          pattern: 'service: RELEASE-NAME-varnish.NAMESPACE.svc.cluster.local:80'
+  

--- a/chart/tests/varnish_test.yaml
+++ b/chart/tests/varnish_test.yaml
@@ -1,0 +1,38 @@
+suite: varnish deployment
+templates:
+  - varnish-deployment.yaml
+tests:
+  - it: sets VARNISH_STORAGE_BACKEND environment variable correctly
+    set:
+      varnish.enabled: true
+      varnish.storageBackend: 'type,/storage/location,size'
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: VARNISH_STORAGE_BACKEND
+            value: 'type,/storage/location,size'
+
+  - it: takes resource requests and limits
+    set:
+      varnish.enabled: true
+      varnish.resources:
+        requests:
+          cpu: 123m
+          memory: 1G
+        limits:
+          cpu: 234m
+          memory: 2G
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: 123m
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.memory
+          value: 1G
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.cpu
+          value: 234m
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.memory
+          value: 2G

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -280,6 +280,10 @@ mariadb:
 varnish:
   enabled: true
   resources: {}
+  caching:
+    # file / malloc
+    type: file
+    size: 512M
 
 elasticsearch:
   enabled: false

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -279,7 +279,10 @@ mariadb:
 
 varnish:
   enabled: false
-  resources: {}
+  resources:
+    requests:
+      cpu: 50m
+      memory: 32Mi
   # https://varnish-cache.org/docs/trunk/users-guide/storage-backends.html
   storageBackend: 'file,/var/lib/varnish/varnish_storage.bin,512M'
   # Inject custom code into vcl_recv subroutine

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -278,12 +278,11 @@ mariadb:
         memory: 128M
 
 varnish:
-  enabled: true
+  enabled: false
   resources: {}
-  caching:
-    # file / malloc
-    type: file
-    size: 512M
+  # https://varnish-cache.org/docs/trunk/users-guide/storage-backends.html
+  storageBackend: 'file,/var/lib/varnish/varnish_storage.bin,512M'
+  # Inject custom code into vcl_recv subroutine
   vcl_recv_extra: |
 
 elasticsearch:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -273,6 +273,10 @@ mariadb:
         cpu: 50m
         memory: 128M
 
+varnish:
+  enabled: true
+  resources: {}
+
 elasticsearch:
   enabled: false
   # Choose versions in https://www.docker.elastic.co/ from "Elasticsearch" list

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -60,13 +60,17 @@ nginx:
       username: silta
       password: demo
 
-    # Trust X-Forwarded-For from these hosts for getting external IP 
-    realipfrom: 10.0.0.0/8
+  # Trust X-Forwarded-For from these hosts for getting external IP 
+  realipfrom: 10.0.0.0/8
 
-    # Add IP addresses that should be excluded from basicauth.
-    # Note that the key is only used for documentation purposes.
-    noauthips:
-      gke-internal: 10.0.0.0/8
+  # Define the internal network access.
+  # These are used below to allow internal access to certain files
+  # from trusted locations while not allowing access from the public internet.
+  # These addreses are also excluded from basicauth.
+  # Note that the key is only used for documentation purposes.
+  internalACL:
+    gke-internal: 10.0.0.0/8
+    vyper-hel: 94.237.33.88/32
 
   # Robots txt file blocked by default
   robotsTxt:
@@ -275,11 +279,6 @@ mariadb:
 
 varnish:
   enabled: true
-  # Define the internal network access.
-  # These are used below to allow internal access to certain files
-  # from trusted locations while not allowing access from the public internet.
-  internalACL: |
-    "94.237.33.88";
   resources: {}
 
 elasticsearch:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -275,6 +275,11 @@ mariadb:
 
 varnish:
   enabled: true
+  # Define the internal network access.
+  # These are used below to allow internal access to certain files
+  # from trusted locations while not allowing access from the public internet.
+  internalACL: |
+    "94.237.33.88";
   resources: {}
 
 elasticsearch:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -68,7 +68,7 @@ nginx:
   # from trusted locations while not allowing access from the public internet.
   # These addreses are also excluded from basicauth.
   # Note that the key is only used for documentation purposes.
-  internalACL:
+  noauthips:
     gke-internal: 10.0.0.0/8
 
   # Robots txt file blocked by default

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -284,6 +284,7 @@ varnish:
     # file / malloc
     type: file
     size: 512M
+  vcl_recv_extra: |
 
 elasticsearch:
   enabled: false

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -70,7 +70,6 @@ nginx:
   # Note that the key is only used for documentation purposes.
   internalACL:
     gke-internal: 10.0.0.0/8
-    vyper-hel: 94.237.33.88/32
 
   # Robots txt file blocked by default
   robotsTxt:

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -3,3 +3,6 @@
 #
 # See https://github.com/wunderio/charts/blob/master/drupal/values.yaml
 # for all possible options.
+
+varnish:
+  enabled: true

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -3,6 +3,3 @@
 #
 # See https://github.com/wunderio/charts/blob/master/drupal/values.yaml
 # for all possible options.
-
-varnish:
-  enabled: true


### PR DESCRIPTION
- `VARNISH_ADMIN_HOST`, `VARNISH_ADMIN_PORT` and `VARNISH_CONTROL_KEY` environment variables available in php container when `varnish.enabled` is set to `true`
- Correct `$_SERVER['REMOTE_ADDR']` is set in php headers;
- `Values.nginx.basicauth.noauthips` changed to `Values.nginx.noauthips` to unify nginx and varnish whitelist. This will need a change in existing projects!
  - noauthips is also used to control access to cron/install/update pages trough drupal
  ```
    if (req.url ~ "^(|/core)/(cron|install|update)\.php$" && !client.ip ~ internal) {
  ```
- `Values.nginx.basicauth.realipfrom` changed to `Values.nginx.realipfrom` for the reason mentioned above.
- Ability to define varnish caching backend and size using `Values.varnish.storageBackend`
- Ability to inject custom code into vcl_recv subroutine via `Values.varnish.vcl_recv_extra`
- Ability to redefine subroutines using helm templates (useful for chart developers).

Followup after merging this:

- migrate `Values.nginx.basicauth.noauthips` to `Values.nginx.noauthips` in existing projects.
- migrate `Values.nginx.basicauth.realipfrom` to `Values.nginx.realipfrom` in existing projects.