### PR TITLE
Feature/networkpolicy

### DIFF
--- a/chart/templates/networkpolicy.yaml
+++ b/chart/templates/networkpolicy.yaml
@@ -1,0 +1,30 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ .Release.Name }}-np
+  labels:
+    {{- include "drupal.release_labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "drupal.release_labels" . | nindent 6 }}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          name: {{ .Release.Namespace }}
+    - namespaceSelector:
+        matchLabels:
+          name: silta-cluster
+    {{- if (index .Values "networkPolicy") }}
+    {{- if (index .Values.networkPolicy "allowNamespaces") }}
+    {{- range $index, $namespace := .Values.networkPolicy.allowNamespaces }}
+    - namespaceSelector:
+        matchLabels:
+          name: {{ $namespace }}
+    {{- end }}
+    {{- end }}
+    {{- end }}
+

--- a/chart/tests/networkpolicy_test.yaml
+++ b/chart/tests/networkpolicy_test.yaml
@@ -1,0 +1,12 @@
+suite: network policy
+templates:
+  - networkpolicy.yaml
+tests:
+  - it: selected namespaces are added to whitelist
+    set:
+      networkPolicy.allowNamespaces: ['foo']
+    asserts:
+      - equal:
+          path: spec.ingress[0].from[2].namespaceSelector.matchLabels.name
+          value: "foo"
+      

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -53,6 +53,13 @@
         "enabled": { "type": "boolean" }
       }
     },
+    "networkPolicy": { 
+      "type": "object",
+      "properties": {
+        "allowNamespaces": { "type": "array" }
+      },
+      "additionalProperties": false
+    },
     "exposeDomains": { "type": ["array","object"], "items": { "type": "object"}},
     "domainPrefixes": { "type": "array", "items": { "type": "string"}},
     "ssl": { "type": "object" },

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -36,6 +36,11 @@ autoscaling:
         name: cpu
         targetAverageUtilization: 80
 
+# Whitelist namespaces / projects that can connect containers in your project release.
+# silta-cluster and your current namespace is always whitelisted.
+# networkPolicy:
+#   allowNamespaces: ['silta-cluster']
+
 # Domain names that will be mapped to this deployment.
 # Example of exposing 2 additional domains for this deployment, each with its own certificate
 # Note that the key is only used for documentation purposes.


### PR DESCRIPTION
### DO NOT MERGE, SOME OF THIS WILL BE ADDED TO LIBRARY SUBCHART

Adds a networkpolicy resource to each pod in release that denies connections from all namespaces but `silta-cluster` and the current.

Configuration definition is still open for debate if there are any suggestions (i.e. ingress vs egress if we want to go there)
```
networkPolicy:
  allowNamespaces: ['silta-cluster']
```