### PR TITLE
Support for existing TLS secrets.

### DIFF
--- a/charts/drupal/templates/drupal-certificate.yaml
+++ b/charts/drupal/templates/drupal-certificate.yaml
@@ -128,7 +128,7 @@ spec:
 ---
 
 {{- else if eq $domain.ssl.issuer "custom" }}
-{{- if not $context_ssl.existingTLSSecret }}
+{{- if not $domain.ssl.existingTLSSecret }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/drupal/templates/drupal-certificate.yaml
+++ b/charts/drupal/templates/drupal-certificate.yaml
@@ -65,6 +65,7 @@ spec:
 ---
 
 {{- else if eq $context_ssl.issuer "custom" }}
+{{- if not $context_ssl.existingTLSSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -77,6 +78,7 @@ data:
   tls.crt: {{ $context_ssl.crt | b64enc }}
   tls.key: {{ $context_ssl.key | b64enc }}
 ---
+{{- end }}
 {{- end }}
 
 # Certificates for exposeDomains 
@@ -126,6 +128,7 @@ spec:
 ---
 
 {{- else if eq $domain.ssl.issuer "custom" }}
+{{- if not $context_ssl.existingTLSSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -138,6 +141,7 @@ data:
   tls.crt: {{ $domain.ssl.crt | default "" | b64enc }}
   tls.key: {{ $domain.ssl.key | default "" | b64enc }}
 ---
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/drupal/templates/drupal-ingress.yaml
+++ b/charts/drupal/templates/drupal-ingress.yaml
@@ -48,9 +48,13 @@ metadata:
 spec:
   {{- if $ingress.tls }}
   tls:
+  {{- if .Values.ssl.existingTLSSecret }}
+  - secretName: {{ .Values.ssl.existingTLSSecret }}
+  {{- else }}
   - secretName: {{ .Release.Name }}-tls
   {{- range $index, $prefix := .Values.domainPrefixes }}
   - secretName: {{ $.Release.Name }}-tls-p{{ $index }}
+  {{- end }}
   {{- end }}
   {{- end }}
   rules:

--- a/charts/drupal/templates/drupal-ingress.yaml
+++ b/charts/drupal/templates/drupal-ingress.yaml
@@ -134,7 +134,11 @@ spec:
   {{- if eq $domain.ingress $ingress_index }}
   {{- if $domain.ssl }}
   {{- if $domain.ssl.enabled }}
+  {{- if $domain.ssl.existingTLSSecret }}
+  - secretName: {{ $domain.ssl.existingTLSSecret }}
+  {{- else }}
   - secretName: {{ $.Release.Name }}-tls-{{ $domain_index }}
+  {{- end }}
   {{- end }}
   {{- end }}
   {{- end }}

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -45,3 +45,7 @@ exposeDomains:
       enabled: true
       issuer: custom
       existingTLSSecret: tlstest-tls
+
+ssl:
+  issuer: custom
+  existingTLSSecret: tlstest-tls

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -37,3 +37,10 @@ silta-release:
         - namespaceSelector:
             matchLabels:
               name: drupal-project
+
+exposeDomains:
+  tlstest:
+    hostname: tlstest.dev.wdr.io
+    ssl:
+      enabled: true
+      existingTLSSecret: tlstest-tls

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -45,7 +45,3 @@ exposeDomains:
       enabled: true
       issuer: custom
       existingTLSSecret: tlstest-tls
-
-ssl:
-  issuer: custom
-  existingTLSSecret: tlstest-tls

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -37,11 +37,3 @@ silta-release:
         - namespaceSelector:
             matchLabels:
               name: drupal-project
-
-exposeDomains:
-  tlstest:
-    hostname: tlstest.dev.wdr.io
-    ssl:
-      enabled: true
-      issuer: custom
-      existingTLSSecret: tlstest-tls

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -43,4 +43,5 @@ exposeDomains:
     hostname: tlstest.dev.wdr.io
     ssl:
       enabled: true
+      issuer: custom
       existingTLSSecret: tlstest-tls


### PR DESCRIPTION
Ensure the test domain is using the provided existing secret.
Note: the existing secret doesn't have valid cert.

Reminder to self: remove test domain from silta.yaml