### PR TITLE
Start copying reference data files right away

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -214,6 +214,10 @@ done
 {{- define "drupal.post-release-command" -}}
 set -e
 
+{{ if and .Release.IsInstall .Values.referenceData.enabled -}}
+{{ include "drupal.import-reference-files" . }}
+{{- end }}
+
 {{ include "drupal.wait-for-db-command" . }}
 {{ if .Values.elasticsearch.enabled }}
 {{ include "drupal.wait-for-elasticsearch-command" . }}
@@ -222,12 +226,15 @@ set -e
 {{ if .Release.IsInstall }}
 touch /app/web/sites/default/files/_installing
 {{- if .Values.referenceData.enabled }}
-{{ include "drupal.import-reference-data" . }}
+{{ include "drupal.import-reference-db" . }}
 {{- end }}
 {{ .Values.php.postinstall.command}}
 rm /app/web/sites/default/files/_installing
 {{ end }}
 {{ .Values.php.postupgrade.command}}
+
+# Wait for background imports to complete.
+wait
 
 {{- if and .Values.referenceData.enabled .Values.referenceData.updateAfterDeployment }}
 {{- if eq .Values.referenceData.referenceEnvironment .Values.environmentName }}
@@ -278,15 +285,19 @@ else
 fi
 {{- end }}
 
-{{- define "drupal.import-reference-data" -}}
+{{- define "drupal.import-reference-db" -}}
 if [ -f /app/reference-data/db.sql.gz ]; then
-
   echo "Dropping old database"
   drush sql-drop -y
 
   echo "Importing reference database dump"
-  cat /app/reference-data/db.sql.gz | gunzip | drush sql-cli &
+  cat /app/reference-data/db.sql.gz | gunzip | drush sql-cli
+else
+  printf "\e[33mNo reference data found, please install Drupal or import a database dump. See release information for instructions.\e[0m\n"
+fi
+{{- end }}
 
+{{- define "drupal.import-reference-files" -}}
   {{ range $index, $mount := .Values.mounts -}}
   {{- if eq $mount.enabled true -}}
   if [ -d "/app/reference-data/{{ $index }}" ]; then
@@ -295,10 +306,4 @@ if [ -f /app/reference-data/db.sql.gz ]; then
   fi
   {{ end -}}
   {{- end }}
-
-  # Wait for imports to complete.
-  wait
-else
-  printf "\e[33mNo reference data found, please install Drupal or import a database dump. See release information for instructions.\e[0m\n"
-fi
 {{- end }}

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -219,15 +219,17 @@ set -e
 {{- end }}
 
 {{ include "drupal.wait-for-db-command" . }}
-{{ if .Values.elasticsearch.enabled }}
-{{ include "drupal.wait-for-elasticsearch-command" . }}
-{{ end }}
 
 {{ if .Release.IsInstall }}
 touch /app/web/sites/default/files/_installing
 {{- if .Values.referenceData.enabled }}
 {{ include "drupal.import-reference-db" . }}
 {{- end }}
+
+{{ if .Values.elasticsearch.enabled }}
+{{ include "drupal.wait-for-elasticsearch-command" . }}
+{{ end }}
+
 {{ .Values.php.postinstall.command}}
 rm /app/web/sites/default/files/_installing
 {{ end }}


### PR DESCRIPTION
We recently sped things up by importing files in parallel with the reference database dump, but we can already do that before the database and elasticsearch are ready, and we can also continue while the configuration import and other drush commands are executing. 