### PR TITLE
SLT-338: Shorten name for cron jobs

### DIFF
--- a/chart/templates/drupal-cron.yaml
+++ b/chart/templates/drupal-cron.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  name: {{ $.Release.Name }}-cron-{{ $index }}
+  name: {{ $.Release.Name }}-{{ $index }}
   labels:
     {{- include "drupal.release_labels" $ | nindent 4 }}
 spec:


### PR DESCRIPTION
Since these are resources of type CronJob, the `cron` prefix can be skipped without losing information. This solves the problem we have where projects with longer repository names run into issues for feature branches, and should also provide a bit more flexibility with the naming of additional cron jobs.