### PR TITLE
SLT-382: Custom nginx redirects

### DIFF
--- a/chart/templates/drupal-configmap.yaml
+++ b/chart/templates/drupal-configmap.yaml
@@ -237,6 +237,8 @@ data:
         add_header                  Strict-Transport-Security max-age=31536000;
         add_header                  X-XSS-Protection '1; mode=block';
 
+        map_hash_bucket_size 128;
+
         map $uri $no_slash_uri {
             ~^/(?<no_slash>.*)$ $no_slash;
         }
@@ -307,10 +309,21 @@ data:
         https on;
     }
 
+    {{- if .Values.nginx.redirects }}
+    # Custom redirects
+    map '$scheme://$host$request_uri' $redirect_uri {
+        {{- .Values.nginx.redirects | nindent 8 -}}
+    }
+    {{- end }}
 
     server {
         server_name drupal;
         listen 80;
+
+        # Redirects to specified path if map returns anything
+        if ($redirect_uri) {
+    	    return 301 $redirect_uri;
+        }
 
         root /app/web;
         index index.php;

--- a/chart/templates/drupal-configmap.yaml
+++ b/chart/templates/drupal-configmap.yaml
@@ -310,9 +310,21 @@ data:
     }
 
     {{- if .Values.nginx.redirects }}
-    # Custom redirects
+    # Custom redirects with full url matching
     map '$scheme://$host$request_uri' $redirect_uri {
-        {{- .Values.nginx.redirects | nindent 8 -}}
+        {{- range .Values.nginx.redirects }}
+        {{- if contains "://" .from }}
+        {{ .from | squote }} {{ .to | squote }};
+        {{- end }}
+        {{- end }}
+    }
+    # Custom redirects with absolute path matching
+    map $request_uri $redirect_uri_local {
+        {{- range .Values.nginx.redirects }}
+        {{- if not ( contains "://" .from ) }}
+        {{ .from | squote }} {{ .to | squote }};
+        {{- end }}
+        {{- end }}
     }
     {{- end }}
 
@@ -323,6 +335,9 @@ data:
         # Redirects to specified path if map returns anything
         if ($redirect_uri) {
     	    return 301 $redirect_uri;
+        }
+        if ($redirect_uri_local) {
+    	    return 301 $redirect_uri_local;
         }
 
         root /app/web;

--- a/chart/templates/drupal-configmap.yaml
+++ b/chart/templates/drupal-configmap.yaml
@@ -332,6 +332,7 @@ data:
         server_name drupal;
         listen 80;
 
