### PR TITLE
SLT-278 & SLT-279: Various Elasticsearch fixes

### DIFF
--- a/chart/templates/elasticsearch-deployment.yaml
+++ b/chart/templates/elasticsearch-deployment.yaml
@@ -57,12 +57,12 @@ spec:
           httpGet:
             path: /
             port: 9200
-          initialDelaySeconds: 5
+          initialDelaySeconds: 30
         livenessProbe:
           httpGet:
             path: /
             port: 9200
-          initialDelaySeconds: 10
+          initialDelaySeconds: 30
         env:
         - name: discovery.type
           value: single-node

--- a/chart/templates/elasticsearch-deployment.yaml
+++ b/chart/templates/elasticsearch-deployment.yaml
@@ -55,12 +55,12 @@ spec:
 {{ .Values.elasticsearch.resources | toYaml | indent 10 }}
         readinessProbe:
           httpGet:
-            path: /_cluster/health
+            path: /
             port: 9200
           initialDelaySeconds: 5
         livenessProbe:
           httpGet:
-            path: /_cluster/health?local=true
+            path: /
             port: 9200
           initialDelaySeconds: 10
         env:

--- a/chart/templates/elasticsearch-deployment.yaml
+++ b/chart/templates/elasticsearch-deployment.yaml
@@ -12,14 +12,14 @@ spec:
     matchLabels:
       {{- include "drupal.release_labels" . | nindent 6 }}
       service: elasticsearch
+  #For pod updates, kill the current pod, stand up the new one
+  strategy:
+    type: Recreate
   template:
     metadata:
       labels:
         {{- include "drupal.release_labels" . | nindent 8 }}
         service: elasticsearch
-    #For pod updates, kill the current pod, stand up the new one
-    strategy:
-      type: Recreate
     spec:
       initContainers:
       # Refer to https://www.elastic.co/guide/en/elasticsearch/reference/current/vm-max-map-count.html

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -303,7 +303,7 @@ elasticsearch:
     size: 512Mi
   resources:
     requests:
-      cpu: 25m
+      cpu: 100m
       memory: 512Mi
 
 # Memcache service overrides

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -309,7 +309,7 @@ elasticsearch:
       cpu: 100m
       memory: 512Mi
     limits:
-      cpu: 200m
+      cpu: 1000m
       memory: 512Mi
 
 # Memcache service overrides

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -305,6 +305,9 @@ elasticsearch:
     requests:
       cpu: 100m
       memory: 512Mi
+    limits:
+      cpu: 200m
+      memory: 512Mi
 
 # Memcache service overrides
 # see: https://github.com/helm/charts/blob/master/stable/memcached/values.yaml

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -280,6 +280,9 @@ mariadb:
       requests:
         cpu: 50m
         memory: 128M
+      limits:
+        cpu: 100m
+        memory: 128M
 
 varnish:
   enabled: false


### PR DESCRIPTION
The previous resource settings for the Elasticsearch deployment caused it to have too little cpu to be able to properly boot. These settings are now adjusted and the liveness and readiness probes have also been adjusted. 