### PR TITLE
Speed up database import

### DIFF
--- a/charts/drupal/templates/_helpers.tpl
+++ b/charts/drupal/templates/_helpers.tpl
@@ -301,7 +301,8 @@ if [ -f /app/reference-data/db.sql.gz ]; then
   drush sql-drop -y
 
   echo "Importing reference database dump"
-  cat /app/reference-data/db.sql.gz | gunzip | drush sql-cli
+  gunzip -c /app/reference-data/db.sql.gz > /tmp/reference-data-db.sql
+  pv /tmp/reference-data-db.sql | drush sql-cli
 
   # Clear caches before doing anything else.
   drush cr

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,6 @@
         "composer/installers": "^1.2",
         "cweagans/composer-patches": "^1.6",
         "drupal-composer/drupal-scaffold": "^2.2",
-        "drupal/config_installer": "~1.7",
         "drupal/core": "~8.5",
         "drupal/memcache": "^2.0",
         "drupal/monolog": "^1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -1416,16 +1416,16 @@
         },
         {
             "name": "doctrine/common",
-            "version": "2.12.0",
+            "version": "2.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/common.git",
-                "reference": "2053eafdf60c2172ee1373d1b9289ba1db7f1fc6"
+                "reference": "308728eae8d90412d850c155d40b1cfbede549da"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/common/zipball/2053eafdf60c2172ee1373d1b9289ba1db7f1fc6",
-                "reference": "2053eafdf60c2172ee1373d1b9289ba1db7f1fc6",
+                "url": "https://api.github.com/repos/doctrine/common/zipball/308728eae8d90412d850c155d40b1cfbede549da",
+                "reference": "308728eae8d90412d850c155d40b1cfbede549da",
                 "shasum": ""
             },
             "require": {
@@ -1435,7 +1435,7 @@
                 "doctrine/event-manager": "^1.0",
                 "doctrine/inflector": "^1.0",
                 "doctrine/lexer": "^1.0",
-                "doctrine/persistence": "^1.1",
+                "doctrine/persistence": "^1.3.3",
                 "doctrine/reflection": "^1.0",
                 "php": "^7.1"
             },
@@ -1495,7 +1495,7 @@
                 "doctrine",
                 "php"
             ],
-            "time": "2020-01-10T15:49:25+00:00"
+            "time": "2020-05-15T05:51:54+00:00"
         },
         {
             "name": "doctrine/event-manager",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b40a6f052602118a46078c1ab162308b",
+    "content-hash": "731e91f0a0841a48c189be7e20b0bf26",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -1917,52 +1917,6 @@
             ],
             "description": "Composer Plugin for updating the Drupal scaffold files when using drupal/core",
             "time": "2019-03-30T10:41:38+00:00"
-        },
-        {
-            "name": "drupal/config_installer",
-            "version": "1.8.0",
-            "source": {
-                "type": "git",
-                "url": "https://git.drupalcode.org/project/config_installer.git",
-                "reference": "8.x-1.8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/config_installer-8.x-1.8.zip",
-                "reference": "8.x-1.8",
-                "shasum": "43d7af76a3f00d074161e242ddf94d942d256250"
-            },
-            "require": {
-                "drupal/core": "~8.0"
-            },
-            "type": "drupal-profile",
-            "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev"
-                },
-                "drupal": {
-                    "version": "8.x-1.8",
-                    "datestamp": "1524572284",
-                    "security-coverage": {
-                        "status": "covered",
-                        "message": "Covered by Drupal's security advisory policy"
-                    }
-                }
-            },
-            "notification-url": "https://packages.drupal.org/8/downloads",
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "authors": [
-                {
-                    "name": "alexpott",
-                    "homepage": "https://www.drupal.org/user/157725"
-                }
-            ],
-            "homepage": "https://www.drupal.org/project/config_installer",
-            "support": {
-                "source": "https://git.drupalcode.org/project/config_installer"
-            }
         },
         {
             "name": "drupal/core",


### PR DESCRIPTION
This came through a happy accident, trying to show output while importing a database dump to avoid CircleCI timeouts due to the lack of output. It turns out that separating the decompressing of the database dump from the piping to `drush sql-cli` speeds things up, which is even increased when using `pv`. 

Unfortunately the output from `pv` doesn't show up in CircleCI, I'll leave that as a separate topic, now that the import is much faster, showing progress is not as critical anymore.