### PR TITLE
Introducing silta-ingress: allow

### DIFF
--- a/charts/drupal/Chart.yaml
+++ b/charts/drupal/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: drupal
-version: 0.3.20
+version: 0.3.21
 apiVersion: v2
 dependencies:
 - name: mariadb

--- a/charts/drupal/templates/drupal-deployment.yaml
+++ b/charts/drupal/templates/drupal-deployment.yaml
@@ -15,6 +15,7 @@ spec:
       labels:
         {{- include "drupal.release_labels" . | nindent 8 }}
         deployment: drupal
+        silta-ingress: allow
       annotations:
         # We use a checksum to redeploy the pods when the configMap changes.
         configMap-checksum: {{ include (print $.Template.BasePath "/drupal-configmap.yaml") . | sha256sum }}

--- a/charts/drupal/templates/network-policy.yaml
+++ b/charts/drupal/templates/network-policy.yaml
@@ -1,6 +1,0 @@
-# Allow access to drupal or varnish pods from the ingress in the silta-cluster namespace
-{{- $id := "allow-ingress" -}}
-{{- $podSelectors := dict "silta-ingress" "allow" -}}
-{{- $from := list (dict "namespaceSelector" (dict "matchLabels" (dict "name" "silta-cluster"))) -}}
-{{- $params := mergeOverwrite . (dict "id" $id "additionalPodSelectors" $podSelectors "from" $from) -}}
-{{ include "silta-release.networkPolicy" $params }}

--- a/charts/drupal/templates/network-policy.yaml
+++ b/charts/drupal/templates/network-policy.yaml
@@ -1,6 +1,6 @@
 # Allow access to drupal or varnish pods from the ingress in the silta-cluster namespace
 {{- $id := "allow-ingress" -}}
-{{- $podSelectors := ternary (dict "service" "varnish") (dict "app" "drupal") .Values.varnish.enabled -}}
+{{- $podSelectors := dict "silta-ingress" "allow" -}}
 {{- $from := list (dict "namespaceSelector" (dict "matchLabels" (dict "name" "silta-cluster"))) -}}
 {{- $params := mergeOverwrite . (dict "id" $id "additionalPodSelectors" $podSelectors "from" $from) -}}
 {{ include "silta-release.networkPolicy" $params }}

--- a/charts/drupal/templates/shell-deployment.yaml
+++ b/charts/drupal/templates/shell-deployment.yaml
@@ -19,6 +19,7 @@ spec:
       labels:
         {{- include "drupal.release_labels" . | nindent 8 }}
         service: shell
+        silta-ingress: allow
     spec:
       enableServiceLinks: false
       containers:

--- a/charts/drupal/templates/varnish-deployment.yaml
+++ b/charts/drupal/templates/varnish-deployment.yaml
@@ -17,6 +17,7 @@ spec:
       labels:
         {{- include "drupal.release_labels" . | nindent 8 }}
         service: varnish
+        silta-ingress: allow
       annotations:
         # We use a checksum to redeploy the pods when the configMap changes.
         configMap-checksum: {{ include (print $.Template.BasePath "/varnish-configmap-vcl.yaml") . | sha256sum }}

--- a/charts/silta-release/templates/network-policy.yaml
+++ b/charts/silta-release/templates/network-policy.yaml
@@ -2,6 +2,13 @@
 {{- $params := mergeOverwrite . (dict "id" "default") -}}
 {{ include "silta-release.networkPolicy" $params }}
 ---
+# Allow access to drupal or varnish pods from the ingress in the silta-cluster namespace
+{{- $id := "allow-ingress" -}}
+{{- $podSelectors := dict "silta-ingress" "allow" -}}
+{{- $from := list (dict "namespaceSelector" (dict "matchLabels" (dict "name" "silta-cluster"))) -}}
+{{- $params := mergeOverwrite $ (dict "id" $id "additionalPodSelectors" $podSelectors "from" $from) -}}
+{{ include "silta-release.networkPolicy" $params }}
+---
 # Iterate through exceptions
 {{- range $index, $accessDefinition := .Values.ingressAccess -}}
 {{- $podSelectors := $accessDefinition.additionalPodSelector -}}


### PR DESCRIPTION
Introduces new label for pods that allow traffic from `silta-cluster` namespace.
Web and shell access works.