### PR TITLE
Create reference files snapshot with rsync

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -295,8 +295,8 @@ if [ -f reference-data/db.sql.gz ]; then
   {{ range $index, $mount := .Values.mounts -}}
   {{- if eq $mount.enabled true -}}
   if [ -d "reference-data/{{ $index }}" ]; then
-    echo "Importing public files"
-    rsync -r "reference-data/{{ $index}}/" "{{ $mount.mountPath }}"
+    echo "Importing {{ $index }} files"
+    rsync -r "reference-data/{{ $index }}/" "{{ $mount.mountPath }}"
   fi
   {{- end -}}
   {{- end }}

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -272,6 +272,7 @@ if [[ "$(drush status --fields=bootstrap)" = *'Successful'* ]] ; then
     {{ range $folderIndex, $folderPattern := $.Values.referenceData.ignoreFolders -}}
     --exclude="{{ $folderPattern }}" \
     {{ end -}}
+    --delete
     $REFERENCE_DATA_LOCATION/{{ $index }}
   {{- end -}}
   {{- end }}

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -243,9 +243,6 @@ if [[ "$(drush status --fields=bootstrap)" = *'Successful'* ]] ; then
 
   REFERENCE_DATA_LOCATION="/app/reference-data"
 
-  # Clean up existing reference data.
-  rm -f $REFERENCE_DATA_LOCATION/*
-
   # Figure out which tables to skip.
   IGNORE_TABLES=""
   IGNORED_TABLES=""

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -268,7 +268,7 @@ if [[ "$(drush status --fields=bootstrap)" = *'Successful'* ]] ; then
   echo "Dump reference files for {{ $index }} volume."
 
   # Update reference data files.
-  rsync -rvu "{{ $mount.mountPath }}" \
+  rsync -rvu "{{ $mount.mountPath }}/" \
     --max-size="{{ $.Values.referenceData.maxFileSize }}" \
     {{ range $folderIndex, $folderPattern := $.Values.referenceData.ignoreFolders -}}
     --exclude="{{ $folderPattern }}" \

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -267,16 +267,14 @@ if [[ "$(drush status --fields=bootstrap)" = *'Successful'* ]] ; then
   # File backup for {{ $index }} volume.
   echo "Dump reference files for {{ $index }} volume."
 
-  # We need relative path to create a tarball.
-  relativeMountPath=$(realpath --relative-base . "{{ $mount.mountPath }}")
+  # Update reference data files.
+  rsync -rvu "{{ $mount.mountPath }}" \
+    --max-size="{{ $.Values.referenceData.maxFileSize }}" \
+    {{ range $folderIndex, $folderPattern := $.Values.referenceData.ignoreFolders -}}
+    --exclude="{{ $folderPattern }}" \
+    {{ end -}}
+    $REFERENCE_DATA_LOCATION/{{ $index }}
 
-  # Get a list of matching files, and put them in a tarball.
-  find "$relativeMountPath" \
-    -regextype posix-extended \
-    -type f \
-    -size -"{{ $.Values.referenceData.maxFileSize }}" \
-    -not -regex "{{ $.Values.referenceData.ignoreFiles }}" \
-    -exec echo '"{}"' \; | xargs tar cPf $REFERENCE_DATA_LOCATION/{{ $index }}.tar
   {{- end -}}
   {{- end }}
 

--- a/chart/templates/post-release.yaml
+++ b/chart/templates/post-release.yaml
@@ -21,7 +21,8 @@ spec:
         {{- include "drupal.php-container" . | nindent 8 }}
         command: ["/bin/bash", "-c"]
         args:
-        - {{ include "drupal.post-release-command" . | quote }}
+        - |
+            {{ include "drupal.post-release-command" . | nindent 12 }}
         volumeMounts:
           - name: config
             mountPath: /etc/my.cnf.d/gdpr-dump.cnf

--- a/chart/tests/drupal_postinstall_test.yaml
+++ b/chart/tests/drupal_postinstall_test.yaml
@@ -26,7 +26,7 @@ tests:
       - matchRegex:
           path: spec.template.spec.containers[0].args[0]
           pattern: 'foo'
-      - notMatchRegex:
+      - matchRegex:
           path: spec.template.spec.containers[0].args[0]
           pattern: 'bar'
 

--- a/chart/tests/drupal_postinstall_test.yaml
+++ b/chart/tests/drupal_postinstall_test.yaml
@@ -38,7 +38,7 @@ tests:
     asserts:
       - matchRegex:
           path: spec.template.spec.containers[0].args[0]
-          pattern: 'REFERENCE_DATA_LOCATION'
+          pattern: 'Dump reference database'
 
   - it: doesn't exports reference data after deployments if disabled
     set:
@@ -49,7 +49,7 @@ tests:
     asserts:
       - notMatchRegex:
           path: spec.template.spec.containers[0].args[0]
-          pattern: 'REFERENCE_DATA_LOCATION'
+          pattern: 'Dump reference database'
 
   - it: sets environment variables correctly
     set:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -268,8 +268,12 @@ referenceData:
 
   ignoreTableContent: '(cache|cache_.*|sessions|watchdog)'
 
-  # Matching files will not be included in reference data.
-  ignoreFiles: '.*/(css|js|styles)/.*'
+  # Matching folders will not be included in reference data.
+  ignoreFolders:
+    - css
+    - js
+    - styles
+    - languages
 
   # Files larger than this will not be included in reference data.
   maxFileSize: '5M'

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -139,35 +139,9 @@ php:
   # Post-installation hook.
   # This is run every time a new environment is created.
   postinstall:
-    command: |
-      if [ -f reference-data/db.sql.gz ]; then
-
-        echo "Dropping old database"
-        drush sql-drop -y
-
-        echo "Importing reference database dump"
-        cat reference-data/db.sql.gz | gunzip | drush sql-cli
-
-        if [ -f reference-data/public_files.tar.gz ]; then
-          # Deprecated location, only there for backward compatibility.
-          echo "Importing public files"
-          tar xf reference-data/public_files.tar.gz
-        else
-          if [ -f reference-data/public-files.tar ]; then
-            echo "Importing public files"
-            tar xf reference-data/public-files.tar
-          fi
-        fi
-
-        drush cr
-        drush updatedb -y
-        if [ -f $DRUPAL_CONFIG_PATH/core.extension.yml ]; then
-          drush config-import -y
-          drush cr
-        fi
-      else
-        printf "\e[33mNo reference data found, please install Drupal or import a database dump. See release information for instructions.\e[0m\n"
-      fi
+    # Specify any particular commands to be executed after an environment is installed.
+    # If referenced data is enabled, it gets imported before this step.
+    command: ""
     resources:
       requests:
         cpu: 500m


### PR DESCRIPTION
A project recently ran into issues with large amounts of files and reference data, and we've had issues in general where taking the snapshots was too slow. 

What this changes
- Reference data files are stored as they are, rather than creating a tarball. This enables us to keep existing file, and to just transfer incremental changes.
- Rather than a regexp for files to be excluded, we provide a list of folders that are excluded. This option wasn't used by any project so far. 
- By making the code that imports reference data dynamic, we can remove it from the post-install hook. The post-install command is currently empty, but could be used for things like indexing content into elasticsearch.
- The post-upgrade hook gets run after post-install too, further reducing duplicate code.

Since the location of the reference data changes (tarball vs folder), we need to take care of existing projects. The reference data would get exported correctly with the next deployment, but it would make sense to proactively update the master releases to make sure everything is up to date and new releases work correctly.