### PR TITLE
Feature/fpm tweaks

### DIFF
--- a/charts/drupal/templates/_helpers.tpl
+++ b/charts/drupal/templates/_helpers.tpl
@@ -30,6 +30,10 @@ ports:
   mountPath: /app/web/sites/default/silta.services.yml
   readOnly: true
   subPath: silta_services_yml
+- name: config
+  mountPath: /usr/local/etc/php-fpm.d/zz-custom.conf
+  readOnly: true
+  subPath: php_fpm_d_custom
 {{- end }}
 
 {{- define "drupal.volumes" -}}

--- a/charts/drupal/templates/drupal-configmap.yaml
+++ b/charts/drupal/templates/drupal-configmap.yaml
@@ -54,6 +54,8 @@ data:
     opcache.enable = 1
     opcache.enable_cli = 0
     opcache.memory_consumption = 256
+    ; XX
+    opcache.memory_consumption = 128
     opcache.interned_strings_buffer = 32
     opcache.use_cwd = ${PHP_OPCACHE_USE_CWD}
     opcache.validate_timestamps = 0
@@ -158,6 +160,132 @@ data:
     fastcgi_param  REDIRECT_STATUS    200;
 
     fastcgi_param  HTTPS              $fastcgi_https;
+
+  php_fpm_d_custom: |
+
+    ; Start a new pool named 'www'.
+    ; the variable $pool can we used in any directive and will be replaced by the
+    ; pool name ('www' here)
+    [www]
+
+    ; The address on which to accept FastCGI requests.
+    ; Valid syntaxes are:
+    ;   'ip.add.re.ss:port'    - to listen on a TCP socket to a specific IPv4 address on
+    ;                            a specific port;
+    ;   '[ip:6:addr:ess]:port' - to listen on a TCP socket to a specific IPv6 address on
+    ;                            a specific port;
+    ;   'port'                 - to listen on a TCP socket to all addresses
+    ;                            (IPv6 and IPv4-mapped) on a specific port;
+    ;   '/path/to/unix/socket' - to listen on a unix socket.
+    ; Note: This value is mandatory.
+    ; listen = [::]:9000
+
+    ; Choose how the process manager will control the number of child processes.
+    ; Possible Values:
+    ;   static  - a fixed number (pm.max_children) of child processes;
+    ;   dynamic - the number of child processes are set dynamically based on the
+    ;             following directives. With this process management, there will be
+    ;             always at least 1 children.
+    ;             pm.max_children      - the maximum number of children that can
+    ;                                    be alive at the same time.
+    ;             pm.start_servers     - the number of children created on startup.
+    ;             pm.min_spare_servers - the minimum number of children in 'idle'
+    ;                                    state (waiting to process). If the number
+    ;                                    of 'idle' processes is less than this
+    ;                                    number then some children will be created.
+    ;             pm.max_spare_servers - the maximum number of children in 'idle'
+    ;                                    state (waiting to process). If the number
+    ;                                    of 'idle' processes is greater than this
+    ;                                    number then some children will be killed.
+    ;  ondemand - no children are created at startup. Children will be forked when
+    ;             new requests will connect. The following parameter are used:
+    ;             pm.max_children           - the maximum number of children that
+    ;                                         can be alive at the same time.
+    ;             pm.process_idle_timeout   - The number of seconds after which
+    ;                                         an idle process will be killed.
+    ; Note: This value is mandatory.
+    pm = dynamic
+
+    ; The number of child processes to be created when pm is set to 'static' and the
+    ; maximum number of child processes when pm is set to 'dynamic' or 'ondemand'.
+    ; This value sets the limit on the number of simultaneous requests that will be
+    ; served. Equivalent to the ApacheMaxClients directive with mpm_prefork.
+    ; Equivalent to the PHP_FCGI_CHILDREN environment variable in the original PHP
+    ; CGI. The below defaults are based on a server without much resources. Don't
+    ; forget to tweak pm.* to fit your needs.
+    ; Note: Used when pm is set to 'static', 'dynamic' or 'ondemand'
+    ; Note: This value is mandatory.
+    ; pm.max_children = 50
+    ; XX
+    pm.max_children = 6
+
+    ; The number of child processes created on startup.
+    ; Note: Used only when pm is set to 'dynamic'
+    ; Default Value: min_spare_servers + (max_spare_servers - min_spare_servers) / 2
+    pm.start_servers = 2
+
+    ; The desired minimum number of idle server processes.
+    ; Note: Used only when pm is set to 'dynamic'
+    ; Note: Mandatory when pm is set to 'dynamic'
+    pm.min_spare_servers = 2
+
+    ; The desired maximum number of idle server processes.
+    ; Note: Used only when pm is set to 'dynamic'
+    ; Note: Mandatory when pm is set to 'dynamic'
+    pm.max_spare_servers = 2
+
+    ; The number of seconds after which an idle process will be killed.
+    ; Note: Used only when pm is set to 'ondemand'
+    ; Default Value: 10s
+    pm.process_idle_timeout = 60s
+
+    ; The number of requests each child process should execute before respawning.
+    ; This can be useful to work around memory leaks in 3rd party libraries. For
+    ; endless request processing specify '0'. Equivalent to PHP_FCGI_MAX_REQUESTS.
+    ; Default Value: 0
+    pm.max_requests = 500
+
+    ; The ping URI to call the monitoring page of FPM. If this value is not set, no
+    ; URI will be recognized as a ping page. This could be used to test from outside
+    ; that FPM is alive and responding, or to
+    ; - create a graph of FPM availability (rrd or such);
+    ; - remove a server from a group if it is not responding (load balancing);
+    ; - trigger alerts for the operating team (24/7).
+    ; Note: The value must start with a leading slash (/). The value can be
+    ;       anything, but it may not be a good idea to use the .php extension or it
+    ;       may conflict with a real PHP file.
+    ; Default Value: not set
+    ping.path = /ping
+
+    ; This directive may be used to customize the response of a ping request. The
+    ; response is formatted as text/plain with a 200 response code.
+    ; Default Value: pong
+    ping.response = pong
+
+    ; PHP FPM Status Page
+    pm.status_path = /status
+
+    ; The access log file
+    ; Default: not set
+    ; access.log = /dev/null
+    ; XX
+    access.log = /proc/self/fd/2
+
+    ; Redirect worker stdout and stderr into main error log. If not set, stdout and
+    ; stderr will be redirected to /dev/null according to FastCGI specs.
+    ; Note: on highloaded environement, this can cause some delay in the page
+    ; process time (several ms).
+    ; Default Value: no
+    catch_workers_output = yes
+
+    ; Clear environment in FPM workers
+    ; Prevents arbitrary environment variables from reaching FPM worker processes
+    ; by clearing the environment in workers before env vars specified in this
+    ; pool configuration are added.
+    ; Setting to "no" will make all environment variables available to PHP code
+    ; via getenv(), $_ENV and $_SERVER.
+    ; Default Value: yes
+    clear_env = no
 
   drupal_conf: |
 

