### PR TITLE
SLT-385: Update subcharts for the Drupal chart

### DIFF
--- a/chart/Chart.lock
+++ b/chart/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: mariadb
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 4.4.2
+  version: 7.3.7
 - name: memcached
   repository: https://kubernetes-charts.storage.googleapis.com/
   version: 3.0.2
@@ -11,5 +11,5 @@ dependencies:
 - name: elasticsearch
   repository: https://helm.elastic.co
   version: 7.4.1
-digest: sha256:be9ac822ffbfd2bbc81594e113698a8911f9ea89f285aff7d7444845b5e8f7fc
-generated: "2020-01-22T10:29:48.720252+01:00"
+digest: sha256:b2d99beaa15e766318618c9cff525bcf7e63956795d73b860b666e869fc68db2
+generated: "2020-02-05T15:04:20.126058+01:00"

--- a/chart/Chart.lock
+++ b/chart/Chart.lock
@@ -4,12 +4,12 @@ dependencies:
   version: 7.3.7
 - name: memcached
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 3.0.2
+  version: 3.2.2
 - name: mailhog
   repository: https://codecentric.github.io/helm-charts
   version: 3.1.2
 - name: elasticsearch
   repository: https://helm.elastic.co
   version: 7.5.2
-digest: sha256:725e6485427b1146366d5ad7f56a3d8d015e572eccbfbed8c9c79923d764612c
-generated: "2020-02-05T15:19:20.071944+01:00"
+digest: sha256:8e5b8d9b826b1ec67520e5bc08df21310a6d85b05cf15bd7330fbf7a32888f0e
+generated: "2020-02-05T15:21:57.470353+01:00"

--- a/chart/Chart.lock
+++ b/chart/Chart.lock
@@ -7,9 +7,9 @@ dependencies:
   version: 3.0.2
 - name: mailhog
   repository: https://codecentric.github.io/helm-charts
-  version: 3.0.1
+  version: 3.1.2
 - name: elasticsearch
   repository: https://helm.elastic.co
   version: 7.4.1
-digest: sha256:b2d99beaa15e766318618c9cff525bcf7e63956795d73b860b666e869fc68db2
-generated: "2020-02-05T15:04:20.126058+01:00"
+digest: sha256:63a964de781e47b48fe7216e107f040bb8411899eb6466d5873af7d22bc5e1b7
+generated: "2020-02-05T15:17:19.269001+01:00"

--- a/chart/Chart.lock
+++ b/chart/Chart.lock
@@ -10,6 +10,6 @@ dependencies:
   version: 3.1.2
 - name: elasticsearch
   repository: https://helm.elastic.co
-  version: 7.4.1
-digest: sha256:63a964de781e47b48fe7216e107f040bb8411899eb6466d5873af7d22bc5e1b7
-generated: "2020-02-05T15:17:19.269001+01:00"
+  version: 7.5.2
+digest: sha256:725e6485427b1146366d5ad7f56a3d8d015e572eccbfbed8c9c79923d764612c
+generated: "2020-02-05T15:19:20.071944+01:00"

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -16,6 +16,6 @@ dependencies:
   repository: https://codecentric.github.io/helm-charts
   condition: mailhog.enabled
 - name: elasticsearch
-  version: 7.4.1
+  version: 7.5.x
   repository: https://helm.elastic.co
   condition: elasticsearch.enabled

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -12,7 +12,7 @@ dependencies:
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: memcached.enabled
 - name: mailhog
-  version: 3.0.1
+  version: 3.1.x
   repository: https://codecentric.github.io/helm-charts
   condition: mailhog.enabled
 - name: elasticsearch

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -8,7 +8,7 @@ dependencies:
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: mariadb.enabled,drupal.mariadb.enabled,global.mariadb.enabled
 - name: memcached
-  version: 3.0.2
+  version: 3.2.x
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: memcached.enabled
 - name: mailhog

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -4,7 +4,7 @@ version: 0.3.0
 apiVersion: v2
 dependencies:
 - name: mariadb
-  version: 4.4.2
+  version: 7.3.x
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: mariadb.enabled,drupal.mariadb.enabled,global.mariadb.enabled
 - name: memcached

--- a/chart/templates/_overrides.tpl
+++ b/chart/templates/_overrides.tpl
@@ -6,14 +6,14 @@ Override templates from subcharts.
 The elasticsearch chart uses an incompatible naming scheme,
 we make it compatible by overriding the following templates.
 */}}
-{{- define "uname" -}}
+{{- define "elasticsearch.uname" -}}
 {{ .Release.Name }}-es
 {{- end }}
 
-{{- define "masterService" -}}
+{{- define "elasticsearch.masterService" -}}
 {{ .Release.Name }}-es
 {{- end }}
 
-{{- define "endpoints" -}}
+{{- define "elasticsearch.endpoints" -}}
 {{ .Release.Name }}-es-0
 {{- end -}}


### PR DESCRIPTION
- Subchart versions are hard-coded, we should only set the minor version (specific versions belong in the lock file).
- There are no major version updates of the underlying updates, but it's still good to keep things up to date.