### PR TITLE
Reference data / GDPR refactoring

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -205,7 +205,7 @@ done
 {{- end -}}
 
 {{- define "drupal.post-release-command" -}}
-set -e
+set -ex
 
 {{ include "drupal.wait-for-db-command" . }}
 {{ if .Values.elasticsearch.enabled }}
@@ -229,6 +229,7 @@ rm /app/web/sites/default/files/_installing
 
 
 {{- define "drupal.extract-reference-data" -}}
+set -ex
 if [[ "$(drush status --fields=bootstrap)" = *'Successful'* ]] ; then
 
   REFERENCE_DATA_LOCATION="/app/reference-data"

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -30,12 +30,6 @@ ports:
   mountPath: /etc/php7/php-fpm.d/www.conf
   readOnly: true
   subPath: www_conf
-{{ if ne $.Template.Name "drupal/templates/backup-cron.yaml" -}}
-- name: gdpr-dump
-  mountPath: /etc/my.cnf.d/gdpr-dump.cnf
-  readOnly: true
-  subPath: gdpr-dump
-{{- end }}
 - name: settings
   mountPath: /app/web/sites/default/settings.silta.php
   readOnly: true
@@ -53,11 +47,6 @@ ports:
 - name: php-conf
   configMap:
     name: {{ .Release.Name }}-php-conf
-{{ if ne $.Template.Name "drupal/templates/backup-cron.yaml" -}}
-- name: gdpr-dump
-  configMap:
-    name: {{ .Release.Name }}-gdpr-dump
-{{- end }}
 - name: settings
   configMap:
     name: {{ .Release.Name }}-settings

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -244,8 +244,8 @@ if [[ "$(drush status --fields=bootstrap)" = *'Successful'* ]] ; then
   done
 
   # Take a database dump.
-  mysqldump -u $DB_USER --password=$DB_PASS -h $DB_HOST --skip-lock-tables --single-transaction --quick $IGNORE_TABLES $DB_NAME > /tmp/db.sql
-  mysqldump -u $DB_USER --password=$DB_PASS -h $DB_HOST --skip-lock-tables --single-transaction --quick --force --no-data $DB_NAME $IGNORED_TABLES >> /tmp/db.sql
+  mysqldump -u $DB_USER --password=$DB_PASS --host=$DB_HOST $IGNORE_TABLES $DB_NAME > /tmp/db.sql
+  mysqldump -u $DB_USER --password=$DB_PASS --host=$DB_HOST --no-data $DB_NAME $IGNORED_TABLES >> /tmp/db.sql
 
   # Compress the database dump and copy it into the backup folder.
   # We don't do this directly on the volume mount to avoid sending the uncompressed dump across the network.

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -239,8 +239,8 @@ if [[ "$(drush status --fields=bootstrap)" = *'Successful'* ]] ; then
   IGNORED_TABLES=""
   for TABLE in `drush sql-query "show tables;" | grep -E '{{ .Values.referenceData.ignoreTableContent }}'` ;
   do
-    IGNORE_TABLES="$IGNORE_TABLES --ignore-table='$DB_NAME.$TABLE'";
-    IGNORED_TABLES="$IGNORED_TABLES '$TABLE'";
+    IGNORE_TABLES="$IGNORE_TABLES --ignore-table=$DB_NAME.$TABLE";
+    IGNORED_TABLES="$IGNORED_TABLES $TABLE";
   done
 
   # Take a database dump.

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -242,7 +242,13 @@ if [[ "$(drush status --fields=bootstrap)" = *'Successful'* ]] ; then
   IGNORED_TABLES="$IGNORED_TABLES '$TABLE'";
   done
 
-  # Take a database dump. We use the full path to bypass gdpr-dump
+  echo $PATH
+  which mysqldump
+  ls /home/.composer/
+  ls /home/.composer/vendor/
+  ls /home/.composer/vendor/bin/
+
+  # Take a database dump.
   mysqldump -u $DB_USER --password=$DB_PASS -h $DB_HOST --skip-lock-tables --single-transaction --quick $IGNORE_TABLES $DB_NAME > /tmp/db.sql
   mysqldump -u $DB_USER --password=$DB_PASS -h $DB_HOST --skip-lock-tables --single-transaction --quick --force --no-data $DB_NAME $IGNORED_TABLES >> /tmp/db.sql
 

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -229,7 +229,7 @@ rm /app/web/sites/default/files/_installing
 
 
 {{- define "drupal.extract-reference-data" -}}
-set -ex
+set -e
 if [[ "$(drush status --fields=bootstrap)" = *'Successful'* ]] ; then
 
   REFERENCE_DATA_LOCATION="/app/reference-data"

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -231,22 +231,16 @@ rm /app/web/sites/default/files/_installing
 {{- define "drupal.extract-reference-data" -}}
 if [[ "$(drush status --fields=bootstrap)" = *'Successful'* ]] ; then
 
