### PR TITLE
Proxy follow-up

### DIFF
--- a/charts/drupal/templates/_helpers.tpl
+++ b/charts/drupal/templates/_helpers.tpl
@@ -245,11 +245,13 @@ touch /app/web/sites/default/files/_installing
 {{- if .Values.referenceData.enabled }}
 {{ include "drupal.import-reference-db" . }}
 {{- end }}
+{{- end }}
 
 {{ if .Values.elasticsearch.enabled }}
 {{ include "drupal.wait-for-elasticsearch-command" . }}
 {{ end }}
 
+{{ if .Release.IsInstall }}
 {{ .Values.php.postinstall.command}}
 rm /app/web/sites/default/files/_installing
 {{ end }}

--- a/charts/drupal/templates/_helpers.tpl
+++ b/charts/drupal/templates/_helpers.tpl
@@ -173,9 +173,9 @@ imagePullSecrets:
 - name: HTTPS_PROXY
   value: "{{ $proxy.url }}:{{ $proxy.port }}"
 - name: no_proxy
-  value: .svc.cluster.local,{{ .Release.Name }}-es
+  value: .svc.cluster.local,{{ .Release.Name }}-es{{ if $proxy.no_proxy }},{{$proxy.no_proxy}}{{ end }}
 - name: NO_PROXY
-  value: .svc.cluster.local,{{ .Release.Name }}-es
+  value: .svc.cluster.local,{{ .Release.Name }}-es{{ if $proxy.no_proxy }},{{$proxy.no_proxy}}{{ end }}
 {{- end }}
 {{- end }}
 

--- a/charts/drupal/templates/_helpers.tpl
+++ b/charts/drupal/templates/_helpers.tpl
@@ -172,6 +172,10 @@ imagePullSecrets:
   value: "{{ $proxy.url }}:{{ $proxy.port }}"
 - name: HTTPS_PROXY
   value: "{{ $proxy.url }}:{{ $proxy.port }}"
+- name: no_proxy
+  value: .svc.cluster.local,{{ .Release.Name }}-es
+- name: NO_PROXY
+  value: .svc.cluster.local,{{ .Release.Name }}-es
 {{- end }}
 {{- end }}
 

--- a/charts/silta-release/values.schema.json
+++ b/charts/silta-release/values.schema.json
@@ -19,7 +19,15 @@
         }
       }
     },
-    "proxy": { "type": "object" },
+    "proxy": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean"},
+        "url":     { "type": "string"},
+        "port": { "type": "integer"},
+        "no_proxy": { "type": "string"}
+      }
+    },
     "global": { "type": "object"}
   }
 }

--- a/charts/silta-release/values.yaml
+++ b/charts/silta-release/values.yaml
@@ -24,3 +24,8 @@ proxy:
   enabled: false
   url: 'silta-cluster-proxy.silta-cluster'
   port: 80
+
+  # Set a comma-separated list of hostnames or hostname suffixes that should not be proxied,
+  # such as cluster-internal services from other namespaces. For example, for unproxied access
+  # to services in the namespace "foo", use ".foo" as the value.
+  no_proxy: ""

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -37,3 +37,4 @@ silta-release:
 
   proxy:
     enabled: true
+    no_proxy: ".example.com"


### PR DESCRIPTION
When the HTTP proxy is enabled, it is currently used for all HTTP requests made with tools that support these standard environment variables, such as curl. This interferes for example with connecting to the internal elasticsearch service. 

This PR adds some built-in exclusion for internal services called with their full hostname (subdomains of `.svc.cluster.local`), the Elasticsearch service, as well as a configurable list of additional domains. 