### PR TITLE
Feature/silta varnish

### DIFF
--- a/chart/templates/varnish-configmap-vcl.yaml
+++ b/chart/templates/varnish-configmap-vcl.yaml
@@ -18,8 +18,9 @@ data:
       .max_connections = 300;
 
       .probe = {
-        .interval  = 30s; # check the health of each backend every n seconds
-        .timeout   = 2s; # timing out after n seconds
+        .url       = "/robots.txt"; 
+        .interval  = 5s; # check the health of each backend every n seconds
+        .timeout   = 1s; # timing out after n seconds
         .window    = 5;  # If 3 out of the last 5 polls succeeded the backend is
         .threshold = 3;  # considered healthy, otherwise it will be marked as sick
       }

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -131,6 +131,9 @@ php:
     command: |
       if [ -f reference-data/db.sql.gz ]; then
 
+        echo "Dropping old database"
+        drush sql-drop -y
+
         echo "Importing reference database dump"
         cat reference-data/db.sql.gz | gunzip | drush sql-cli
 

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -3,3 +3,6 @@
 #
 # See https://github.com/wunderio/charts/blob/master/drupal/values.yaml
 # for all possible options.
+
+varnish:
+  enabled: true


### PR DESCRIPTION
This change probes `/robots.txt` file and does `drush sql-drop` before importing dump in post-install hook.

Fresh post-install with https://feature-silta-varnish.drupal-project-k8s.silta.wdr.io
Cleaned and rebuilt this twice in a row.