### PR TITLE
Feature/fpm tweaks

### DIFF
--- a/charts/drupal/templates/_helpers.tpl
+++ b/charts/drupal/templates/_helpers.tpl
@@ -32,7 +32,7 @@ ports:
   subPath: silta_services_yml
 - name: config
   mountPath: /usr/local/etc/php-fpm.d/zz-custom.conf
-  readOnly: true
+  readOnly: false
   subPath: php_fpm_d_custom
 {{- end }}
 

--- a/charts/drupal/templates/drupal-configmap.yaml
+++ b/charts/drupal/templates/drupal-configmap.yaml
@@ -177,6 +177,9 @@ data:
     
     clear_env = no
 
+    ; Custom configuration below
+    {{ .Values.php.fpm.extraConfig | nindent 4 }}
+
   drupal_conf: |
 
     ## Nginx FCGI specific directives.

--- a/charts/drupal/values.yaml
+++ b/charts/drupal/values.yaml
@@ -117,6 +117,11 @@ php:
     limits:
       memory: 512M
 
+  fpm:
+    # Custom php-fpm settings block. May override parameters previously defined. 
+    # This will be put under [www] process pool.
+    extraConfig: |
+
   # Cron tasks, each of which will be run into a dedicated temporary pod.
   # When overriding this value, make sure to include the `drush cron` command.
   cron:

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -31,3 +31,12 @@ silta-release:
         - namespaceSelector:
             matchLabels:
               name: drupal-project
+
+# Configuration for everything that runs in php containers.
+php:
+  fpm:
+    extraConfig: |
+      pm.max_children = 2
+      pm.start_servers = 1
+      pm.min_spare_servers = 1
+      pm.max_spare_servers = 1

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -31,12 +31,3 @@ silta-release:
         - namespaceSelector:
             matchLabels:
               name: drupal-project
-
-# Configuration for everything that runs in php containers.
-php:
-  fpm:
-    extraConfig: |
-      pm.max_children = 2
-      pm.start_servers = 1
-      pm.min_spare_servers = 1
-      pm.max_spare_servers = 1


### PR DESCRIPTION
Custom PHP-FPM configuration overrides.

Tested with following example configuration in `silta.yml` file:
```
php:
  fpm:
    extraConfig: |
      pm.max_children = 2
      pm.start_servers = 1
      pm.min_spare_servers = 1
      pm.max_spare_servers = 1
```

And confirming the config overrides are used by logging into container and running this command:
```
# php-fpm -tt -R

(..)
[22-Apr-2020 09:58:31] NOTICE: 	pm = dynamic
[22-Apr-2020 09:58:31] NOTICE: 	pm.max_children = 2
[22-Apr-2020 09:58:31] NOTICE: 	pm.start_servers = 1
[22-Apr-2020 09:58:31] NOTICE: 	pm.min_spare_servers = 1
[22-Apr-2020 09:58:31] NOTICE: 	pm.max_spare_servers = 1
[22-Apr-2020 09:58:31] NOTICE: 	pm.process_idle_timeout = 60
(..)
```

While the current defaults are [these](https://github.com/wunderio/drupal-project-k8s/blob/master/charts/drupal/templates/drupal-configmap.yaml#L168):
```
pm.max_children = 6
pm.start_servers = 2
pm.min_spare_servers = 2
pm.max_spare_servers = 2
```

Which means overrides work correctly.