--- a/charts/drupal/templates/drupal-configmap.yaml
+++ b/charts/drupal/templates/drupal-configmap.yaml
@@ -53,9 +53,8 @@ data:
     [opcache]
     opcache.enable = 1
     opcache.enable_cli = 0
-    opcache.memory_consumption = 256
-    ; XX
-    ; opcache.memory_consumption = 128
+    ; This should adjust to amount of memory given to the container
+    opcache.memory_consumption = 128
     opcache.interned_strings_buffer = 32
     opcache.use_cwd = ${PHP_OPCACHE_USE_CWD}
     opcache.validate_timestamps = 0
@@ -163,128 +162,19 @@ data:
 
   php_fpm_d_custom: |
 
-    ; Start a new pool named 'www'.
-    ; the variable $pool can we used in any directive and will be replaced by the
-    ; pool name ('www' here)
     [www]
-
-    ; The address on which to accept FastCGI requests.
-    ; Valid syntaxes are:
-    ;   'ip.add.re.ss:port'    - to listen on a TCP socket to a specific IPv4 address on
-    ;                            a specific port;
-    ;   '[ip:6:addr:ess]:port' - to listen on a TCP socket to a specific IPv6 address on
-    ;                            a specific port;
-    ;   'port'                 - to listen on a TCP socket to all addresses
-    ;                            (IPv6 and IPv4-mapped) on a specific port;
-    ;   '/path/to/unix/socket' - to listen on a unix socket.
-    ; Note: This value is mandatory.
-    ; listen = [::]:9000
-
-    ; Choose how the process manager will control the number of child processes.
-    ; Possible Values:
-    ;   static  - a fixed number (pm.max_children) of child processes;
-    ;   dynamic - the number of child processes are set dynamically based on the
-    ;             following directives. With this process management, there will be
-    ;             always at least 1 children.
-    ;             pm.max_children      - the maximum number of children that can
-    ;                                    be alive at the same time.
-    ;             pm.start_servers     - the number of children created on startup.
-    ;             pm.min_spare_servers - the minimum number of children in 'idle'
-    ;                                    state (waiting to process). If the number
-    ;                                    of 'idle' processes is less than this
-    ;                                    number then some children will be created.
-    ;             pm.max_spare_servers - the maximum number of children in 'idle'
-    ;                                    state (waiting to process). If the number
-    ;                                    of 'idle' processes is greater than this
-    ;                                    number then some children will be killed.
-    ;  ondemand - no children are created at startup. Children will be forked when
-    ;             new requests will connect. The following parameter are used:
-    ;             pm.max_children           - the maximum number of children that
-    ;                                         can be alive at the same time.
-    ;             pm.process_idle_timeout   - The number of seconds after which
-    ;                                         an idle process will be killed.
-    ; Note: This value is mandatory.
     pm = dynamic
