### PR TITLE
Feature/gcr images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,9 @@ executors:
   silta-latest:
     docker:
       - image: wunderio/silta-circleci:latest
+  silta-gcr:
+    docker:
+      - image: eu.gcr.io/silta-images/cicd:circleci-php7.3-node12-composer1-v0.1
 
 workflows:
   version: 2
@@ -23,7 +26,7 @@ workflows:
           name: build-deploy
 
           # Use the latest orb version.
-          executor: silta-latest
+          executor: silta-gcr
 
           # Use a local chart during development.
           chart_name: "./charts/drupal"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,10 +4,7 @@ orbs:
   silta: silta/silta@dev:master
 
 executors:
-  silta-latest:
-    docker:
-      - image: wunderio/silta-circleci:latest
-  silta-gcr:
+  custom-executor:
     docker:
       - image: eu.gcr.io/silta-images/cicd:circleci-php7.3-node12-composer1-v0.1
 
@@ -25,8 +22,8 @@ workflows:
       - silta/drupal-build-deploy: &build-deploy
           name: build-deploy
 
-          # Use the latest orb version.
-          executor: silta-gcr
+          # Use custom executor.
+          executor: custom-executor
 
           # Use a local chart during development.
           chart_name: "./charts/drupal"

--- a/silta/nginx.Dockerfile
+++ b/silta/nginx.Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for building nginx.
-FROM wunderio/drupal-nginx:latest
+FROM eu.gcr.io/silta-images/nginx:latest
 
 COPY . /app/web
 

--- a/silta/php.Dockerfile
+++ b/silta/php.Dockerfile
@@ -1,4 +1,4 @@
 # Dockerfile for the Drupal container.
-FROM wunderio/drupal-php-fpm:latest
+FROM eu.gcr.io/silta-images/php:7.3-fpm-v0.1
 
 COPY --chown=www-data:www-data . /app

--- a/silta/shell.Dockerfile
+++ b/silta/shell.Dockerfile
@@ -1,4 +1,4 @@
 # Dockerfile for the Drupal container.
-FROM eu.gcr.io/silta-images/shell:7.3-v0.1
+FROM eu.gcr.io/silta-images/shell:php7.3-v0.1
 
 COPY --chown=www-data:www-data . /app

--- a/silta/shell.Dockerfile
+++ b/silta/shell.Dockerfile
@@ -1,4 +1,4 @@
 # Dockerfile for the Drupal container.
-FROM wunderio/drupal-shell:latest
+FROM eu.gcr.io/silta-images/shell:7.3-v0.1
 
 COPY --chown=www-data:www-data . /app


### PR DESCRIPTION
Use the same images (and versions) as currently used on dockerhub, just stored on our GCR to avoid hitting dockerhub usage limits.