### PR TITLE
SLT-514: mariadb update

### DIFF
--- a/charts/drupal/Chart.lock
+++ b/charts/drupal/Chart.lock
@@ -1,10 +1,10 @@
 dependencies:
 - name: mariadb
   repository: https://charts.bitnami.com/bitnami
-  version: 4.4.2
+  version: 7.5.2
 - name: memcached
   repository: https://charts.bitnami.com/bitnami
-  version: 4.2.18
+  version: 4.2.19
 - name: mailhog
   repository: https://codecentric.github.io/helm-charts
   version: 3.1.3
@@ -14,5 +14,5 @@ dependencies:
 - name: silta-release
   repository: file://../silta-release
   version: 0.1.1
-digest: sha256:6875b3836a2481688d0af376bfd44be78a35c448397be59a2d325690b50c87f3
-generated: "2020-05-14T10:53:10.426698477Z"
+digest: sha256:2bcec6a2b814f5be47c140ad89577ddc48f50c5f2fbb05c54c07beba4f9835de
+generated: "2020-06-19T15:00:51.135864+02:00"

--- a/charts/drupal/Chart.yaml
+++ b/charts/drupal/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: drupal
-version: 0.3.40
+version: 0.3.43
 apiVersion: v2
 dependencies:
 - name: mariadb

--- a/charts/drupal/Chart.yaml
+++ b/charts/drupal/Chart.yaml
@@ -4,7 +4,7 @@ version: 0.3.40
 apiVersion: v2
 dependencies:
 - name: mariadb
-  version: 4.4.x
+  version: 7.5.x
   repository: https://charts.bitnami.com/bitnami
   condition: mariadb.enabled,drupal.mariadb.enabled,global.mariadb.enabled
 - name: memcached

--- a/charts/drupal/templates/_overrides.tpl
+++ b/charts/drupal/templates/_overrides.tpl
@@ -17,3 +17,11 @@ we make it compatible by overriding the following templates.
 {{- define "elasticsearch.endpoints" -}}
 {{ .Release.Name }}-es-0
 {{- end -}}
+
+{{/*
+The mariadb chart switched to an incompatible naming scheme,
+we make it compatible by overriding the following templates.
+*/}}
+{{- define "mariadb.fullname" -}}
+{{ .Release.Name }}-mariadb
+{{- end }}


### PR DESCRIPTION
Update to version 7.x of the mariadb helm chart. This is a major update and requires the statefulset to be recreated, which is done in https://github.com/wunderio/silta-circleci/pull/103

Updating to the 7.x mariadb helm chart is part of the prerequisites for upgrading to kubernetes 1.16.