### PR TITLE
Allow skipping files backup.

### DIFF
--- a/charts/drupal/templates/_helpers.tpl
+++ b/charts/drupal/templates/_helpers.tpl
@@ -463,12 +463,14 @@ fi
   mkdir -p $BACKUP_LOCATION
   cp /tmp/db.sql.gz $BACKUP_LOCATION/db.sql.gz
 
+  {{- if not .Values.backup.skipFiles }}
   {{ range $index, $mount := .Values.mounts -}}
   {{- if eq $mount.enabled true }}
   # File backup for {{ $index }} volume.
   echo "Starting {{ $index }} volume backup."
   tar -czP --exclude=css --exclude=js --exclude=styles -f $BACKUP_LOCATION/{{ $index }}.tar.gz {{ $mount.mountPath }}
   {{- end -}}
+  {{- end }}
   {{- end }}
 
   # Delete old backups

--- a/charts/drupal/values.yaml
+++ b/charts/drupal/values.yaml
@@ -395,6 +395,9 @@ backup:
   # These tables will have their content ignored from the backups.
   ignoreTableContent: '(cache|cache_.*)'
 
+  #  Do not backup files
+  #skipFiles: true
+
   # Resources for the backup cron job.
   resources:
     requests:


### PR DESCRIPTION
In case the storage backend filesystem is already backed up there is no need to take extra backups of files.