### PR TITLE
Drupal 7 aware drush commands

### DIFF
--- a/charts/drupal/templates/_helpers.tpl
+++ b/charts/drupal/templates/_helpers.tpl
@@ -365,7 +365,9 @@ if [ -f /app/reference-data/db.sql.gz ]; then
   pv /tmp/reference-data-db.sql | drush sql-cli
 
   # Clear caches before doing anything else.
-  drush cr
+  drupal_major_version=$(drush status --fields=drupal-version  | sed -nre 's/^[^0-9]*([0-9]+).*/\1/p')
+  if [[ $drupal_major_version -eq 7 ]] ; then drush cache-clear all; 
+  else drush cache-rebuild; fi
 else
   printf "\e[33mNo reference data found, please install Drupal or import a database dump. See release information for instructions.\e[0m\n"
 fi
@@ -381,7 +383,9 @@ if [ -f /backups/{{ $.Values.backup.restoreId }}/db.sql.gz ]; then
   pv /tmp/backup-data-db.sql | drush sql-cli
 
   # Clear caches before doing anything else.
-  drush cr
+  drupal_major_version=$(drush status --fields=drupal-version  | sed -nre 's/^[^0-9]*([0-9]+).*/\1/p')
+  if [[ $drupal_major_version -eq 7 ]] ; then drush cache-clear all; 
+  else drush cache-rebuild; fi
 else
   printf "\e[33mNo reference data found, please install Drupal or import a database dump. See release information for instructions.\e[0m\n"
 fi

--- a/charts/drupal/templates/_helpers.tpl
+++ b/charts/drupal/templates/_helpers.tpl
@@ -365,7 +365,7 @@ if [ -f /app/reference-data/db.sql.gz ]; then
   pv /tmp/reference-data-db.sql | drush sql-cli
 
   # Clear caches before doing anything else.
-  drupal_major_version=$(drush status --fields=drupal-version  | sed -nre 's/^[^0-9]*([0-9]+).*/\1/p')
+  drupal_major_version=$(drush status --fields=drupal-version  | sed -nEe 's/^[^0-9]*([0-9]+).*/\1/p')
   if [[ $drupal_major_version -eq 7 ]] ; then drush cache-clear all; 
   else drush cache-rebuild; fi
 else
@@ -383,7 +383,7 @@ if [ -f /backups/{{ $.Values.backup.restoreId }}/db.sql.gz ]; then
   pv /tmp/backup-data-db.sql | drush sql-cli
 
   # Clear caches before doing anything else.
-  drupal_major_version=$(drush status --fields=drupal-version  | sed -nre 's/^[^0-9]*([0-9]+).*/\1/p')
+  drupal_major_version=$(drush status --fields=drupal-version  | sed -nEe 's/^[^0-9]*([0-9]+).*/\1/p')
   if [[ $drupal_major_version -eq 7 ]] ; then drush cache-clear all; 
   else drush cache-rebuild; fi
 else

--- a/charts/drupal/values.yaml
+++ b/charts/drupal/values.yaml
@@ -214,7 +214,7 @@ php:
   postupgrade:
     command: |
       if [[ "$(drush status --fields=bootstrap)" = *'Successful'* ]] ; then
-        drupal_major_version=$(drush status --fields=drupal-version  | sed -nre 's/^[^0-9]*([0-9]+).*/\1/p')
+        drupal_major_version=$(drush status --fields=drupal-version  | sed -nEe 's/^[^0-9]*([0-9]+).*/\1/p')
         if [[ $drupal_major_version -eq 7 ]] ; then
           drush cache-clear all
           drush updatedb -y

--- a/charts/drupal/values.yaml
+++ b/charts/drupal/values.yaml
@@ -214,13 +214,19 @@ php:
   postupgrade:
     command: |
       if [[ "$(drush status --fields=bootstrap)" = *'Successful'* ]] ; then
-        # This first cache rebuild is unfortunately needed for the common case where a Drupal or
-        # contrib module flaw requires a rebuild before running database updates.
-        drush cr
-        drush updatedb -y
-        if [ -f $DRUPAL_CONFIG_PATH/core.extension.yml ]; then
-          drush config-import -y
-          drush cr
+        drupal_major_version=$(drush status --fields=drupal-version  | sed -nre 's/^[^0-9]*([0-9]+).*/\1/p')
+        if [[ $drupal_major_version -eq 7 ]] ; then
+          drush cache-clear all
+          drush updatedb -y
+        else
+          # This first cache rebuild is unfortunately needed for the common case where a Drupal or
+          # contrib module flaw requires a rebuild before running database updates.
+          drush cache-rebuild
+          drush updatedb -y
+          if [ -f $DRUPAL_CONFIG_PATH/core.extension.yml ]; then
+            drush config-import -y
+            drush cache-rebuild
+          fi
         fi
       fi
 


### PR DESCRIPTION
Since Drupal 7 projects are using this chart now, the build process might fail when `drush cr` is executed.
Tried several ways to detect major version, even define via `.Values.drupal.majorVersion`, but this seems like the least intrusive one.