### PR TITLE
Use the php post_max_size for the nginx client_max_body_size for consistency.

### DIFF
--- a/chart/templates/drupal-configmap.yaml
+++ b/chart/templates/drupal-configmap.yaml
@@ -208,7 +208,8 @@ data:
         sendfile                    on;
         client_body_timeout         60s;
         client_header_timeout       60s;
-        client_max_body_size        32m;
+        ## This value is set to be identical with PHP's post_max_size.
+        client_max_body_size        {{ .Values.php.php_ini.post_max_size }};
         client_body_buffer_size     16k;
         client_header_buffer_size   4k;
         large_client_header_buffers 8 16K;


### PR DESCRIPTION
Tested this here: https://feature-configurable-nginx-bod07.drupal-project-k8s.silta.wdr.io/

Uploaded a 37MB file, and it was uploaded successfully.