### PR TITLE
Allow robots.txt if the file exists

### DIFF
--- a/chart/templates/drupal-configmap-nginx.yaml
+++ b/chart/templates/drupal-configmap-nginx.yaml
@@ -332,7 +332,7 @@ data:
 
             location = /robots.txt {
                 add_header  Content-Type  text/plain;
-                return 200 "User-agent: *\nDisallow: /\n";
+                try_files $uri @drupal;
             }
 
             location = /radioactivity_node.php {
@@ -397,16 +397,6 @@ data:
             fastcgi_param SCRIPT_FILENAME $document_root/update.php;                                                                                       
             fastcgi_pass php;                                                                                                                              
         }                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     
-
-        location = /robots.txt {
-          access_log off;
-          {{- if not .Values.nginx.robotsTxt.allow }}
-            add_header Content-Type text/plain;
-            return 200 'User-agent: *\nDisallow: /';
-          {{- else }}
-            try_files $uri @drupal-no-args;
-          {{- end}}
-        } 
                                                                                                                                                                                                   
         location ~* ^/.well-known/ {                                                                                                                       
             allow all;                                                                                                                                     

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -89,10 +89,6 @@ nginx:
   noauthips:
     gke-internal: 10.0.0.0/8
 
-  # Robots txt file blocked by default
-  robotsTxt:
-    allow: false
-
   # Extra configuration to pass to nginx as a file
   extraConfig: |
 


### PR DESCRIPTION
robots.txt rewrite removed. When the site is not supposed to be accessed, one can set up basic auth.
https://feature-robots.drupal-project-k8s.silta.wdr.io/robots.txt