### PR TITLE
Mailhog log suppression

### DIFF
--- a/charts/drupal/values.yaml
+++ b/charts/drupal/values.yaml
@@ -509,6 +509,11 @@ memcached:
 # see: https://github.com/codecentric/helm-charts/blob/master/charts/mailhog/values.yaml
 mailhog:
   enabled: false
+  image:
+    # Set image repository to "mailhog/mailhog" to reenable logging.
+    repository: eu.gcr.io/silta-images/silta-mailhog
+    # Set image tag to "" to reenable logging.
+    tag: silent
   resources:
     requests:
       cpu: 1m

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -13,6 +13,9 @@ elasticsearch:
 memcached:
   enabled: false
 
+mailhog:
+  enabled: true
+
 mounts:
   private-files:
     enabled: true

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -13,9 +13,6 @@ elasticsearch:
 memcached:
   enabled: false
 
-mailhog:
-  enabled: true
-
 mounts:
   private-files:
     enabled: true


### PR DESCRIPTION
Our deployments receive a steady flow of mailhog log messages that are normally irrelevant (because it just works) and it generates unnecessary noise. We use [mailhog chart by codecentric](https://github.com/codecentric/helm-charts/tree/master/charts/mailhog) to deploy mailhog, but [there's no way to suppress logs](https://github.com/codecentric/helm-charts/pull/272) other than overriding entrypoint currently. Our solution to this is to replace entrypoint in the Docker image and overriding the image source in helm chart.

Entrypoint override:
https://github.com/wunderio/silta-images/blob/master/silta-mailhog/silent/Dockerfile#L3

If one still wants to see mailhog logs for some reason, he can reset/override `.Values.mailhog.image.repository` and `.Values.mailhog.image.tag` variables.