### PR TITLE
Feature/aws cluster/storageclassname

### DIFF
--- a/charts/drupal/templates/solr-statefulset.yaml
+++ b/charts/drupal/templates/solr-statefulset.yaml
@@ -84,6 +84,8 @@ spec:
       accessModes: [ "ReadWriteOnce" ]
       {{- if .Values.solr.persistence.data.storageClassName }}
       storageClassName: {{ .Values.solr.persistence.data.storageClassName }}
+      {{- else if eq .Values.cluster.type "gke" }}
+      storageClassName: standard
       {{- end }}
       {{- if .Values.solr.persistence.data.csiDriverName }}
       csiDriverName: {{ .Values.solr.persistence.data.csiDriverName }}

--- a/charts/drupal/templates/solr-statefulset.yaml
+++ b/charts/drupal/templates/solr-statefulset.yaml
@@ -82,7 +82,9 @@ spec:
       name: {{ .Release.Name }}-solr-data
     spec:
       accessModes: [ "ReadWriteOnce" ]
+      {{- if .Values.solr.persistence.data.storageClassName }}
       storageClassName: {{ .Values.solr.persistence.data.storageClassName }}
+      {{- end }}
       {{- if .Values.solr.persistence.data.csiDriverName }}
       csiDriverName: {{ .Values.solr.persistence.data.csiDriverName }}
       {{- end }}

--- a/charts/drupal/values.yaml
+++ b/charts/drupal/values.yaml
@@ -563,7 +563,7 @@ solr:
   persistence:
     data:
       size: 1Gi
-      storageClassName: standard
+      # storageClassName: standard
       # Provide driver name if using CSI driver backed storage class (optional).
       # csiDriverName: csi-driver-name
       accessModes: 

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -40,3 +40,12 @@ silta-release:
 
 solr:
   enabled: true
+  persistence:
+    data:
+      size: 1Gi
+      # Error: UPGRADE FAILED: cannot patch "feature-storageclassname-solr" with kind StatefulSet: StatefulSet.apps "feature-storageclassname-solr" is invalid: spec: Forbidden: updates to statefulset spec for fields other than 'replicas', 'template', and 'updateStrategy' are forbidden
+      # storageClassName: standard
+      # Provide driver name if using CSI driver backed storage class (optional).
+      # csiDriverName: csi-driver-name
+      accessModes: 
+        - ReadWriteOnce 

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -37,3 +37,6 @@ silta-release:
         - namespaceSelector:
             matchLabels:
               name: drupal-project
+
+solr:
+  enabled: true

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -37,15 +37,3 @@ silta-release:
         - namespaceSelector:
             matchLabels:
               name: drupal-project
-
-solr:
-  enabled: true
-  persistence:
-    data:
-      size: 1Gi
-      # Error: UPGRADE FAILED: cannot patch "feature-storageclassname-solr" with kind StatefulSet: StatefulSet.apps "feature-storageclassname-solr" is invalid: spec: Forbidden: updates to statefulset spec for fields other than 'replicas', 'template', and 'updateStrategy' are forbidden
-      # storageClassName: standard
-      # Provide driver name if using CSI driver backed storage class (optional).
-      # csiDriverName: csi-driver-name
-      accessModes: 
-        - ReadWriteOnce 


### PR DESCRIPTION
removes default `storageClassName`, falls back to standard for gke cluster type, otherwise upgrade for existing deployments fail with

> Error: UPGRADE FAILED: cannot patch "feature-storageclassname-solr" with kind StatefulSet: StatefulSet.apps "feature-storageclassname-solr" is invalid: spec: Forbidden: updates to statefulset spec for fields other than 'replicas', 'template', and 'updateStrategy' are forbidden

Not setting `storageClassName` for new deployments uses cluster's default storageclass.