### PR TITLE
Sending e-mail

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,9 @@ workflows:
             - silta/npm-install-build
           pre-release:
             - run:
+                name: Add codecentric repo for mailhog
+                command: helm repo add codecentric https://codecentric.github.io/helm-charts
+            - run:
                 name: Build local helm dependencies
                 command: helm dependency build ./chart
 

--- a/chart/requirements.lock
+++ b/chart/requirements.lock
@@ -5,5 +5,8 @@ dependencies:
 - name: memcached
   repository: https://kubernetes-charts.storage.googleapis.com/
   version: 2.3.1
-digest: sha256:fa461d4a18989ac09f4b956a570eb145f156a5207d1eb894ecb9686e5f274201
-generated: 2018-11-21T15:49:00.515486879Z
+- name: mailhog
+  repository: https://codecentric.github.io/helm-charts
+  version: 3.0.1
+digest: sha256:812d2cf12daf5a640afa04af2092d63ff49b64631aee9411efaf61c19debffba
+generated: "2019-08-29T11:52:57.8913672Z"

--- a/chart/requirements.yaml
+++ b/chart/requirements.yaml
@@ -7,3 +7,7 @@ dependencies:
   version: 2.3.1
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: memcached.enabled
+- name: mailhog
+  version: 3.0.1
+  repository: https://codecentric.github.io/helm-charts
+  condition: mailhog.enabled

--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -5,6 +5,16 @@ Your site is available here:
   {{ $domain }}
   {{- end }}
 
+
+{{ if .Values.mailhog.enabled -}}
+Mailhog available at:
+  http://{{- template "drupal.domain" . }}/mailhog
+  {{- range $index, $domain := .Values.exposeDomains }}
+  {{ $domain }}/mailhog
+  {{- end }}
+
+{{- end }}
+
 {{ if .Values.nginx.basicauth.enabled -}}
 Basicauth username: {{ .Values.nginx.basicauth.credentials.username }}
 Basicauth password: {{ .Values.nginx.basicauth.credentials.password }}

--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -12,7 +12,6 @@ Mailhog available at:
   {{- range $index, $domain := .Values.exposeDomains }}
   {{ $domain }}/mailhog
   {{- end }}
-
 {{- end }}
 
 {{ if .Values.nginx.basicauth.enabled -}}

--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -5,9 +5,9 @@ Your site is available here:
   {{ $domain }}
   {{- end }}
 
-
 {{ if .Values.mailhog.enabled -}}
 Mailhog available at:
+
   http://{{- template "drupal.domain" . }}/mailhog
   {{- range $index, $domain := .Values.exposeDomains }}
   {{ $domain }}/mailhog

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -134,7 +134,7 @@ imagePullSecrets:
 - name: ELASTICSEARCH_HOST
   value: {{ .Release.Name }}-elastic
 {{- end }}
-{{- if .Values.smtp.enabled }}
+{{- if or .Values.mailhog.enabled .Values.smtp.enabled }}
 {{ include "smtp.env" . }}
 {{- end}}
 - name: HASH_SALT

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -75,7 +75,7 @@ imagePullSecrets:
   {{- if .Values.mailhog.enabled }}
   value: "{{ .Release.Name }}-mailhog:1025"
   {{ else }}
-  value: {{ .Values.smtp.address }} | quote
+  value: {{ .Values.smtp.address | quote }}
   {{- end }}
 - name: SMTP_TLS
   value: {{ .Values.smtp.tls | default false | quote }}

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -70,6 +70,44 @@ imagePullSecrets:
 {{- end }}
 {{- end }}
 
