### PR TITLE
Feature/varnish pipe

### DIFF
--- a/charts/drupal/templates/varnish-configmap-vcl.yaml
+++ b/charts/drupal/templates/varnish-configmap-vcl.yaml
@@ -163,8 +163,8 @@ data:
         set beresp.do_esi = true;
       }
 
-      # Pipe files larger than {{ int .Values.varnish.cache_skip_size }} bytes
-      if (std.integer(beresp.http.Content-Length, 0) > {{ int .Values.varnish.cache_skip_size }} ) {
+      # Pipe files larger than {{ int .Values.varnish.cache_skip_size }} megabytes
+      if (std.integer(beresp.http.Content-Length, 0) > {{ mul ( int .Values.varnish.cache_skip_size ) 1024 1024 }} ) {
         set bereq.http.x-error-reason = "oversize";
         return (error);
       }

--- a/charts/drupal/templates/varnish-configmap-vcl.yaml
+++ b/charts/drupal/templates/varnish-configmap-vcl.yaml
@@ -163,6 +163,12 @@ data:
         set beresp.do_esi = true;
       }
 
+      # Files with Content-Length >= 7 digits (~ 10+ Mb) should be piped
+      if ( beresp.http.Content-Length ~ "[0-9]{8,}" ) {
+        set bereq.http.x-error-reason = "oversize";
+        return (error);
+      }
+
       # Store the request url in cached item
       # See "Smart banning" https://www.varnish-software.com/static/book/Cache_invalidation.html
       set beresp.http.x-url = bereq.url;
@@ -214,13 +220,6 @@ data:
         }
       }
 
-      // Making theme development a bit faster on local envs.
-      if (bereq.url ~ "\.(css|js)\??.*$" && bereq.http.host ~ "^local") {
-        set beresp.ttl = 0s;
-        set beresp.http.X-Noncached-Static = 1;
-        set beresp.http.Cache-control = "no-cache, max-age=0, must-revalidate";
-      }
-
       if(beresp.status >= 500){
         // Cache (public) internal errors, but for only 1s. Never cache client side.
         set beresp.ttl = 1s;
@@ -234,6 +233,10 @@ data:
     }
 
     sub vcl_backend_error {
+      if (bereq.http.x-error-reason == "oversize") {
+        set beresp.status = 599;
+        return (deliver);
+      }
       return(retry);
     }
 
@@ -291,8 +294,9 @@ data:
       # which backend to use.
       # also used to modify the request
 
-      if (req.url == "/monit-check-url-happy") {
-        return (synth(200, "Varnish up"));
+      # Pipe connections with x-pipe-request (used for larger file downloads)
+      if (req.http.x-pipe-request && req.restarts > 0) {
+          return(pipe);
       }
 
       # Only allow BAN requests from IP addresses in the 'purge' ACL.
@@ -495,6 +499,11 @@ data:
       unset resp.http.X-Powered-By;
       unset resp.http.x-do-esi;
       unset resp.http.X-Forced-Gzip;
+
+      if (resp.status == 599) {
+        set req.http.x-pipe-request = "1";
+        return (restart);
+      }
 
       # deliver can return synth, but we must avoid a potential loop.
       # This GET-param can be used to see the real backend error:

--- a/charts/drupal/templates/varnish-configmap-vcl.yaml
+++ b/charts/drupal/templates/varnish-configmap-vcl.yaml
@@ -163,8 +163,8 @@ data:
         set beresp.do_esi = true;
       }
 
-      # Files with Content-Length >= 7 digits (~ 10+ Mb) should be piped
-      if ( beresp.http.Content-Length ~ "[0-9]{8,}" ) {
+      # Pipe files larger than {{ int .Values.varnish.cache_skip_size }} bytes
+      if (std.integer(beresp.http.Content-Length, 0) > {{ int .Values.varnish.cache_skip_size }} ) {
         set bereq.http.x-error-reason = "oversize";
         return (error);
       }

--- a/charts/drupal/values.yaml
+++ b/charts/drupal/values.yaml
@@ -450,8 +450,8 @@ varnish:
   status_500_html: ""
   # Additional cookie based rules
   vcl_extra_cookies: ""
-  # Do not cache files larger than 3MB. This needs to be defined in bytes.
-  cache_skip_size: 3036432
+  # Do not cache files larger than 3 megabytes (use integers).
+  cache_skip_size: 3
 
 elasticsearch:
   enabled: false

--- a/charts/drupal/values.yaml
+++ b/charts/drupal/values.yaml
@@ -450,6 +450,8 @@ varnish:
   status_500_html: ""
   # Additional cookie based rules
   vcl_extra_cookies: ""
+  # Do not cache files larger than 3MB. This needs to be defined in bytes.
+  cache_skip_size: 3036432
 
 elasticsearch:
   enabled: false

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -5,7 +5,7 @@
 # for all possible options.
 
 varnish:
-  enabled: false
+  enabled: true
 
 elasticsearch:
   enabled: true

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -5,7 +5,7 @@
 # for all possible options.
 
 varnish:
-  enabled: true
+  enabled: false
 
 elasticsearch:
   enabled: true


### PR DESCRIPTION
Skips varnish cache (pipe) for files bigger than 3MB (size is determined based on Content-Length header and casted to int so 0 would not match).
The filesize threshold can be redefined with `.Values.varnish.cache_skip_size`.