### PR TITLE
SLT-485: Disable Instana Twig instrumentation

### DIFF
--- a/charts/drupal/templates/drupal-configmap.yaml
+++ b/charts/drupal/templates/drupal-configmap.yaml
@@ -65,6 +65,7 @@ data:
 
     [instana]
     ; Disable Twig instrumentation, it causes issues when used with Drupal.
+    ; See https://docs.instana.io/ecosystem/php/#tracing
     instana.disabled_instrumentation=2097152
     
     ; Custom configuration below

--- a/charts/drupal/templates/drupal-configmap.yaml
+++ b/charts/drupal/templates/drupal-configmap.yaml
@@ -62,6 +62,10 @@ data:
 
     [igbinary]
     igbinary.compact_strings=1
+
+    [instana]
+    ; Disable Twig instrumentation, it causes issues when used with Drupal.
+    instana.disabled_instrumentation=2097152
     
     ; Custom configuration below
     {{ .Values.php.php_ini.extraConfig | nindent 4 }}


### PR DESCRIPTION
The way Drupal uses Twig can cause an excessive number of independent calls to Instana which generates a high CPU activity on our servers.