+{{- define "smtp.env" }}
+- name: SMTP_ADDRESS
+  {{- if .Values.mailhog.enabled }}
+  value: "{{ .Release.Name }}-mailhog:1025"
+  {{ else }}
+  value: {{ .Values.smtp.address }} | quote
+  {{- end }}
+- name: SMTP_TLS
+  value: {{ .Values.smtp.tls | default false | quote }}
+- name: SMTP_STARTTLS
+  value: {{ .Values.smtp.starttls | default false | quote }}
+- name: SMTP_USERNAME
+  value: {{ .Values.smtp.username | quote }}
+- name: SMTP_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Release.Name }}-secrets-smtp
+      key: password
+# Duplicate SMTP env variables for ssmtp bundled with amazee php image 
+- name: SSMTP_MAILHUB
+  {{- if .Values.mailhog.enabled }}
+  value: "{{ .Release.Name }}-mailhog:1025"
+  {{ else }}
+  value: {{ .Values.smtp.address | quote }}
+  {{- end }}
+- name: SSMTP_USETLS
+  value: {{ .Values.smtp.tls | default false | quote }}
+- name: SSMTP_USESTARTTLS
+  value: {{ .Values.smtp.starttls | default false | quote }}
+- name: SSMTP_AUTHUSER
+  value: {{ .Values.smtp.username | quote }}
+- name: SSMTP_AUTHPASS
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Release.Name }}-secrets-smtp
+      key: password
+{{- end }}
+
 {{- define "drupal.env" }}
 - name: SILTA_CLUSTER
   value: "1"
@@ -96,47 +134,9 @@ imagePullSecrets:
 - name: ELASTICSEARCH_HOST
   value: {{ .Release.Name }}-elastic
 {{- end }}
-
-# SMTP values
 {{- if .Values.smtp.enabled }}
-- name: SMTP_ADDRESS
-  {{- if .Values.mailhog.enabled }}
-  value: "{{ .Release.Name }}-mailhog:1025"
-  {{ else }}
-  value: {{ .Values.smtp.address }} | quote
-  {{- end }}
-- name: SMTP_TLS
-  value: {{ .Values.smtp.tls | default false | quote }}
-- name: SMTP_STARTTLS
-  value: {{ .Values.smtp.starttls | default false | quote }}
-- name: SMTP_USERNAME
-  value: {{ .Values.smtp.username | quote }}
-- name: SMTP_PASSWORD
-  valueFrom:
-    secretKeyRef:
-      name: {{ .Release.Name }}-secrets-smtp
-      key: password
-
-# Duplicate SMTP env variables for ssmtp bundled with amazee php image 
-- name: SSMTP_MAILHUB
-  {{- if .Values.mailhog.enabled }}
-  value: "{{ .Release.Name }}-mailhog:1025"
-  {{ else }}
-  value: {{ .Values.smtp.address | quote }}
-  {{- end }}
-- name: SSMTP_USETLS
-  value: {{ .Values.smtp.tls | default false | quote }}
-- name: SSMTP_USESTARTTLS
-  value: {{ .Values.smtp.starttls | default false | quote }}
-- name: SSMTP_AUTHUSER
-  value: {{ .Values.smtp.username | quote }}
-- name: SSMTP_AUTHPASS
-  valueFrom:
-    secretKeyRef:
-      name: {{ .Release.Name }}-secrets-smtp
-      key: password
+{{ include "smtp.env" . }}
 {{- end}}
-
 - name: HASH_SALT
   valueFrom:
     secretKeyRef:

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -96,6 +96,47 @@ imagePullSecrets:
 - name: ELASTICSEARCH_HOST
   value: {{ .Release.Name }}-elastic
 {{- end }}
+
+# SMTP values
+{{- if .Values.smtp.enabled }}
+- name: SMTP_ADDRESS
+  {{- if .Values.mailhog.enabled }}
+  value: "{{ .Release.Name }}-mailhog:1025"
+  {{ else }}
+  value: {{ .Values.smtp.address }} | quote
+  {{- end }}
+- name: SMTP_TLS
+  value: {{ .Values.smtp.tls | default false | quote }}
+- name: SMTP_STARTTLS
+  value: {{ .Values.smtp.starttls | default false | quote }}
+- name: SMTP_USERNAME
+  value: {{ .Values.smtp.username | quote }}
+- name: SMTP_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Release.Name }}-secrets-smtp
+      key: password
+
+# Duplicate SMTP env variables for ssmtp bundled with amazee php image 
+- name: SSMTP_MAILHUB
+  {{- if .Values.mailhog.enabled }}
+  value: "{{ .Release.Name }}-mailhog:1025"
+  {{ else }}
+  value: {{ .Values.smtp.address | quote }}
+  {{- end }}
+- name: SSMTP_USETLS
+  value: {{ .Values.smtp.tls | default false | quote }}
+- name: SSMTP_USESTARTTLS
+  value: {{ .Values.smtp.starttls | default false | quote }}
+- name: SSMTP_AUTHUSER
+  value: {{ .Values.smtp.username | quote }}
+- name: SSMTP_AUTHPASS
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Release.Name }}-secrets-smtp
+      key: password
+{{- end}}
+
 - name: HASH_SALT
   valueFrom:
     secretKeyRef:

