### PR TITLE
Feature/slt 505 enable memcache settingsphp

### DIFF
--- a/charts/drupal/files/settings.silta.php
+++ b/charts/drupal/files/settings.silta.php
@@ -45,9 +45,11 @@ if ($elasticsearch_host = getenv('ELASTICSEARCH_HOST')) {
 
 /**
  * Set the memcache server hostname when a memcached server is available.
+ * Set the cache backend to use memcache when a memcache server is available.
  */
 if (getenv('MEMCACHED_HOST')) {
   $settings['memcache']['servers'] = [getenv('MEMCACHED_HOST') . ':11211' => 'default'];
+  $settings['cache']['default'] = 'cache.backend.memcache';
 }
 
 /**

--- a/charts/drupal/files/settings.silta.php
+++ b/charts/drupal/files/settings.silta.php
@@ -48,15 +48,11 @@ if ($elasticsearch_host = getenv('ELASTICSEARCH_HOST')) {
  */
 if (getenv('MEMCACHED_HOST')) {
   $settings['memcache']['servers'] = [getenv('MEMCACHED_HOST') . ':11211' => 'default'];
-}
 
-/**
- * Set the cache backend to use memcache.
- *
- * Make sure that memcache host is set and memcache backend class is defined.
- */
-if (getenv('MEMCACHED_HOST') && class_exists('\Drupal\memcache\MemcacheBackend')) {
-  $settings['cache']['default'] = 'cache.backend.memcache';
+  // Set the memcache backend if class is defined.
+  if (class_exists('\Drupal\memcache\MemcacheBackend')) {
+    $settings['cache']['default'] = 'cache.backend.memcache';
+  }
 }
 
 /**

--- a/charts/drupal/files/settings.silta.php
+++ b/charts/drupal/files/settings.silta.php
@@ -45,10 +45,16 @@ if ($elasticsearch_host = getenv('ELASTICSEARCH_HOST')) {
 
 /**
  * Set the memcache server hostname when a memcached server is available.
- * Set the cache backend to use memcache when a memcache server is available.
  */
 if (getenv('MEMCACHED_HOST')) {
   $settings['memcache']['servers'] = [getenv('MEMCACHED_HOST') . ':11211' => 'default'];
+}
+
+/**
+ * Set the cache backend to use memcache when a memcache server is set
+ * and if memcache backend class is defined.
+ */
+if (getenv('MEMCACHED_HOST') && class_exists('\Drupal\memcache\MemcacheBackend')) {
   $settings['cache']['default'] = 'cache.backend.memcache';
 }
 

--- a/charts/drupal/files/settings.silta.php
+++ b/charts/drupal/files/settings.silta.php
@@ -51,8 +51,9 @@ if (getenv('MEMCACHED_HOST')) {
 }
 
 /**
- * Set the cache backend to use memcache when a memcache server is set
- * and if memcache backend class is defined.
+ * Set the cache backend to use memcache.
+ *
+ * Make sure that memcache host is set and memcache backend class is defined.
  */
 if (getenv('MEMCACHED_HOST') && class_exists('\Drupal\memcache\MemcacheBackend')) {
   $settings['cache']['default'] = 'cache.backend.memcache';


### PR DESCRIPTION
Description

User story: https://wunder.atlassian.net/browse/SLT-505

Changes to charts: https://github.com/wunderio/charts/pull/160

Set the default cache backend to use memcache when a memcache server is available and when memcache cache backend is defined.

At the moment we only set the memcache host server settings, but it remains unused because it is not set as the backend cache for Drupal.