### PR TITLE
Extra config for nginx server context

### DIFF
--- a/chart/templates/drupal-configmap.yaml
+++ b/chart/templates/drupal-configmap.yaml
@@ -319,6 +319,9 @@ data:
 
         {{ include "drupal.basicauth" . | indent 6}}
 
+        # Custom configuration gets included here
+        {{- .Values.nginx.serverExtraConfig | nindent 8 -}}
+
         {{- if .Values.mailhog.enabled }}
         location /mailhog {
 

--- a/chart/tests/drupal_configmap_test.yaml
+++ b/chart/tests/drupal_configmap_test.yaml
@@ -27,6 +27,18 @@ tests:
         path: data.php_ini
         pattern: 'upload_max_filesize = 123M'
 
+  - it: injects custom nginx configuration into server context
+    set:
+      nginx:
+        serverExtraConfig: |
+          location = /randomlocation {
+            return 418; 
+          }
+    asserts:
+    - matchRegex:
+        path: data.drupal_conf
+        pattern: "location = /randomlocation"
+
   - it: injects the nginx configuration
     set:
       nginx:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -89,6 +89,9 @@ nginx:
   noauthips:
     gke-internal: 10.0.0.0/8
 
+  # Extra configuration block in server context. 
+  serverExtraConfig: |
+
   # Extra configuration to pass to nginx as a file
   extraConfig: |
 


### PR DESCRIPTION
This allows having custom configuration (like `location {}`) in server context.
 ```
nginx:
  serverExtraConfig: |
    location = /randomlocation {
      return 418; 
    }
```

Diferrence from `nginx.extraConfig` is that `extraConfig` is mounted as `/etc/nginx/conf.d/misc.conf` and included into `http {}` context. It's used for different purposes.

Frontend chart has this, but slightly different solution - the config block goes above basic auth.
https://github.com/wunderio/charts/blob/master/frontend/templates/configmap.yaml#L102