### PR TITLE
SLT-409: Use csi-rclone driver for ssh host keys volume

### DIFF
--- a/chart/templates/drupal-volumes.yaml
+++ b/chart/templates/drupal-volumes.yaml
@@ -89,17 +89,3 @@ spec:
 {{- end }}
 {{- end }}
 ---
-{{- if .Values.shell.enabled }}
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: {{ .Release.Name }}-shell-keys
-  labels:
-    {{- include "drupal.release_labels" . | nindent 4 }}
-spec:
-  accessModes:
-    - ReadWriteOnce
-  resources:
-    requests:
-      storage: 50M
-{{- end }}

--- a/chart/templates/shell-deployment.yaml
+++ b/chart/templates/shell-deployment.yaml
@@ -35,7 +35,7 @@ spec:
           - containerPort: 22
         volumeMounts:
         {{- include "drupal.volumeMounts" . | nindent 8 }}
-        - name: shell-keys
+        - name: sshd
           mountPath: /etc/ssh/keys
         resources:
           {{- .Values.php.resources | toYaml | nindent 10 }}
@@ -43,9 +43,9 @@ spec:
         {{- .Values.php.nodeSelector | toYaml | nindent 8 }}
       volumes:
       {{- include "drupal.volumes" . | nindent 6 }}
-      - name: shell-keys
+      - name: sshd
         persistentVolumeClaim:
-          claimName: {{ .Release.Name }}-shell-keys
+          claimName: {{ .Release.Name }}-sshd
       {{- include "drupal.imagePullSecrets" . | nindent 6 }}
 {{- end }}
 ---

--- a/chart/templates/shell-deployment.yaml
+++ b/chart/templates/shell-deployment.yaml
@@ -35,7 +35,7 @@ spec:
           - containerPort: 22
         volumeMounts:
         {{- include "drupal.volumeMounts" . | nindent 8 }}
-        - name: sshd
+        - name: ssh-keys
           mountPath: /etc/ssh/keys
         resources:
           {{- .Values.php.resources | toYaml | nindent 10 }}
@@ -43,9 +43,9 @@ spec:
         {{- .Values.php.nodeSelector | toYaml | nindent 8 }}
       volumes:
       {{- include "drupal.volumes" . | nindent 6 }}
-      - name: sshd
+      - name: ssh-keys
         persistentVolumeClaim:
-          claimName: {{ .Release.Name }}-sshd
+          claimName: {{ .Release.Name }}-ssh-keys
       {{- include "drupal.imagePullSecrets" . | nindent 6 }}
 {{- end }}
 ---

--- a/chart/templates/shell-volume.yaml
+++ b/chart/templates/shell-volume.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.shell.enabled }}
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ .Release.Name }}-sshd
+  labels:
+    name: {{ .Release.Name }}-sshd
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: {{ .Values.shell.mount.storageClassName }}
+  capacity:
+    storage: {{ .Values.shell.mount.storage }}
+  {{- if .Values.shell.mount.csiDriverName }}
+  csi:
+    driver: {{ .Values.shell.mount.csiDriverName }}
+    volumeHandle: {{ .Release.Name }}-reference-data
+    volumeAttributes:
+      remotePathSuffix: /{{ .Release.Namespace }}/{{ .Values.environmentName }}/sshd
+  {{- end }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Release.Name }}-sshd
+  labels:
+    {{- include "drupal.release_labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: {{ .Values.shell.mount.storageClassName }}
+  resources:
+    requests:
+      storage: {{ .Values.shell.mount.storage }}
+{{- if eq .Values.shell.mount.storageClassName "silta-shared" }}
+  selector:
+    matchLabels:
+      name: {{ .Release.Name }}-sshd
+{{- end }}
+{{- end }}

--- a/chart/templates/shell-volume.yaml
+++ b/chart/templates/shell-volume.yaml
@@ -2,9 +2,9 @@
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: {{ .Release.Name }}-sshd
+  name: {{ .Release.Name }}-ssh-keys
   labels:
-    name: {{ .Release.Name }}-sshd
+    name: {{ .Release.Name }}-ssh-keys
 spec:
   accessModes:
     - ReadWriteMany
@@ -16,14 +16,14 @@ spec:
     driver: {{ .Values.shell.mount.csiDriverName }}
     volumeHandle: {{ .Release.Name }}-reference-data
     volumeAttributes:
-      remotePathSuffix: /{{ .Release.Namespace }}/{{ .Values.environmentName }}/sshd
+      remotePathSuffix: /{{ .Release.Namespace }}/{{ .Values.environmentName }}/ssh-keys
       umask: "077"
   {{- end }}
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ .Release.Name }}-sshd
+  name: {{ .Release.Name }}-ssh-keys
   labels:
     {{- include "drupal.release_labels" . | nindent 4 }}
 spec:
