### PR TITLE
SLT-502: replace deprecated APIs

### DIFF
--- a/charts/drupal/templates/drupal-ingress.yaml
+++ b/charts/drupal/templates/drupal-ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ .Release.Name }}-drupal
@@ -45,7 +45,7 @@ spec:
 ---
 
 {{- range $index, $domain := .Values.exposeDomains }}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ $.Release.Name }}-drupal-{{ $index }}

--- a/charts/drupal/templates/shell-deployment.yaml
+++ b/charts/drupal/templates/shell-deployment.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.shell.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Release.Name }}-shell


### PR DESCRIPTION
The extensions/v1beta1 API is deprecated, and unsupported for Deployment resources starting with kubernetes 1.16. These resources are stateless, replacing them doesn't cause any issues. 