### PR TITLE
SLT-602: Trim cronjob names

### DIFF
--- a/charts/drupal/templates/drupal-cron.yaml
+++ b/charts/drupal/templates/drupal-cron.yaml
@@ -2,7 +2,8 @@
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  name: {{ $.Release.Name }}-cron-{{ $index }}
+  {{- $indexHash := sha256sum $index | trunc 3 }}
+  name: {{ $.Release.Name }}-cron-{{ (gt (len $index) 6) | ternary ( print ($index | trunc 3) print $indexHash ) $index}}
   labels:
     {{- include "drupal.release_labels" $ | nindent 4 }}
 spec:

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -17,6 +17,7 @@ mounts:
   private-files:
     enabled: true
 
+
 # Allow access from another namespace for testing purposes.
 silta-release:
   proxy:

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -17,7 +17,6 @@ mounts:
   private-files:
     enabled: true
 
-
 # Allow access from another namespace for testing purposes.
 silta-release:
   proxy:


### PR DESCRIPTION
Trims cronjob to fit DNS spec name length, while also having a unique identifier at the end of resources name.