### PR TITLE
Pass maxMemoryLimit and maxItemSize as command arguments to memcached.

### DIFF
--- a/charts/drupal/values.yaml
+++ b/charts/drupal/values.yaml
@@ -506,7 +506,7 @@ memcached:
       memory: 128Mi
   arguments:
     - /run.sh
-    # MaxMemoryLimit, this should be less than the memory limit, or memcached will crash.
+    # MaxMemoryLimit, this should be less than the resources.limits.memory, or memcached will crash.
     - -m 118
     # MaxItemSize
     - -I 4M

--- a/charts/drupal/values.yaml
+++ b/charts/drupal/values.yaml
@@ -494,20 +494,22 @@ elasticsearch:
           - static-ip
 
 # Memcache service overrides
-# see: https://github.com/helm/charts/blob/master/stable/memcached/values.yaml
+# see: https://github.com/bitnami/charts/blob/master/bitnami/memcached/values.yaml
 memcached:
   enabled: false
   replicaCount: 1
-  pdbMinAvailable: 0
-  memcached:
-    # This should be less than the memory limit, or memcached will crash.
-    maxItemMemory: 118
   resources:
     requests:
       cpu: 10m
       memory: 128Mi
     limits:
       memory: 128Mi
+  arguments:
+    - /run.sh
+    # MaxMemoryLimit, this should be less than the memory limit, or memcached will crash.
+    - -m 118
+    # MaxItemSize
+    - -I 4M
 
 # Mailhog service overrides
 # see: https://github.com/codecentric/helm-charts/blob/master/charts/mailhog/values.yaml


### PR DESCRIPTION
Memcache chart has been changed from Kubernetes stable to Bitnami (https://github.com/wunderio/drupal-project-k8s/commit/735d7e242e93484712fd0a5aef1d87e2bc5652e7) but the configurations to comply with Bitnami chart wasn't updated.
This pull request updates the memcached maxMemorySize from `memcached.maxItemMemory` to be passed as command argument. An alternative option to pass the maxMemorySize would have been to use `extraEnv` and set the `MEMCACHED_CACHE_SIZE` like this:
```
  extraEnv:
    - name: MEMCACHED_CACHE_SIZE
    - value: "118"
```
Using environment variables however doesn't allow setting some other configuration variables such as `maxItemSize` which must be provided as a command line argument. So if we want to set both the `arguments` option is more simple solution.

How to test:
1. Enable memcached by setting `enabled: true` in `silta/silta.yml`
2. Verify the deployed memcached instance has the defined default 118M maxMemoryLimit and not the 64M limit which is default for the image.
3. Add 
```  
  arguments:
    - /run.sh
    - -m 96
    - -I 4M
```
  to the `silta/silta.yml` under `memcached:`
4. Verify the deployed memcached instance has the updated config values.