-  BACKUP_LOCATION="/app/reference-data"
+  REFERENCE_DATA_LOCATION="/app/reference-data"
 
   # Figure out which tables to skip.
   IGNORE_TABLES=""
   IGNORED_TABLES=""
   for TABLE in `drush sql-query "show tables;" | grep -E '{{ .Values.referenceData.ignoreTableContent }}'` ;
   do
-  IGNORE_TABLES="$IGNORE_TABLES --ignore-table='$DB_NAME.$TABLE'";
-  IGNORED_TABLES="$IGNORED_TABLES '$TABLE'";
+    IGNORE_TABLES="$IGNORE_TABLES --ignore-table='$DB_NAME.$TABLE'";
+    IGNORED_TABLES="$IGNORED_TABLES '$TABLE'";
   done
-
-  echo $PATH
-  which mysqldump
-  ls /home/.composer/
-  ls /home/.composer/vendor/
-  ls /home/.composer/vendor/bin/
 
   # Take a database dump.
   mysqldump -u $DB_USER --password=$DB_PASS -h $DB_HOST --skip-lock-tables --single-transaction --quick $IGNORE_TABLES $DB_NAME > /tmp/db.sql
@@ -255,12 +249,12 @@ if [[ "$(drush status --fields=bootstrap)" = *'Successful'* ]] ; then
   # Compress the database dump and copy it into the backup folder.
   # We don't do this directly on the volume mount to avoid sending the uncompressed dump across the network.
   gzip -9 /tmp/db.sql
-  cp /tmp/db.sql.gz $BACKUP_LOCATION/db.sql.gz
+  cp /tmp/db.sql.gz $REFERENCE_DATA_LOCATION/db.sql.gz
 
   {{ range $index, $mount := .Values.mounts -}}
   {{- if eq $mount.enabled true -}}
   # File backup for {{ $index }} volume.
-  tar -czP --exclude=css --exclude=js --exclude=styles -f $BACKUP_LOCATION/{{ $index }}.tar.gz {{ $mount.mountPath }}
+  tar -czP --exclude=css --exclude=js --exclude=styles -f $REFERENCE_DATA_LOCATION/{{ $index }}.tar.gz {{ $mount.mountPath }}
   {{- end -}}
   {{- end }}
 else

--- a/chart/templates/post-release.yaml
+++ b/chart/templates/post-release.yaml
@@ -23,6 +23,10 @@ spec:
         args:
         - {{ include "drupal.post-release-command" . | quote }}
         volumeMounts:
+          - name: gdpr-dump
+            mountPath: /etc/my.cnf.d/gdpr-dump.cnf
+            readOnly: true
+            subPath: gdpr-dump
           {{- include "drupal.volumeMounts" . | nindent 10 }}
           {{- if .Values.referenceData.enabled }}
           {{- if or (eq .Values.referenceData.referenceEnvironment .Values.environmentName) (not .Values.referenceData.skipMount) }}
@@ -38,7 +42,9 @@ spec:
       {{- include "drupal.imagePullSecrets" . | nindent 6 }}
       volumes:
         {{- include "drupal.volumes" . | nindent 8 }}
-
+        - name: gdpr-dump
+          configMap:
+            name: {{ .Release.Name }}-gdpr-dump
         {{- if .Values.referenceData.enabled -}}
         {{- if or (eq .Values.referenceData.referenceEnvironment .Values.environmentName) (not .Values.referenceData.skipMount) }}
         - name: reference-data-volume

--- a/chart/templates/reference-data-cron.yaml
+++ b/chart/templates/reference-data-cron.yaml
@@ -20,6 +20,10 @@ spec:
               {{- include "drupal.volumeMounts" . | nindent 14 }}
               - name: reference-data-volume
                 mountPath: /app/reference-data
+              - name: gdpr-dump
+                mountPath: /etc/my.cnf.d/gdpr-dump.cnf
+                readOnly: true
+                subPath: gdpr-dump
             command: ["/bin/bash", "-c"]
             args:
               - {{ .Values.referenceData.command | quote }}
@@ -31,6 +35,9 @@ spec:
             - name: reference-data-volume
               persistentVolumeClaim:
                 claimName: {{ include "drupal.referenceEnvironment" . }}-reference-data
+            - name: gdpr-dump
+              configMap:
+                name: {{ .Release.Name }}-gdpr-dump
 
 
           {{- include "drupal.imagePullSecrets" . | nindent 10 }}

--- a/chart/templates/reference-data-cron.yaml
+++ b/chart/templates/reference-data-cron.yaml
@@ -26,7 +26,9 @@ spec:
                 subPath: gdpr-dump
             command: ["/bin/bash", "-c"]
             args:
-              - {{ .Values.referenceData.command | quote }}
+              - |
+                {{ include "drupal.extract-reference-data" . | nindent 16 }}
+
             resources:
               {{- .Values.php.resources | toYaml | nindent 14 }}
           restartPolicy: OnFailure