-
-    ; The number of child processes to be created when pm is set to 'static' and the
-    ; maximum number of child processes when pm is set to 'dynamic' or 'ondemand'.
-    ; This value sets the limit on the number of simultaneous requests that will be
-    ; served. Equivalent to the ApacheMaxClients directive with mpm_prefork.
-    ; Equivalent to the PHP_FCGI_CHILDREN environment variable in the original PHP
-    ; CGI. The below defaults are based on a server without much resources. Don't
-    ; forget to tweak pm.* to fit your needs.
-    ; Note: Used when pm is set to 'static', 'dynamic' or 'ondemand'
-    ; Note: This value is mandatory.
-    pm.max_children = 50
-    ; XX
-    ; pm.max_children = 6
-
-    ; The number of child processes created on startup.
-    ; Note: Used only when pm is set to 'dynamic'
-    ; Default Value: min_spare_servers + (max_spare_servers - min_spare_servers) / 2
+    ; This should adjust to amount of memory given to the container
+    pm.max_children = 6
     pm.start_servers = 2
-
-    ; The desired minimum number of idle server processes.
-    ; Note: Used only when pm is set to 'dynamic'
-    ; Note: Mandatory when pm is set to 'dynamic'
     pm.min_spare_servers = 2
-
-    ; The desired maximum number of idle server processes.
-    ; Note: Used only when pm is set to 'dynamic'
-    ; Note: Mandatory when pm is set to 'dynamic'
     pm.max_spare_servers = 2
-
-    ; The number of seconds after which an idle process will be killed.
-    ; Note: Used only when pm is set to 'ondemand'
-    ; Default Value: 10s
     pm.process_idle_timeout = 60s
-
-    ; The number of requests each child process should execute before respawning.
-    ; This can be useful to work around memory leaks in 3rd party libraries. For
-    ; endless request processing specify '0'. Equivalent to PHP_FCGI_MAX_REQUESTS.
-    ; Default Value: 0
     pm.max_requests = 500
