### PR TITLE
gitAuth key stored in secret

### DIFF
--- a/chart/templates/shell-deployment.yaml
+++ b/chart/templates/shell-deployment.yaml
@@ -27,7 +27,10 @@ spec:
         env:
         {{- include "drupal.env" . | indent 8 }}
         - name: GITAUTH_API_TOKEN
-          value: "{{ .Values.shell.gitAuth.apiToken }}"
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Release.Name }}-secrets-shell
+              key: gitAuth.apiToken
         - name: GITAUTH_REPOSITORY_URL
           value: "{{ .Values.shell.gitAuth.repositoryUrl }}"
         - name: DRUSH_OPTIONS_URI

--- a/chart/templates/shell-secret.yaml
+++ b/chart/templates/shell-secret.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-secrets-shell
+  labels:
+    {{- include "drupal.release_labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{- if .Values.shell.gitAuth.apiToken }}
+  gitAuth.apiToken: "{{ .Values.shell.gitAuth.apiToken | b64enc }}"
+  {{- end }}

--- a/chart/tests/shell_deployment_test.yaml
+++ b/chart/tests/shell_deployment_test.yaml
@@ -35,15 +35,10 @@ tests:
     set:
       shell.enabled: true
       shell.gitAuth.repositoryUrl: 'foo'
-      shell.gitAuth.apiToken: 'bar'
     asserts:
       - contains:
           path: spec.template.spec.containers[0].env
           content:
             name: GITAUTH_REPOSITORY_URL
             value: foo
-      - contains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: GITAUTH_API_TOKEN
-            value: bar
+


### PR DESCRIPTION
Stores gitAuth token  in a secret.

- ssh connection still works;
- Environment variables reference the secret instead of showing it in pod info:
  ```
  PROJECT_NAME:            drupal-project-k8s
  ENVIRONMENT_NAME:        feature/gitauth-key-secret
  [..]
  GITAUTH_API_TOKEN:       <set to the key 'gitAuth.apiToken' in secret 'feature-gitauth-key-secret-secrets-shell'>  Optional: false 
  ```