### PR TITLE
Some FPM config moved to Docker container

### DIFF
--- a/charts/drupal/templates/drupal-configmap.yaml
+++ b/charts/drupal/templates/drupal-configmap.yaml
@@ -187,11 +187,6 @@ data:
 
   php_fpm_d_custom: |
 
-    [global]
-    error_log = /proc/self/fd/2
-    ; https://github.com/docker-library/php/pull/725#issuecomment-443540114
-    log_limit = 8192
-
     [www]
     pm = dynamic
     ; This should adjust to amount of memory given to the container
@@ -202,15 +197,6 @@ data:
     pm.process_idle_timeout = 60s
     pm.max_requests = 500
     
-    ; if we send this to /proc/self/fd/1, it never appears
-    access.log = /proc/self/fd/2
-    
-    ; Ensure worker stdout and stderr are sent to the main error log.
-    catch_workers_output = yes
-    decorate_workers_output = no
-    
-    clear_env = no
-
     ; Custom configuration below
     {{ .Values.php.fpm.extraConfig | nindent 4 }}
 

--- a/silta/php.Dockerfile
+++ b/silta/php.Dockerfile
@@ -2,3 +2,4 @@
 FROM eu.gcr.io/silta-images/php:7.3-fpm-v0.1
 
 COPY --chown=www-data:www-data . /app
+


### PR DESCRIPTION
FPM config moved out of silta template, so fpm images can have have dedicated config. 

https://github.com/wunderio/drupal-php-fpm/commit/6df24f5dcf0b11035589c002ecf6c57acb81b3b8
https://github.com/wunderio/silta-images/commit/ab9930bd75e2b3343c4418e0955859f92cfd8e29

Config is embedded into container, verified by viewing `/usr/local/etc/php-fpm.d/w-php-defaults.conf` in drupal/php container