### PR TITLE
Make varnish more configurable

### DIFF
--- a/charts/drupal/templates/varnish-configmap-vcl.yaml
+++ b/charts/drupal/templates/varnish-configmap-vcl.yaml
@@ -15,19 +15,19 @@ data:
     backend prod1_http1 {
       .host = "{{ .Release.Name }}-drupal";
       .port = "80";
-      .max_connections = 300;
+      .max_connections = {{ int .Values.varnish.max_connections }};
 
       .probe = {
-        .url       = "/robots.txt"; 
-        .interval  = 5s; # check the health of each backend every n seconds
-        .timeout   = 1s; # timing out after n seconds
-        .window    = 5;  # If 3 out of the last 5 polls succeeded the backend is
-        .threshold = 3;  # considered healthy, otherwise it will be marked as sick
+        .url       = {{ .Values.varnish.probe_url }}; 
+        .interval  = {{ .Values.varnish.probe_interval }}; # check the health of each backend every n seconds
+        .timeout   = {{ .Values.varnish.probe_timeout }}; # timing out after n seconds
+        .window    = {{ int .Values.varnish.probe_window }};  # If 3 out of the last 5 polls succeeded the backend is
+        .threshold = {{ int .Values.varnish.probe_threshold }};  # considered healthy, otherwise it will be marked as sick
       }
 
-      .first_byte_timeout     = 300s;    # How long to wait before we receive a first byte from our backend?
-      .connect_timeout        = 10s;     # How long to wait for a backend connection?
-      .between_bytes_timeout  = 10s;     # How long to wait between bytes received from our backend?
+      .first_byte_timeout     = {{ .Values.varnish.first_byte_timeout }};    # How long to wait before we receive a first byte from our backend?
+      .connect_timeout        = {{ .Values.varnish.connect_timeout }};     # How long to wait for a backend connection?
+      .between_bytes_timeout  = {{ .Values.varnish.between_bytes_timeout }};     # How long to wait between bytes received from our backend?
     }
  
     # Define the internal network access.

--- a/charts/drupal/values.yaml
+++ b/charts/drupal/values.yaml
@@ -457,6 +457,24 @@ varnish:
   vcl_extra_cookies: ""
   # Do not cache files larger than 3 megabytes (use integers).
   cache_skip_size: 3
+  # Maximum amount of connections
+  max_connections: 300
+  # Probe URL
+  probe_url: "/robots.txt"
+  # Check the health of each backend every n seconds
+  probe_interval: 5s
+  # Probe timeout after n seconds.
+  probe_timeout: 1s
+  # If {{threshold}} out of the last {{window}} polls succeeded the backend is..
+  probe_window: 5
+  # ..considered healthy, otherwise it will be marked as sick
+  probe_threshold: 3
+  # How long to wait before we receive a first byte from our backend?
+  first_byte_timeout: 300s
+  # How long to wait for a backend connection?
+  connect_timeout: 10s
+  # How long to wait between bytes received from our backend?
+  between_bytes_timeout: 10s
 
 elasticsearch:
   enabled: false

--- a/charts/drupal/values.yaml
+++ b/charts/drupal/values.yaml
@@ -464,7 +464,7 @@ varnish:
   # Check the health of each backend every n seconds
   probe_interval: 5s
   # Probe timeout after n seconds.
-  probe_timeout: 1s
+  probe_timeout: 5s
   # If {{threshold}} out of the last {{window}} polls succeeded the backend is..
   probe_window: 5
   # ..considered healthy, otherwise it will be marked as sick


### PR DESCRIPTION
When we try to ddos our silta-prod environment we see some 503 errors from Varnish and we'd like to see if we can avoid those errors by adjusting connect_timeout (at least). 

I figured it could be nice to make the other probe settings configurable while I was at it.  