### PR TITLE
Run rsync in parallel for each subfolder

### DIFF
--- a/charts/drupal/templates/_helpers.tpl
+++ b/charts/drupal/templates/_helpers.tpl
@@ -312,7 +312,9 @@ fi
   {{- if eq $mount.enabled true -}}
   if [ -d "/app/reference-data/{{ $index }}" ]; then
     echo "Importing {{ $index }} files"
-    rsync -r --temp-dir=/tmp/ "/app/reference-data/{{ $index }}/" "{{ $mount.mountPath }}" &
+    for f in /app/reference-data/{{ $index }}/*; do
+      rsync -r --temp-dir=/tmp/ $f "{{ $mount.mountPath }}" &
+    done
   fi
   {{ end -}}
   {{- end }}

--- a/charts/drupal/templates/_helpers.tpl
+++ b/charts/drupal/templates/_helpers.tpl
@@ -310,7 +310,7 @@ fi
 {{- define "drupal.import-reference-files" -}}
   {{ range $index, $mount := .Values.mounts -}}
   {{- if eq $mount.enabled true -}}
-  if [ -d "/app/reference-data/{{ $index }}" ]; then
+  if [ -d "/app/reference-data/{{ $index }}" ] && [ -n "$(ls /app/reference-data/{{ $index }})" ]; then
     echo "Importing {{ $index }} files"
     for f in /app/reference-data/{{ $index }}/*; do
       rsync -r --temp-dir=/tmp/ $f "{{ $mount.mountPath }}" &


### PR DESCRIPTION
We have an issue with the rsync command that copies the reference data, it takes too long and then the temporary empty folders created by the rclone driver are gone, which results in errors. 

This PR executes separate rsync calls for each subfolder within the mounted volumes. This speeds things up considerably, not only in total, but also from the time it takes from the initial rsync call to the file being created, thus removing the error above.

For testing purposes I added the reference data files from one problematic project to this project, the deployment of a new environment runs in less than 2 minutes.