### PR TITLE
Make varnish backend config configurable

### DIFF
--- a/charts/drupal/templates/varnish-configmap-vcl.yaml
+++ b/charts/drupal/templates/varnish-configmap-vcl.yaml
@@ -15,7 +15,7 @@ data:
     backend prod1_http1 {
       .host = "{{ .Release.Name }}-drupal";
       .port = "80";
-      {{ .Values.varnish.backend_config }}
+      {{- .Values.varnish.backend_config | nindent 6 }}
     }
  
     # Define the internal network access.

--- a/charts/drupal/templates/varnish-configmap-vcl.yaml
+++ b/charts/drupal/templates/varnish-configmap-vcl.yaml
@@ -15,19 +15,7 @@ data:
     backend prod1_http1 {
       .host = "{{ .Release.Name }}-drupal";
       .port = "80";
-      .max_connections = 300;
-
-      .probe = {
-        .url       = "/robots.txt"; 
-        .interval  = 5s; # check the health of each backend every n seconds
-        .timeout   = 1s; # timing out after n seconds
-        .window    = 5;  # If 3 out of the last 5 polls succeeded the backend is
-        .threshold = 3;  # considered healthy, otherwise it will be marked as sick
-      }
-
-      .first_byte_timeout     = 300s;    # How long to wait before we receive a first byte from our backend?
-      .connect_timeout        = 10s;     # How long to wait for a backend connection?
-      .between_bytes_timeout  = 10s;     # How long to wait between bytes received from our backend?
+      {{ .Values.varnish.backend_config }}
     }
  
     # Define the internal network access.

--- a/charts/drupal/values.yaml
+++ b/charts/drupal/values.yaml
@@ -462,15 +462,14 @@ varnish:
     .max_connections = 300;
     .probe = {
       .url       = "/robots.txt";
-      .interval  = 5s; # check the health of each backend every n seconds
-      .timeout   = 5s; # timing out after n seconds
-      .window    = 5;  # If 3 out of the last 5 polls succeeded the backend is
-      .threshold = 3;  # considered healthy, otherwise it will be marked as sick
+      .interval  = 5s;
+      .timeout   = 5s;
+      .window    = 5;
+      .threshold = 3;
     }
-
-    .first_byte_timeout     = 300s;    # How long to wait before we receive a first byte from our backend?
-    .connect_timeout        = 10s;     # How long to wait for a backend connection?
-    .between_bytes_timeout  = 10s;     # How long to wait between bytes received from our backend?
+    .first_byte_timeout     = 300s;
+    .connect_timeout        = 10s;
+    .between_bytes_timeout  = 10s;
 
 elasticsearch:
   enabled: false

--- a/charts/drupal/values.yaml
+++ b/charts/drupal/values.yaml
@@ -457,6 +457,20 @@ varnish:
   vcl_extra_cookies: ""
   # Do not cache files larger than 3 megabytes (use integers).
   cache_skip_size: 3
+  # https://varnish-cache.org/docs/6.0/reference/vcl.html#backend-definition
+  backend_config: |
+    .max_connections = 300;
+    .probe = {
+      .url       = "/robots.txt";
+      .interval  = 5s; # check the health of each backend every n seconds
+      .timeout   = 5s; # timing out after n seconds
+      .window    = 5;  # If 3 out of the last 5 polls succeeded the backend is
+      .threshold = 3;  # considered healthy, otherwise it will be marked as sick
+    }
+
+    .first_byte_timeout     = 300s;    # How long to wait before we receive a first byte from our backend?
+    .connect_timeout        = 10s;     # How long to wait for a backend connection?
+    .between_bytes_timeout  = 10s;     # How long to wait between bytes received from our backend?
 
 elasticsearch:
   enabled: false


### PR DESCRIPTION
Bonus: Increase default varnish probe timeout to 5s to hopefully avoid 503s under high load. 