### PR TITLE
SLT-504: overridable resources for shell container

### DIFF
--- a/charts/drupal/templates/shell-deployment.yaml
+++ b/charts/drupal/templates/shell-deployment.yaml
@@ -43,7 +43,7 @@ spec:
         - name: ssh-keys
           mountPath: /etc/ssh/keys
         resources:
-          {{- .Values.php.resources | toYaml | nindent 10 }}
+          {{- merge .Values.shell.resources .Values.php.resources | toYaml | nindent 10 }}
       nodeSelector:
         {{ if .Values.shell.nodeSelector }}
         {{- .Values.shell.nodeSelector | toYaml | nindent 8 }}

--- a/charts/drupal/values.yaml
+++ b/charts/drupal/values.yaml
@@ -234,6 +234,9 @@ shell:
     csiDriverName: csi-rclone
     storage: 1M
 
+  # Extend resources defined under php.resources.
+  resources: {}
+
   # Set a restriction on where the shell pod are provisioned.
   # This can be used for example to get a static IP for egress traffic.
   nodeSelector: {}


### PR DESCRIPTION
It makes sense to have the same resources for the shell containers by default, but when we allocate more cpu for production environment, we don't need to allocate those resources for a container that will be idle most of the time.