### PR TITLE
Run database and file import in parallel.

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -285,16 +285,19 @@ if [ -f /app/reference-data/db.sql.gz ]; then
   drush sql-drop -y
 
   echo "Importing reference database dump"
-  cat /app/reference-data/db.sql.gz | gunzip | drush sql-cli
+  cat /app/reference-data/db.sql.gz | gunzip | drush sql-cli &
 
   {{ range $index, $mount := .Values.mounts -}}
   {{- if eq $mount.enabled true -}}
   if [ -d "/app/reference-data/{{ $index }}" ]; then
     echo "Importing {{ $index }} files"
-    rsync -r "/app/reference-data/{{ $index }}/" "{{ $mount.mountPath }}"
+    rsync -r "/app/reference-data/{{ $index }}/" "{{ $mount.mountPath }}" &
   fi
   {{ end -}}
   {{- end }}
+
+  # Wait for imports to complete.
+  wait
 else
   printf "\e[33mNo reference data found, please install Drupal or import a database dump. See release information for instructions.\e[0m\n"
 fi


### PR DESCRIPTION
For our test project there are no perceivable improvement, because we have so few files that the import takes almost no time compared to importing the db dump. The deployment log does show both commands running at the same time though. This should speed things up quite a bit for projects with a lot of content.