### PR TITLE
Use keyserver for drupal shell access

### DIFF
--- a/charts/drupal/templates/shell-deployment.yaml
+++ b/charts/drupal/templates/shell-deployment.yaml
@@ -27,13 +27,22 @@ spec:
         image: {{ .Values.shell.image | quote }}
         env:
         {{- include "drupal.env" . | indent 8 }}
-        - name: GITAUTH_API_TOKEN
+        - name: GITAUTH_URL
+          value: {{ .Values.shell.gitAuth.keyserver.url | default (printf "https://keys.%s/api/1/git-ssh-keys" .Values.clusterDomain) | quote }}
+        - name: GITAUTH_USERNAME
           valueFrom:
             secretKeyRef:
               name: {{ .Release.Name }}-secrets-shell
-              key: gitAuth.apiToken
-        - name: GITAUTH_REPOSITORY_URL
-          value: "{{ .Values.shell.gitAuth.repositoryUrl }}"
+              key: keyserver.username
+        - name: GITAUTH_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Release.Name }}-secrets-shell
+              key: keyserver.password
+        - name: GITAUTH_SCOPE
+          value: {{ .Values.shell.gitAuth.repositoryUrl }}
+        - name: OUTSIDE_COLLABORATORS
+          value: {{ .Values.shell.gitAuth.outsideCollaborators | default true | quote }}
         - name: DRUSH_OPTIONS_URI
           value: "http://{{- template "drupal.domain" . }}"
         ports:

--- a/charts/drupal/templates/shell-secret.yaml
+++ b/charts/drupal/templates/shell-secret.yaml
@@ -6,6 +6,9 @@ metadata:
     {{- include "drupal.release_labels" . | nindent 4 }}
 type: Opaque
 data:
-  {{- if .Values.shell.gitAuth.apiToken }}
-  gitAuth.apiToken: "{{ .Values.shell.gitAuth.apiToken | b64enc }}"
+  {{- if .Values.shell.gitAuth.keyserver.username }}
+  keyserver.username: "{{ .Values.shell.gitAuth.keyserver.username | b64enc }}"
+  {{- end }}
+  {{- if .Values.shell.gitAuth.keyserver.password }}
+  keyserver.password: "{{ .Values.shell.gitAuth.keyserver.password | b64enc }}"
   {{- end }}

--- a/charts/drupal/tests/shell_deployment_test.yaml
+++ b/charts/drupal/tests/shell_deployment_test.yaml
@@ -39,6 +39,6 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].env
           content:
-            name: GITAUTH_REPOSITORY_URL
+            name: GITAUTH_SCOPE
             value: foo
 

--- a/charts/drupal/values.yaml
+++ b/charts/drupal/values.yaml
@@ -221,8 +221,13 @@ shell:
   # Values for the SSH gitAuth.
   gitAuth:
     # Project's git repository URL
-    repositoryUrl: 'you need to pass in a value for repositoryUrl to your helm chart'
-    apiToken: 'you need to pass in a value for shell.gitAuth.apiToken to your helm chart'
+    repositoryUrl: 'you need to pass in a value for shell.gitAuth.repositoryUrl to your helm chart'
+    outsideCollaborators: true
+    keyserver:
+      # Defaults to https://keys.[clusterDomain]/api/1/git-ssh-keys
+      url: ''
+      username: ''
+      password: ''
 
   # Specifications for the volume where host keys are mounted.
   mount:

--- a/silta/shell.Dockerfile
+++ b/silta/shell.Dockerfile
@@ -1,4 +1,4 @@
 # Dockerfile for the Drupal container.
-FROM wunderio/drupal-shell:latest
+FROM wunderio/drupal-shell:v0.2
 
 COPY --chown=www-data:www-data . /app

--- a/silta/shell.Dockerfile
+++ b/silta/shell.Dockerfile
@@ -1,4 +1,4 @@
 # Dockerfile for the Drupal container.
-FROM wunderio/drupal-shell:v0.2
+FROM wunderio/drupal-shell:latest
 
 COPY --chown=www-data:www-data . /app


### PR DESCRIPTION
Merge this into charts repo with caution - the drupal `ssh.Dockerfile` chart uses `drupal-shell:v0.1` while k8s  uses `drupal-shell:latest`. 

This means two things need to be released at the same time:
- `drupal-shell` needs a `v0.1` release tagged from master
- and drupal chart with these changes
- orb needs prefix change for shell image, so the image is rebuilt
