### PR TITLE
SLT-563: Mount backups volume to shell deployment

### DIFF
--- a/charts/drupal/templates/shell-deployment.yaml
+++ b/charts/drupal/templates/shell-deployment.yaml
@@ -54,6 +54,9 @@ spec:
         {{- include "drupal.volumeMounts" . | nindent 8 }}
         - name: ssh-keys
           mountPath: /etc/ssh/keys
+        - name: {{ .Release.Name }}-backup
+          mountPath: /backups
+          readOnly: true
         resources:
           {{- merge .Values.shell.resources .Values.php.resources | toYaml | nindent 10 }}
       nodeSelector:
@@ -73,6 +76,9 @@ spec:
       - name: ssh-keys
         persistentVolumeClaim:
           claimName: {{ .Release.Name }}-ssh-keys
+      - name: {{ .Release.Name }}-backup
+        persistentVolumeClaim:
+          claimName: {{ .Release.Name }}-backup
       {{- include "drupal.imagePullSecrets" . | nindent 6 }}
 {{- end }}
 ---

--- a/charts/drupal/templates/shell-deployment.yaml
+++ b/charts/drupal/templates/shell-deployment.yaml
@@ -54,9 +54,11 @@ spec:
         {{- include "drupal.volumeMounts" . | nindent 8 }}
         - name: ssh-keys
           mountPath: /etc/ssh/keys
+        {{- if .Values.backup.enabled }}
         - name: {{ .Release.Name }}-backup
           mountPath: /backups
           readOnly: true
+        {{- end }}
         resources:
           {{- merge .Values.shell.resources .Values.php.resources | toYaml | nindent 10 }}
       nodeSelector:
@@ -76,9 +78,11 @@ spec:
       - name: ssh-keys
         persistentVolumeClaim:
           claimName: {{ .Release.Name }}-ssh-keys
+      {{- if .Values.backup.enabled }}
       - name: {{ .Release.Name }}-backup
         persistentVolumeClaim:
           claimName: {{ .Release.Name }}-backup
+      {{- end }}
       {{- include "drupal.imagePullSecrets" . | nindent 6 }}
 {{- end }}
 ---

--- a/charts/drupal/tests/shell_deployment_test.yaml
+++ b/charts/drupal/tests/shell_deployment_test.yaml
@@ -47,3 +47,29 @@ tests:
             name: GITAUTH_SCOPE
             value: foo
 
+  - it: mounts backups volume correctly when backups are enabled
+    template: shell-deployment.yaml
+    set:
+      shell.enabled: true
+      backup.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            mountPath: /backups
+            name: RELEASE-NAME-backup
+            readOnly: true
+
+  - it: does not mount backups volume when backups are disabled
+    template: shell-deployment.yaml
+    set:
+      shell.enabled: true
+      backup.enabled: false
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            mountPath: /backups
+            name: RELEASE-NAME-backup
+            readOnly: true
+


### PR DESCRIPTION
Link to ticket: https://wunder.atlassian.net/browse/SLT-563

Changes proposed in this PR:
- if drupal backups are enabled, mount the volume containing the backups to the shell deployment as read-only
- add unit test for these changes

How to test:
1. ssh into the feature environment
1. run `ls -l /`, verify you don't see a `backups` directory
1. modify `silta/silta.yml` file and add this to it:
    ```
    backup:
      enabled: true
    ```
1. push this change to a new branch (in order to not mess up this branch)
1. ssh into the new feature environment
1. run `ls -l /`, verify you do see a `backups` directory
1. verify you are not able to write to the directory, as it should be read-only