+        {{- if .Values.nginx.redirects }}
         # Redirects to specified path if map returns anything
         if ($redirect_uri) {
     	    return 301 $redirect_uri;
@@ -339,6 +340,7 @@ data:
         if ($redirect_uri_local) {
     	    return 301 $redirect_uri_local;
         }
+        {{- end }}
 
         root /app/web;
         index index.php;

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -9,3 +9,19 @@ varnish:
 
 elasticsearch:
   enabled: true
+
+exposeDomains:
+  - hostname: feature-redirects-exposedomain.drupal-project-k8s.silta.wdr.io
+    ssl:
+      enabled: true
+      issuer: letsencrypt-staging
+
+nginx:
+  redirects: |
+    /test1 / ;
+    /test2 /test2-redirect ;
+    http://feature-redirects.drupal-project-k8s.silta.wdr.io/test3 /test3-redirect ;
+    '~feature-redirects.drupal-project-k8s.silta.wdr.io/test4$' /test4-redirect ;
+    ~/test5$ /test5-redirect ;
+    ~/test6 /test6-redirect ;
+    http://feature-redirects-exposedomain.drupal-project-k8s.silta.wdr.io/test7 /test7-redirect ;

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -9,26 +9,3 @@ varnish:
 
 elasticsearch:
   enabled: true
-
-exposeDomains:
-  - hostname: feature-redirects-exposedomain.drupal-project-k8s.silta.wdr.io
-    ssl:
-      enabled: true
-      issuer: letsencrypt-staging
-
-nginx:
-  redirects:
-    - from: /test1 
-      to: /
-    - from: /test2 
-      to: /test2-redirect
-    - from: http://feature-redirects.drupal-project-k8s.silta.wdr.io/test3 
-      to: /test3-redirect
-    - from: '~://feature-redirects.drupal-project-k8s.silta.wdr.io/test4$' 
-      to: /test4-redirect
-    - from: ~/test5$ 
-      to: /test5-redirect
-    - from: ~/test6
-      to: /test-6-redirect
-    - from: http://feature-redirects-exposedomain.drupal-project-k8s.silta.wdr.io/test7 
-      to: /test7-redirect

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -17,11 +17,18 @@ exposeDomains:
       issuer: letsencrypt-staging
 
 nginx:
-  redirects: |
-    /test1 / ;
-    /test2 /test2-redirect ;
-    http://feature-redirects.drupal-project-k8s.silta.wdr.io/test3 /test3-redirect ;
-    '~feature-redirects.drupal-project-k8s.silta.wdr.io/test4$' /test4-redirect ;
-    ~/test5$ /test5-redirect ;
-    ~/test6 /test6-redirect ;
-    http://feature-redirects-exposedomain.drupal-project-k8s.silta.wdr.io/test7 /test7-redirect ;
+  redirects:
+    - from: /test1 
+      to: /
+    - from: /test2 
+      to: /test2-redirect
+    - from: http://feature-redirects.drupal-project-k8s.silta.wdr.io/test3 
+      to: /test3-redirect
+    - from: '~://feature-redirects.drupal-project-k8s.silta.wdr.io/test4$' 
+      to: /test4-redirect
+    - from: ~/test5$ 
+      to: /test5-redirect
+    - from: ~/test6
+      to: /test-6-redirect
+    - from: http://feature-redirects-exposedomain.drupal-project-k8s.silta.wdr.io/test7 
+      to: /test7-redirect


### PR DESCRIPTION
[nginx map directive](http://nginx.org/en/docs/http/ngx_http_map_module.html) is being leveraged for this task. The list of defined redirects is matched with current url and assigned a variable to custom `$redirect_uri` variable in case it does match. Mapping is done outside of `server` scope, so that full url (with protocol and domain name) can be matched too. Then, the `$redirect_uri` variable is used for actual redirection in `server` scope.

There are following test redirects:
```
nginx:
  redirects: |
    /test1 / ;
    /test2 /test2-redirect ;
    http://feature-redirects.drupal-project-k8s.silta.wdr.io/test3 /test3-redirect ;
    '://~feature-redirects.drupal-project-k8s.silta.wdr.io/test4$' /test4-redirect ;
    ~/test5$ /test5-redirect ;
    ~/test6 /test6-redirect ;
    http://feature-redirects-exposedomain.drupal-project-k8s.silta.wdr.io/test7 /test7-redirect ;
```

---

And this is the result for each of them:

 - works, uses absolute path (`/test`, exact matching):
```
➜  ~ curl https://feature-redirects.drupal-project-k8s.silta.wdr.io/test1 -IL
HTTP/1.1 301 Moved Permanently
Location: https://feature-redirects.drupal-project-k8s.silta.wdr.io/
```

 - works, uses absolute path (`/test`, exact matching):
```
➜  ~ curl https://feature-redirects.drupal-project-k8s.silta.wdr.io/test2 -IL 
HTTP/1.1 301 Moved Permanently
Location: https://feature-redirects.drupal-project-k8s.silta.wdr.io/test2-redirect
```

 - works, full url matching
```
➜  ~ curl https://feature-redirects.drupal-project-k8s.silta.wdr.io/test3 -IL
HTTP/1.1 301 Moved Permanently
Location: https://feature-redirects.drupal-project-k8s.silta.wdr.io/test3-redirect
```
 - XX ~works~, full url matching, protocol as wildcard
```
➜  ~ curl https://feature-redirects.drupal-project-k8s.silta.wdr.io/test4 -IL
HTTP/1.1 301 Moved Permanently
Location: https://feature-redirects.drupal-project-k8s.silta.wdr.io/test4-redirect
```

 - Exact path (all exposeDomains)
```
➜  ~ curl https://feature-redirects.drupal-project-k8s.silta.wdr.io/test5 -IL
HTTP/1.1 301 Moved Permanently
Location: https://feature-redirects.drupal-project-k8s.silta.wdr.io/test5-redirect

➜  ~ curl https://feature-redirects.drupal-project-k8s.silta.wdr.io/test5/subpath -IL
HTTP/2 404
```

 - Reacts to all subpaths too:
```
➜  ~ curl https://feature-redirects.drupal-project-k8s.silta.wdr.io/test6 -I
HTTP/1.1 301 Moved Permanently
Location: https://feature-redirects.drupal-project-k8s.silta.wdr.io/test-6-redirect

➜  ~ curl https://feature-redirects.drupal-project-k8s.silta.wdr.io/test6/subpath -I
HTTP/1.1 301 Moved Permanently
Location: https://feature-redirects.drcupal-project-k8s.silta.wdr.io/test-6-redirect
```

 - Only reacts to specific domain
```
➜  ~ curl https://feature-redirects.drupal-project-k8s.silta.wdr.io/test7 -Ik 
HTTP/2 404 

➜  ~ curl https://feature-redirects-exposedomain.drupal-project-k8s.silta.wdr.io/test7 -Ik
HTTP/1.1 301 Moved Permanently
Location: https://feature-redirects-exposedomain.drupal-project-k8s.silta.wdr.io/test7-redirect
```