### PR TITLE
SLT-460: fix the php.ini location

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -23,14 +23,6 @@ ports:
   readOnly: true
   subPath: php_ini
 - name: config
-  mountPath: /etc/php7/php-fpm.conf
-  readOnly: true
-  subPath: php-fpm_conf
-- name: config
-  mountPath: /etc/php7/php-fpm.d/www.conf
-  readOnly: true
-  subPath: www_conf
-- name: config
   mountPath: /app/web/sites/default/settings.silta.php
   readOnly: true
   subPath: settings_silta_php

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -19,7 +19,7 @@ ports:
 {{- end }}
 {{- end }}
 - name: config
-  mountPath: /etc/php7/php.ini
+  mountPath: /usr/local/etc/php/conf.d/silta.ini
   readOnly: true
   subPath: php_ini
 - name: config

--- a/chart/templates/drupal-configmap.yaml
+++ b/chart/templates/drupal-configmap.yaml
@@ -154,30 +154,6 @@ data:
     [igbinary]
     igbinary.compact_strings=1
 
-
-  php-fpm_conf: |
-    [global]
-    error_log = /proc/self/fd/2
-    log_level = {{ .Values.php.php_ini.loglevel }} ; Possible Values: alert, error, warning, notice, debug
-    daemonize = no
-    include=/etc/php7/php-fpm.d/*.conf
-
-  www_conf: |
-    [www]
-    listen = [::]:9000
-    user = www-data
-    group = www-data
-    pm = ondemand
-    pm.max_children = 100
-    pm.start_servers = 5
-    pm.min_spare_servers = 5
-    pm.max_spare_servers = 20
-    pm.process_idle_timeout = 60s
-    pm.max_requests = 500
-    access.log = /proc/self/fd/2
-    catch_workers_output = yes
-    clear_env = no
-
   nginx_conf: |
     user                            nginx;
     worker_processes                auto;

--- a/chart/templates/drupal-configmap.yaml
+++ b/chart/templates/drupal-configmap.yaml
@@ -13,114 +13,34 @@ data:
 
   php_ini: |
     [PHP]
-    engine = On
     short_open_tag = Off
     precision = -1
-    output_buffering = 4096
-    zlib.output_compression = Off
-    implicit_flush = Off
-    unserialize_callback_func =
     serialize_precision = -1
-    disable_classes =
     realpath_cache_size = 32k
     realpath_cache_ttl = 120
-    zend.enable_gc = On
-    expose_php = Off
     max_execution_time = 60
     max_input_time = 60
     memory_limit = 256M
     error_reporting = E_ALL
-    display_errors = 0
-    display_startup_errors = 0
-    log_errors = 1
     log_errors_max_len = 10240
-    ignore_repeated_errors = Off
-    ignore_repeated_source = Off
     report_memleaks = On
-    track_errors = 0
-    html_errors = On
     variables_order = EGPCS
     request_order = GP
-    register_argc_argv = Off
-    auto_globals_jit = On
     post_max_size = {{ .Values.php.php_ini.post_max_size }}
-    auto_prepend_file =
-    auto_append_file =
-    default_mimetype = "text/html"
-    default_charset = "UTF-8"
-    doc_root =
-    user_dir =
-    enable_dl = Off
-    cgi.fix_pathinfo = 0
-    file_uploads = On
     upload_max_filesize = {{ .Values.php.php_ini.upload_max_filesize }}
-    max_file_uploads = 20
-    allow_url_fopen = On
-    allow_url_include = Off
-    default_socket_timeout = 60
-
-    [CLI Server]
-    cli_server.color = On
 
     [Date]
     date.timezone = Europe/Helsinki
 
-    [Pdo_mysql]
-    pdo_mysql.cache_size = 2000
-    pdo_mysql.default_socket =
-
     [mail function]
     mail.add_x_header = Off
 
-    [SQL]
-    sql.safe_mode = Off
-
-    [MySQLi]
-    mysqli.max_persistent = -1
-    mysqli.allow_persistent = On
-    mysqli.max_links = -1
-    mysqli.cache_size = 2000
-    mysqli.default_port = 3306
-    mysqli.reconnect = Off
-
-    [mysqlnd]
-    mysqlnd.collect_statistics = On
-    mysqlnd.collect_memory_statistics = Off
-
-    [PostgreSQL]
-    pgsql.allow_persistent = On
-    pgsql.auto_reset_persistent = Off
-    pgsql.max_persistent = -1
-    pgsql.max_links = -1
-    pgsql.ignore_notice = 0
-    pgsql.log_notice = 0
-
-    [bcmath]
-    bcmath.scale = 0
-
     [Session]
-    session.save_handler = files
-    session.save_path = /tmp
-    session.use_strict_mode = 0
-    session.use_cookies = 1
-    session.use_only_cookies = 1
-    session.name = PHPSESSID
-    session.auto_start = 0
     session.cookie_lifetime = 0
-    session.cookie_path = /
-    session.cookie_domain =
     session.cookie_httponly = 1
     session.serialize_handler = php_binary
-    session.gc_probability = 1
     session.gc_divisor = 10000
     session.gc_maxlifetime = 1440
-    session.referer_check =
-    session.cache_limiter = nocache
-    session.cache_expire = 180
-    session.use_trans_sid = 0
-    session.hash_function = 0
-    session.hash_bits_per_character = 5
-    url_rewriter.tags = "a=href,area=href,frame=src,input=src,form=fakeentry"
 
     [Assertion]
     zend.assertions = -1
@@ -128,27 +48,13 @@ data:
     [mbstring]
     mbstring.internal_encoding = UTF-8
 
-    [Tidy]
-    tidy.clean_output = Off
-
-    [soap]
-    soap.wsdl_cache_enabled = 1
-    soap.wsdl_cache_dir = "/tmp"
-    soap.wsdl_cache_ttl = 86400
-    soap.wsdl_cache_limit = 5
-
-    [ldap]
-    ldap.max_links = -1
-
     [opcache]
     opcache.enable = 1
     opcache.enable_cli = 0
     opcache.memory_consumption = 128
     opcache.interned_strings_buffer = 32
-
     opcache.use_cwd = ${PHP_OPCACHE_USE_CWD}
     opcache.validate_timestamps = 0
-    opcache.enable_file_override = 1
     opcache.log_verbosity_level = 2
 
     [igbinary]

--- a/chart/tests/drupal_configmap_test.yaml
+++ b/chart/tests/drupal_configmap_test.yaml
@@ -13,14 +13,9 @@ tests:
   - it: injects the php.ini values
     set:
       php.php_ini:
-        loglevel: 'debug'
         upload_max_filesize: '123M'
         post_max_size: '321M'
     asserts:
-    - matchRegex:
-        path: data.php-fpm_conf
-        pattern: 'log_level = debug'
-    - matchRegex:
         path: data.php_ini
         pattern: 'post_max_size = 321M'
     - matchRegex:


### PR DESCRIPTION
There's currently a mismatch between the location where we mount our php.ini configuration, and the expected location from the base image. Things still works though, although these configuration files did nothing. This PR fixes the main file with our overrides, removes additional files that were not needed, and also removes unnecessary overrides of the underlying defaults.

We should also revise the remaining overrides. There are some that we probably want to make configurable (like `memory_limit`), and some where we should consider why they should differ from the defaults and document that.