@@ -36,6 +36,6 @@ spec:
 {{- if eq .Values.shell.mount.storageClassName "silta-shared" }}
   selector:
     matchLabels:
-      name: {{ .Release.Name }}-sshd
+      name: {{ .Release.Name }}-ssh-keys
 {{- end }}
 {{- end }}

--- a/chart/templates/shell-volume.yaml
+++ b/chart/templates/shell-volume.yaml
@@ -17,6 +17,7 @@ spec:
     volumeHandle: {{ .Release.Name }}-reference-data
     volumeAttributes:
       remotePathSuffix: /{{ .Release.Namespace }}/{{ .Values.environmentName }}/sshd
+      umask: "077"
   {{- end }}
 ---
 apiVersion: v1

--- a/chart/tests/private_files_test.yaml
+++ b/chart/tests/private_files_test.yaml
@@ -17,7 +17,7 @@ tests:
               claimName: RELEASE-NAME-private-files
       # Only one volume is defined.
       - hasDocuments:
-          count: 3
+          count: 2
         template: drupal-volumes.yaml
 
   - it: private files should work when enabled
@@ -47,7 +47,7 @@ tests:
       # There are two volumes defined.
       - template: drupal-volumes.yaml
         hasDocuments:
-          count: 5
+          count: 4
 
       # Private files are available for cron jobs.
       - template: drupal-cron.yaml

--- a/chart/tests/reference_data_test.yaml
+++ b/chart/tests/reference_data_test.yaml
@@ -14,7 +14,7 @@ tests:
     asserts:
     # Only public files PVC is defined.
     - hasDocuments:
-        count: 3
+        count: 2
       template: drupal-volumes.yaml
     - hasDocuments:
         count: 0
@@ -62,7 +62,7 @@ tests:
         foo: bar
     asserts:
     - hasDocuments:
-        count: 5
+        count: 4
       template: drupal-volumes.yaml
     - template: drupal-volumes.yaml
       documentIndex: 3
@@ -115,7 +115,7 @@ tests:
     asserts:
     - template: drupal-volumes.yaml
       hasDocuments:
-        count: 3
+        count: 2
     - template: reference-data-cron.yaml
       hasDocuments:
         count: 0
@@ -140,7 +140,7 @@ tests:
     asserts:
     - template: drupal-volumes.yaml
       hasDocuments:
-        count: 3
+        count: 2
     - template: reference-data-cron.yaml
       hasDocuments:
         count: 0
@@ -165,7 +165,7 @@ tests:
     asserts:
     - template: drupal-volumes.yaml
       hasDocuments:
-        count: 5
+        count: 4
     - contains:
         path: spec.template.spec.volumes
         content:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -200,9 +200,6 @@ php:
 shell:
   enabled: true
 
-  # Persistent storage for SSH fingerprint keys
-  storage: 1M
-
   # The docker image to be used. This is typically passed by your CI system using the --set parameter.
   image: 'you need to pass in a value for shell.image to your helm chart'
   # Values for the SSH gitAuth.
@@ -210,6 +207,12 @@ shell:
     # Project's git repository URL
     repositoryUrl: 'you need to pass in a value for repositoryUrl to your helm chart'
     apiToken: 'you need to pass in a value for shell.gitAuth.apiToken to your helm chart'
+
+  # Specifications for the volume where host keys are mounted.
+  mount:
+    storageClassName: silta-shared
+    csiDriverName: csi-rclone
+    storage: 1M
 
 # Configure the dynamically mounted volumes
 mounts:


### PR DESCRIPTION
- The SSH host keys are not affected by read performance, so it's fine to store them in object storage.
- Not using PersistentDisk volumes helps with the limits we are already hitting.
- I used a different volume name, otherwise we would get errors because changing the type of a volume is not allowed.
- A known side effect of this change is that all host keys will be recreated, prompting users to delete the entry in their known_hosts file.