### PR TITLE
SLT-329: Only show instructions for enabled mounts.

### DIFF
--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -20,9 +20,11 @@ Importing a database dump:
   ssh {{ include "drupal.shellHost" . }} -J {{ include "drupal.jumphost" . }} "drush sql-cli" < my_database_dump.sql
 
 {{ range $index, $mount := .Values.mounts -}}
+{{ if eq $mount.enabled true -}}
 Importing files to {{ $index }}:
 
   rsync -azv -e 'ssh -A -J {{ include "drupal.jumphost" $ }}' local_folder {{ include "drupal.shellHost" $ }}:{{ $mount.mountPath }}
 
+{{ end -}}
 {{ end -}}
 {{- end -}}


### PR DESCRIPTION
The chart notes always included instructions for the private files, even though they are not enabled by default. This fixes it.