--- a/chart/tests/drupal_postinstall_test.yaml
+++ b/chart/tests/drupal_postinstall_test.yaml
@@ -35,11 +35,10 @@ tests:
       # Simulate a deployment on the reference environment
       environmentName: reference-environment
       referenceData.referenceEnvironment: reference-environment
-      referenceData.command: baz
     asserts:
       - matchRegex:
           path: spec.template.spec.containers[0].args[0]
-          pattern: 'baz'
+          pattern: 'REFERENCE_DATA_LOCATION'
 
   - it: doesn't exports reference data after deployments if disabled
     set:
@@ -47,11 +46,10 @@ tests:
       environmentName: reference-environment
       referenceData.referenceEnvironment: reference-environment
       referenceData.updateAfterDeployment: false
-      referenceData.command: baz
     asserts:
       - notMatchRegex:
           path: spec.template.spec.containers[0].args[0]
-          pattern: 'baz'
+          pattern: 'REFERENCE_DATA_LOCATION'
 
   - it: sets environment variables correctly
     set:

--- a/chart/tests/reference_data_test.yaml
+++ b/chart/tests/reference_data_test.yaml
@@ -57,7 +57,6 @@ tests:
         storage: 123Gi
         storageClassName: silta-shared
         schedule: '0 1 2 3 *'
-        command: "echo Hello World"
       php.env:
         foo: bar
     asserts:
@@ -99,10 +98,6 @@ tests:
       equal:
         path: spec.schedule
         value: '0 1 2 3 *'
-    - template: reference-data-cron.yaml
-      equal:
-        path: spec.jobTemplate.spec.template.spec.containers[0].args[0]
-        value: "echo Hello World"
 
     - contains:
         path: spec.template.spec.containers[0].volumeMounts

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -234,20 +234,7 @@ referenceData:
   # Update the reference data after deployments on the reference environment.
   updateAfterDeployment: true
 
-  # The commands that is executed to export reference data.
-  command: |
-    if [[ "$(drush status --fields=bootstrap)" = *'Successful'* ]] ; then
-      # NFS doesn't support replacing files, so we delete them instead.
-      rm -f reference-data/*
-
-      # Export database dump.
-      drush sql-dump --gzip --result-file ../reference-data/db.sql
-
-      # Export public files.
-      tar cz --exclude=css --exclude=js --exclude=styles -f reference-data/public_files.tar.gz web/sites/default/files/
-    else
-      echo "Drupal is not installed, skipping reference database dump."
-    fi
+  ignoreTableContent: '(cache|cache_.*)'
 
   storage: 1G
   storageClassName: silta-shared

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -234,7 +234,7 @@ referenceData:
   # Update the reference data after deployments on the reference environment.
   updateAfterDeployment: true
 
-  ignoreTableContent: '(cache|cache_.*)'
+  ignoreTableContent: '(cache|cache_.*|sessions|watchdog)'
 
   storage: 1G
   storageClassName: silta-shared

--- a/silta/php.Dockerfile
+++ b/silta/php.Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for the Drupal container.
-FROM wunderio/drupal-php-fpm:v0.1.4
+FROM wunderio/drupal-php-fpm:v0.1.5
 
 COPY --chown=www-data:www-data . /app
 

--- a/silta/shell.Dockerfile
+++ b/silta/shell.Dockerfile
@@ -1,4 +1,4 @@
 # Dockerfile for the Drupal container.
-FROM wunderio/drupal-shell:v0.1.5
+FROM wunderio/drupal-shell:v0.1.6
 
 COPY --chown=www-data:www-data . /app

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -3,9 +3,3 @@
 #
 # See https://github.com/wunderio/charts/blob/master/drupal/values.yaml
 # for all possible options.
-
-elasticsearch:
-  enabled: true
-
-referenceData:
-  referenceEnvironment: 'feature/smaller-reference-data'

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -6,3 +6,6 @@
 
 elasticsearch:
   enabled: true
+
+referenceData:
+  referenceEnvironment: 'feature/smaller-reference-data'


### PR DESCRIPTION
This PR combines a few separate changes which are interrelated:
- Only use gdpr-dump when creating reference data
- Skip the content of cache tables when creating reference data
- Add all mounts to reference data, not just public files

For testing, I made this branch the `referenceEnvironment`, and forked it to a separate branch to test the import (the build is found here: https://circleci.com/gh/wunderio/drupal-project-k8s/7425)

Some follow-up changes:
- Modify gdpr-dump so that it can handle large tables without using a lot of memory.
- Maybe move the gdpr configuration back to a dedicated file. This would work for Drupal 7 since we are not using drush anymore and calling `mysqldump` directly.
- Move gdpr-dump's `mysqldump` to a dedicated command instead of overriding $PATH, so there is no confusion about what gets called when.
- Add support for limiting the number of items in a table when dumping reference data. The underlying php library supports it, it's just a matter of exposing this option in the configuration.