### PR TITLE
Use a local temporary directory when rsyncing files.

### DIFF
--- a/charts/drupal/templates/NOTES.txt
+++ b/charts/drupal/templates/NOTES.txt
@@ -43,7 +43,7 @@ Importing a database dump:
 {{ if eq $mount.enabled true -}}
 Importing files to {{ $index }}:
 
-  rsync -azv -e 'ssh -A -J {{ include "drupal.jumphost" $ }}' local_folder/ {{ include "drupal.shellHost" $ }}:{{ $mount.mountPath }}
+  rsync -azv --temp-dir=/tmp/ -e 'ssh -A -J {{ include "drupal.jumphost" $ }}' local_folder/ {{ include "drupal.shellHost" $ }}:{{ $mount.mountPath }}
 
 {{ end -}}
 {{ end -}}

--- a/charts/drupal/templates/_helpers.tpl
+++ b/charts/drupal/templates/_helpers.tpl
@@ -312,7 +312,7 @@ fi
   {{- if eq $mount.enabled true -}}
   if [ -d "/app/reference-data/{{ $index }}" ]; then
     echo "Importing {{ $index }} files"
-    rsync -r "/app/reference-data/{{ $index }}/" "{{ $mount.mountPath }}" &
+    rsync -r --temp-dir=/tmp/ "/app/reference-data/{{ $index }}/" "{{ $mount.mountPath }}" &
   fi
   {{ end -}}
   {{- end }}


### PR DESCRIPTION
Rsync currently triggers errors when transferring a lot of files, of the form: 
```
rsync: mkstemp "/app/web/sites/default/files/.37388109241_7f23737b05_n.jpg.XXXXXX" failed: No such file or directory (2)
```
Adding a local temporary directory should help.  