--- a/chart/templates/drupal-configmap-nginx.yaml
+++ b/chart/templates/drupal-configmap-nginx.yaml
@@ -144,7 +144,41 @@ data:
         include fastcgi.conf;
 
         {{ include "drupal.basicauth" . | indent 6}}
-                                              
+
+        {{- if .Values.mailhog.enabled }}
+        location /mailhog {
+
+            # Auth / whitelist always enabled
+            satisfy any;
+            allow 127.0.0.1;
+            {{- range .Values.nginx.basicauth.noauthips }}
+            allow {{ . }};
+            {{- end }}
+            deny all;
+            
+            {{ if .Values.nginx.basicauth.noauthips }}
+            # Basic auth only allowed when at least one ip is whitelisted. Prevents using default credentials.
+            auth_basic "Restricted";
+            auth_basic_user_file /etc/nginx/.htaccess;
+            {{- end}}
+
+            rewrite ^/mailhog$ /mailhog/ permanent;
+
+            # Proxy to mailhog container
+            rewrite /mailhog(.*) $1 break;
+            proxy_pass http://{{ .Release.Name }}-mailhog:8025/;
+        
+            # Websock connection
+            chunked_transfer_encoding on;
+            proxy_set_header X-NginX-Proxy true;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+            proxy_http_version 1.1;
+            proxy_redirect off;
+            proxy_buffering off;
+        }
+        {{- end}}
+
         location / {                                                          
                                                     
             location ~* /system/files/ {

--- a/chart/templates/drupal-configmap-nginx.yaml
+++ b/chart/templates/drupal-configmap-nginx.yaml
@@ -156,8 +156,8 @@ data:
             {{- end }}
             deny all;
             
-            {{ if .Values.nginx.basicauth.noauthips }}
-            # Basic auth only allowed when at least one ip is whitelisted. Prevents using default credentials.
+            {{- if gt (len .Values.nginx.basicauth.noauthips) 1 -}}
+            # Basic auth only offered when at least one extra ip is whitelisted. Prevents using default credentials.
             auth_basic "Restricted";
             auth_basic_user_file /etc/nginx/.htaccess;
             {{- end}}

--- a/chart/templates/smtp-secret.yaml
+++ b/chart/templates/smtp-secret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.smtp.enabled }}
+{{- if or .Values.mailhog.enabled .Values.smtp.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/chart/templates/smtp-secret.yaml
+++ b/chart/templates/smtp-secret.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.smtp.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-secrets-smtp
+  labels:
+    {{- include "drupal.release_labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{ if .Values.smtp.password }}
+  password: "{{ .Values.smtp.password | b64enc }}"
+  {{ else }}
+  password: ""
+  {{ end }}
+{{- end }}

--- a/chart/tests/drupal_deployment_test.yaml
+++ b/chart/tests/drupal_deployment_test.yaml
@@ -41,6 +41,57 @@ tests:
             name: SILTA_CLUSTER
             value: '1'
 
+  - it: sets smtp environment variables correctly
+    set:
+      mailhog:
+        enabled: false
+      smtp:
+        enabled: true
+        address: examplehost
+        username: foo
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SMTP_ADDRESS
+            value: examplehost
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SMTP_USERNAME
+            value: foo
+  - it: sets mailhog smtp environment variables correctly
+    set:
+      mailhog:
+        enabled: true
+      smtp:
+        enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SMTP_ADDRESS
+            value: RELEASE-NAME-mailhog:1025
+  - it: sets ssmtp environment variables correctly
+    set:
+      mailhog:
+        enabled: false
+      smtp:
+        enabled: true
+        address: examplehost
+        username: foo
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SSMTP_MAILHUB
+            value: examplehost
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SSMTP_AUTHUSER
+            value: foo
+
   - it: sets the replica count correctly
     set:
       replicas: 3

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -309,7 +309,7 @@ ambassador:
 
 # TODO: Add codecentric repo for mailhog. https://github.com/helm/helm/issues/6005
 mailhog:
-  enabled: true
+  enabled: false
   resources:
     requests:
       cpu: 5m
@@ -317,7 +317,7 @@ mailhog:
 
 # SMTP configuration passed to containers as environment variables (SMTP_ADDRESS, SMTP_PORT, ..)
 smtp:
-  enabled: true
+  enabled: false
   # How to Setup SparkPost as your SMTP Relay: https://www.sparkpost.com/blog/setup-sparkpost-smtp-relay/
   # address: smtp.example.com:25
   # tls: false

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -305,3 +305,7 @@ ambassador:
   config:
     prefix: /
     timeout_ms: 30000
+
+mailhog:
+  enabled: true
+

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -306,6 +306,16 @@ ambassador:
     prefix: /
     timeout_ms: 30000
 
+# TODO: Add codecentric repo for mailhog. https://github.com/helm/helm/issues/6005
 mailhog:
   enabled: true
 
+# SMTP configuration passed to containers as environment variables (SMTP_ADDRESS, SMTP_PORT, ..)
+smtp:
+  enabled: true
+  # How to Setup SparkPost as your SMTP Relay: https://www.sparkpost.com/blog/setup-sparkpost-smtp-relay/
+  # address: smtp.example.com:25
+  # tls: false
+  # starttls: false
+  # username: ""
+  # password: ""

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -309,6 +309,10 @@ ambassador:
 # TODO: Add codecentric repo for mailhog. https://github.com/helm/helm/issues/6005
 mailhog:
   enabled: true
+  resources:
+    requests:
+      cpu: 5m
+      memory: 10M
 
 # SMTP configuration passed to containers as environment variables (SMTP_ADDRESS, SMTP_PORT, ..)
 smtp:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -305,6 +305,7 @@ ambassador:
   config:
     prefix: /
     timeout_ms: 30000
+    use_websocket: true
 
 # TODO: Add codecentric repo for mailhog. https://github.com/helm/helm/issues/6005
 mailhog:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -309,7 +309,7 @@ ambassador:
 
 # TODO: Add codecentric repo for mailhog. https://github.com/helm/helm/issues/6005
 mailhog:
-  enabled: false
+  enabled: true
   resources:
     requests:
       cpu: 5m

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -309,7 +309,7 @@ ambassador:
 
 # TODO: Add codecentric repo for mailhog. https://github.com/helm/helm/issues/6005
 mailhog:
-  enabled: true
+  enabled: false
   resources:
     requests:
       cpu: 5m


### PR DESCRIPTION
We have ssmtp since it's installed in [amazee.io lagoon php images](https://github.com/amazeeio/lagoon/blob/master/images/php/fpm/Dockerfile#L41). This PR utilizes builtin ssmtp binary and it's custom config to allow sending e-mails from drupal site. 

- Installs mailhog subchart from https://github.com/codecentric/helm-charts/tree/master/charts/mailhog when `.Variables.mailhog.enabled` is set to `true`
- Forwards e-mails to mailhog when `.Variables.mailhog.enabled` is set to `true`
- Allows setting custom smtp relayhost via `.Variables.smtp` value map
- Sets environment values for ssmtp and another set with generic environment variables in case application needs them (we want to avoid relying on ssmtp variables (`SSMTP_MAILHUB`, `SSMTP_USETLS` etc.)

TODO: When we merge this into drupal chart, we have to add codecentric repository in builder image or image build steps.
- `helm repo add codecentric https://codecentric.github.io/helm-charts`

![Screenshot from 2019-08-30 16-27-02](https://user-images.githubusercontent.com/635571/64189849-caca4c00-ce7d-11e9-92fd-7228a626e69e.png)
![Screenshot from 2019-08-30 16-27-41](https://user-images.githubusercontent.com/635571/64189854-cef66980-ce7d-11e9-8d86-cad8ecf8b0de.png)
![Screenshot from 2019-08-30 16-31-34](https://user-images.githubusercontent.com/635571/64189895-e03f7600-ce7d-11e9-8f93-2ae2cb14de55.png)
![Screenshot from 2019-08-30 16-32-06](https://user-images.githubusercontent.com/635571/64189884-dcabef00-ce7d-11e9-92f9-ee3e1e17de15.png)
I also fixed the "Disconnected" state for mailhog by [enabling websockets in ambassador](https://github.com/wunderio/drupal-project-k8s/pull/147/commits/661494d281149c6d1a410791c1def81ead1693c5). 