### PR TITLE
Allow passing extra parameters for varnishd

### DIFF
--- a/charts/drupal/templates/varnish-deployment.yaml
+++ b/charts/drupal/templates/varnish-deployment.yaml
@@ -37,6 +37,10 @@ spec:
         env:
         - name: VARNISH_STORAGE_BACKEND
           value: {{ .Values.varnish.storageBackend | quote }}
+        {{- if .Values.varnish.extraParams }}
+        - name: VARNISH_EXTRA_PARAMS
+          value: {{ .Values.varnish.extraParams | quote }}
+        {{- end }}
         resources:
 {{ .Values.varnish.resources | toYaml | indent 10 }}
         volumeMounts:

--- a/charts/drupal/tests/varnish_test.yaml
+++ b/charts/drupal/tests/varnish_test.yaml
@@ -15,6 +15,18 @@ tests:
           content:
             name: VARNISH_STORAGE_BACKEND
             value: 'type,/storage/location,size'
+  - it: sets VARNISH_EXTRA_PARAMS environment variable correctly
+    template: varnish-deployment.yaml
+    set:
+      varnish.enabled: true
+      varnish.extraParams: '-foo -bar'
+    asserts: 
+      - documentIndex: 0
+        contains:
+          path: 'spec.template.spec.containers[0].env'
+          content:
+            name: VARNISH_EXTRA_PARAMS
+            value: '-foo -bar'
 
   - it: takes resource requests and limits
     template: varnish-deployment.yaml

--- a/charts/drupal/values.yaml
+++ b/charts/drupal/values.yaml
@@ -445,8 +445,10 @@ varnish:
       memory: 32Mi
   image: eu.gcr.io/silta-images/varnish
   imageTag: 6-v0.1
-  # https://varnish-cache.org/docs/trunk/users-guide/storage-backends.html
+  # https://varnish-cache.org/docs/6.0/users-guide/storage-backends.html
   storageBackend: 'file,/var/lib/varnish/varnish_storage.bin,512M'
+  # https://varnish-cache.org/docs/6.0/reference/varnishd.html#list-of-parameters
+  extraParams: ""
   # Inject custom code into vcl_recv subroutine.
   vcl_recv_extra: ""
   # Html code for status 500 page.


### PR DESCRIPTION
Allows defining custom parameters for varnishd.
Related image adjustment: https://github.com/wunderio/silta-images/commit/198370953d50325259945c40c447acef1114c9e8

```
varnish:
  enabled: true
  extraParams: "-p http_resp_hdr_len=65536 -p http_resp_size=98304"
```