### PR TITLE
Feature/ingress annotations

### DIFF
--- a/charts/drupal/templates/drupal-ingress.yaml
+++ b/charts/drupal/templates/drupal-ingress.yaml
@@ -35,7 +35,7 @@ metadata:
     {{- end }}
 
     {{- if $ingress.extraAnnotations }}
-    {{ $ingress.extraAnnotations | toYaml }}
+    {{- $ingress.extraAnnotations | toYaml | nindent 4 }}
     {{- end }}
     
     {{- if (index .Values "silta-release").downscaler.enabled }}
@@ -124,7 +124,7 @@ metadata:
     {{- end }}
     
     {{- if $ingress.extraAnnotations }}
-    {{ $ingress.extraAnnotations | toYaml }}
+    {{- $ingress.extraAnnotations | toYaml | nindent 4 }}
     {{- end }}
 spec:
   {{- if $ingress.tls }}

--- a/charts/drupal/templates/drupal-ingress.yaml
+++ b/charts/drupal/templates/drupal-ingress.yaml
@@ -33,6 +33,10 @@ metadata:
     {{- if $ingress.staticIpAddressName }}
     kubernetes.io/ingress.global-static-ip-name: {{ $ingress.staticIpAddressName | quote }}
     {{- end }}
+
+    {{- if $ingress.extraAnnotations }}
+    {{ $ingress.extraAnnotations | toYaml }}
+    {{- end }}
     
     {{- if (index .Values "silta-release").downscaler.enabled }}
     auto-downscale/last-update: {{ dateInZone "2006-01-02T15:04:05.999Z" (now) "UTC" }}
@@ -117,6 +121,10 @@ metadata:
     {{- end }}
     {{- if $ingress.staticIpAddressName }}
     kubernetes.io/ingress.global-static-ip-name: {{ $ingress.staticIpAddressName | quote }}
+    {{- end }}
+    
+    {{- if $ingress.extraAnnotations }}
+    {{ $ingress.extraAnnotations | toYaml }}
     {{- end }}
 spec:
   {{- if $ingress.tls }}

--- a/charts/drupal/values.yaml
+++ b/charts/drupal/values.yaml
@@ -77,6 +77,9 @@ ingress:
     # The name of the reserved static IP address.
     # It is best to first reserve the IP address and then add it here.
     # staticIpAddressName: null
+    # Custom ingress annotations
+    # extraAnnotations: |
+    #   networking.gke.io/suppress-firewall-xpn-error: true
 
 # Infrastructure related settings.
 cluster:

--- a/charts/drupal/values.yaml
+++ b/charts/drupal/values.yaml
@@ -78,8 +78,8 @@ ingress:
     # It is best to first reserve the IP address and then add it here.
     # staticIpAddressName: null
     # Custom ingress annotations
-    # extraAnnotations: |
-    #   networking.gke.io/suppress-firewall-xpn-error: true
+    # extraAnnotations:
+    #   networking.gke.io/suppress-firewall-xpn-error: "true"
 
 # Infrastructure related settings.
 cluster:

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -37,3 +37,17 @@ silta-release:
         - namespaceSelector:
             matchLabels:
               name: drupal-project
+
+exposeDomains:
+  annotation-test:
+    hostname: drupal-project-k8s-annotation-test.wdr.io
+    ingress: test
+    
+ingress:
+  test:
+    type: traefik
+    tls: true
+    redirect-https: true
+    extraAnnotations:
+      networking.gke.io/suppress-firewall-xpn-error: "true"
+      test-annotation2: "true"

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -37,17 +37,3 @@ silta-release:
         - namespaceSelector:
             matchLabels:
               name: drupal-project
-
-exposeDomains:
-  annotation-test:
-    hostname: drupal-project-k8s-annotation-test.wdr.io
-    ingress: test
-    
-ingress:
-  test:
-    type: traefik
-    tls: true
-    redirect-https: true
-    extraAnnotations:
-      networking.gke.io/suppress-firewall-xpn-error: "true"
-      test-annotation2: "true"


### PR DESCRIPTION
Allows custom ingress annotations. 

Example usage:

```
ingress:
  gce:
    type: gce
    (..)
    # Custom ingress annotations
    extraAnnotations:
      networking.gke.io/suppress-firewall-xpn-error: "true"
```

This would generate following resource definition:
```
kind: Ingress
metadata:
  annotations:
    networking.gke.io/suppress-firewall-xpn-error: true
    (..)
(..)    
```