-
-    ; The ping URI to call the monitoring page of FPM. If this value is not set, no
-    ; URI will be recognized as a ping page. This could be used to test from outside
-    ; that FPM is alive and responding, or to
-    ; - create a graph of FPM availability (rrd or such);
-    ; - remove a server from a group if it is not responding (load balancing);
-    ; - trigger alerts for the operating team (24/7).
-    ; Note: The value must start with a leading slash (/). The value can be
-    ;       anything, but it may not be a good idea to use the .php extension or it
-    ;       may conflict with a real PHP file.
-    ; Default Value: not set
-    ping.path = /ping
-
-    ; This directive may be used to customize the response of a ping request. The
-    ; response is formatted as text/plain with a 200 response code.
-    ; Default Value: pong
-    ping.response = pong
-
-    ; PHP FPM Status Page
-    pm.status_path = /status
-
-    ; The access log file
-    ; Default: not set
-    ; access.log = /dev/null
-    ; XX
+    
     access.log = /proc/self/fd/2
-
-    ; Redirect worker stdout and stderr into main error log. If not set, stdout and
-    ; stderr will be redirected to /dev/null according to FastCGI specs.
-    ; Note: on highloaded environement, this can cause some delay in the page
-    ; process time (several ms).
-    ; Default Value: no
     catch_workers_output = yes
-
-    ; Clear environment in FPM workers
-    ; Prevents arbitrary environment variables from reaching FPM worker processes
-    ; by clearing the environment in workers before env vars specified in this
-    ; pool configuration are added.
-    ; Setting to "no" will make all environment variables available to PHP code
-    ; via getenv(), $_ENV and $_SERVER.
-    ; Default Value: yes
+    
     clear_env = no
 
   drupal_conf: |

--- a/charts/drupal/templates/drupal-configmap.yaml
+++ b/charts/drupal/templates/drupal-configmap.yaml
@@ -215,9 +215,9 @@ data:
     ; forget to tweak pm.* to fit your needs.
     ; Note: Used when pm is set to 'static', 'dynamic' or 'ondemand'
     ; Note: This value is mandatory.
-    ; pm.max_children = 50
+    pm.max_children = 50
     ; XX
-    pm.max_children = 6
+    ; pm.max_children = 6
 
     ; The number of child processes created on startup.
     ; Note: Used only when pm is set to 'dynamic'

--- a/charts/drupal/templates/drupal-configmap.yaml
+++ b/charts/drupal/templates/drupal-configmap.yaml
@@ -55,7 +55,7 @@ data:
     opcache.enable_cli = 0
     opcache.memory_consumption = 256
     ; XX
-    opcache.memory_consumption = 128
+    ; opcache.memory_consumption = 128
     opcache.interned_strings_buffer = 32
     opcache.use_cwd = ${PHP_OPCACHE_USE_CWD}
     opcache.validate_timestamps = 0

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -4,11 +4,11 @@
 # See https://github.com/wunderio/charts/blob/master/drupal/values.yaml
 # for all possible options.
 
-varnish:
-  enabled: true
+#varnish:
+#  enabled: true
 
-elasticsearch:
-  enabled: true
+#elasticsearch:
+#  enabled: true
 
 mounts:
   private-files:

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -4,11 +4,11 @@
 # See https://github.com/wunderio/charts/blob/master/drupal/values.yaml
 # for all possible options.
 
-#varnish:
-#  enabled: true
+varnish:
+  enabled: true
 
-#elasticsearch:
-#  enabled: true
+elasticsearch:
+  enabled: true
 
 mounts:
   private-files:
@@ -31,10 +31,3 @@ silta-release:
         - namespaceSelector:
             matchLabels:
               name: drupal-project
-
-# Provide a high-availability, autoscaling deployment.
-replicas: 1
-autoscaling:
-  enabled: true
-  minReplicas: 1
-  maxReplicas: 10

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -31,3 +31,10 @@ silta-release:
         - namespaceSelector:
             matchLabels:
               name: drupal-project
+
+# Provide a high-availability, autoscaling deployment.
+replicas: 1
+autoscaling:
+  enabled: true
+  minReplicas: 1
+  maxReplicas: 10


### PR DESCRIPTION
Did load testing with high concurrency apache benchmark tester and drupal session. Default `pm.max_children` of 50 caused frequent error 502's, changed to more sensible value.