### PR TITLE
Make Drupal installation path configurable.

### DIFF
--- a/charts/drupal/templates/_helpers.tpl
+++ b/charts/drupal/templates/_helpers.tpl
@@ -35,11 +35,11 @@ ports:
   readOnly: true
   subPath: php_ini
 - name: config
-  mountPath: /app/web/sites/default/settings.silta.php
+  mountPath: /app/{{ .Values.appPath }}/sites/default/settings.silta.php
   readOnly: true
   subPath: settings_silta_php
 - name: config
-  mountPath: /app/web/sites/default/silta.services.yml
+  mountPath: /app/{{ .Values.appPath }}/sites/default/silta.services.yml
   readOnly: true
   subPath: silta_services_yml
 - name: config
@@ -251,7 +251,7 @@ done
 {{- end }}
 
 {{- define "drupal.installation-in-progress-test" -}}
--f /app/web/sites/default/files/_installing
+-f /app/{{ .Values.appPath }}/sites/default/files/_installing
 {{- end -}}
 
 
@@ -265,7 +265,7 @@ done
   {{ include "drupal.wait-for-db-command" . }}
 
   {{ if .Release.IsInstall }}
-    touch /app/web/sites/default/files/_installing
+    touch /app/{{ .Values.appPath }}/sites/default/files/_installing
     {{- if .Values.referenceData.enabled }}
       {{ include "drupal.import-reference-db" . }}
     {{- end }}
@@ -277,7 +277,7 @@ done
 
   {{ if .Release.IsInstall }}
     {{ .Values.php.postinstall.command }}
-    rm /app/web/sites/default/files/_installing
+    rm /app/{{ .Values.appPath }}/sites/default/files/_installing
   {{ end }}
   {{ .Values.php.postupgrade.command }}
   {{- if .Values.php.postupgrade.afterCommand }}
@@ -305,7 +305,7 @@ done
   # Restore files from targeted backup
   {{ include "drupal.import-backup-files" . }}
 
-  touch /app/web/sites/default/files/_installing
+  touch /app/{{ .Values.appPath }}/sites/default/files/_installing
 
   # Restore db from targeted backup
   {{ include "drupal.import-backup-db" . }}
@@ -319,7 +319,7 @@ done
 
   # Running custom commands after restored backup
   {{ .Values.php.postRestoreCommand }}
-  rm /app/web/sites/default/files/_installing
+  rm /app/{{ .Values.appPath }}/sites/default/files/_installing
 
 {{- end }}
 

--- a/charts/drupal/templates/_helpers.tpl
+++ b/charts/drupal/templates/_helpers.tpl
@@ -35,11 +35,11 @@ ports:
   readOnly: true
   subPath: php_ini
 - name: config
-  mountPath: /app/{{ .Values.appPath }}/sites/default/settings.silta.php
+  mountPath: {{ .Values.webRoot }}/sites/default/settings.silta.php
   readOnly: true
   subPath: settings_silta_php
 - name: config
-  mountPath: /app/{{ .Values.appPath }}/sites/default/silta.services.yml
+  mountPath: {{ .Values.webRoot }}/sites/default/silta.services.yml
   readOnly: true
   subPath: silta_services_yml
 - name: config
@@ -251,7 +251,7 @@ done
 {{- end }}
 
 {{- define "drupal.installation-in-progress-test" -}}
--f /app/{{ $.Values.appPath }}/sites/default/files/_installing
+-f {{ $.Values.webRoot }}/sites/default/files/_installing
 {{- end -}}
 
 
@@ -265,7 +265,7 @@ done
   {{ include "drupal.wait-for-db-command" . }}
 
   {{ if .Release.IsInstall }}
-    touch /app/{{ .Values.appPath }}/sites/default/files/_installing
+    touch {{ .Values.webRoot }}/sites/default/files/_installing
     {{- if .Values.referenceData.enabled }}
       {{ include "drupal.import-reference-db" . }}
     {{- end }}
@@ -277,7 +277,7 @@ done
 
   {{ if .Release.IsInstall }}
     {{ .Values.php.postinstall.command }}
-    rm /app/{{ .Values.appPath }}/sites/default/files/_installing
+    rm {{ .Values.webRoot }}/sites/default/files/_installing
   {{ end }}
   {{ .Values.php.postupgrade.command }}
   {{- if .Values.php.postupgrade.afterCommand }}
@@ -305,7 +305,7 @@ done
   # Restore files from targeted backup
   {{ include "drupal.import-backup-files" . }}
 
-  touch /app/{{ .Values.appPath }}/sites/default/files/_installing
+  touch {{ .Values.webRoot }}/sites/default/files/_installing
 
   # Restore db from targeted backup
   {{ include "drupal.import-backup-db" . }}
@@ -319,7 +319,7 @@ done
 
   # Running custom commands after restored backup
   {{ .Values.php.postRestoreCommand }}
-  rm /app/{{ .Values.appPath }}/sites/default/files/_installing
+  rm {{ .Values.webRoot }}/sites/default/files/_installing
 
 {{- end }}
 

--- a/charts/drupal/templates/_helpers.tpl
+++ b/charts/drupal/templates/_helpers.tpl
@@ -12,7 +12,7 @@ release: {{ .Release.Name }}
 app.kubernetes.io/name: {{ .Values.app | quote }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
-helm.sh/chart: {{ template "drupal.chart" . }}  
+helm.sh/chart: {{ template "drupal.chart" . }}
 {{- end }}
 
 {{- define "drupal.php-container" -}}
@@ -251,7 +251,7 @@ done
 {{- end }}
 
 {{- define "drupal.installation-in-progress-test" -}}
--f /app/{{ .Values.appPath }}/sites/default/files/_installing
+-f /app/{{ $.Values.appPath }}/sites/default/files/_installing
 {{- end -}}
 
 
@@ -453,7 +453,7 @@ fi
 {{- end }}
 
 {{- define "drupal.backup-command.archive-store-backup" -}}
-  
+
   # Compress the database dump and copy it into the backup folder.
   # We don't do this directly on the volume mount to avoid sending the uncompressed dump across the network.
   echo "Compressing database backup."
@@ -482,12 +482,12 @@ fi
 
 
 {{- define "mariadb.db-validation" -}}
-  
+
   set -e
 
   echo "** DB validation"
 
-  export DB_USER=root 
+  export DB_USER=root
   export DB_PASS={{ .db_password }}
   export DB_HOST=127.0.0.1
   export DB_NAME=drupal

--- a/charts/drupal/templates/drupal-configmap.yaml
+++ b/charts/drupal/templates/drupal-configmap.yaml
@@ -270,7 +270,7 @@ data:
         }
         {{- end }}
 
-        root /app/web;
+        root /app/{{ .Values.appPath }};
         index index.php;
 
         include fastcgi.conf;

--- a/charts/drupal/templates/drupal-configmap.yaml
+++ b/charts/drupal/templates/drupal-configmap.yaml
@@ -67,10 +67,10 @@ data:
     ; Disable Twig instrumentation, it causes issues when used with Drupal.
     ; See https://docs.instana.io/ecosystem/php/#tracing
     instana.disabled_instrumentation=2097152
-    
+
     ; Custom configuration below
     {{ .Values.php.php_ini.extraConfig | nindent 4 }}
-    
+
   nginx_conf: |
     user                            nginx;
     worker_processes                auto;
@@ -141,7 +141,7 @@ data:
 
         types_hash_max_size 8192;
         server_names_hash_bucket_size 64;
-        
+
         map_hash_bucket_size 128;
 
         map $uri $no_slash_uri {
@@ -149,7 +149,7 @@ data:
         }
 
         # List health checks that need to return status 200 here
-        map $http_user_agent $hc_ua { default 0; 'GoogleHC/1.0' 1; } 
+        map $http_user_agent $hc_ua { default 0; 'GoogleHC/1.0' 1; }
 
         include conf.d/*.conf;
     }
@@ -193,7 +193,7 @@ data:
     pm.max_spare_servers = 2
     pm.process_idle_timeout = 60s
     pm.max_requests = 500
-    
+
     ; Custom configuration below
     {{ .Values.php.fpm.extraConfig | nindent 4 }}
 
@@ -257,7 +257,7 @@ data:
         server_name drupal;
         listen 80;
 
-        # Loadbalancer health checks need to be fed with http 200 
+        # Loadbalancer health checks need to be fed with http 200
         if ($hc_ua) { return 200; }
 
         {{- if .Values.nginx.redirects }}
@@ -270,7 +270,7 @@ data:
         }
         {{- end }}
 
-        root /app/{{ .Values.appPath }};
+        root {{ .Values.webRoot }};
         index index.php;
 
         include fastcgi.conf;
@@ -318,7 +318,7 @@ data:
 
             # Custom configuration gets included here
             {{ if .Values.nginx.locationExtraConfig }}
-            {{ .Values.nginx.locationExtraConfig | nindent 10 }} 
+            {{ .Values.nginx.locationExtraConfig | nindent 10 }}
             {{- end }}
 
             location ~* /system/files/ {

--- a/charts/drupal/templates/drupal-cron.yaml
+++ b/charts/drupal/templates/drupal-cron.yaml
@@ -31,9 +31,9 @@ spec:
             args:
               - |
                  set -ex
-                 if [ ! {{ include "drupal.installation-in-progress-test" . }} ]
+                 if [ ! {{ include "drupal.installation-in-progress-test" $ }} ]
                  then
-                  {{ $job.command | nindent 18 }} 
+                  {{ $job.command | nindent 18 }}
                  else
                    exit 1
                  fi

--- a/charts/drupal/test.values.yaml
+++ b/charts/drupal/test.values.yaml
@@ -33,3 +33,5 @@ mounts:
 
 cluster:
   type: ""
+
+appPath: web

--- a/charts/drupal/test.values.yaml
+++ b/charts/drupal/test.values.yaml
@@ -33,5 +33,3 @@ mounts:
 
 cluster:
   type: ""
-
-appPath: web

--- a/charts/drupal/values.schema.json
+++ b/charts/drupal/values.schema.json
@@ -53,6 +53,7 @@
     "branchName": { "type": "string" },
     "imagePullSecrets": { "type": "array" },
     "app": { "type": "string" },
+    "appPath": { "type": "string" },
 
     "replicas": { "type": "integer" },
     "autoscaling": {

--- a/charts/drupal/values.schema.json
+++ b/charts/drupal/values.schema.json
@@ -53,7 +53,7 @@
     "branchName": { "type": "string" },
     "imagePullSecrets": { "type": "array" },
     "app": { "type": "string" },
-    "appPath": { "type": "string" },
+    "webRoot": { "type": "string" },
 
     "replicas": { "type": "integer" },
     "autoscaling": {

--- a/charts/drupal/values.yaml
+++ b/charts/drupal/values.yaml
@@ -26,19 +26,7 @@ app: drupal
 
 # Path to the web root folder.
 # If you change this, make sure to check for any other references to "/app/web" or "web/" in your project.
-# Some known references are:
-# - public-files mount in this file
-# - silta/nginx.Dockerfile
-# - composer.json & composer.lock
-# - .dockerignore
-# - .gitignore
-# - .lando.yml
-# - grumphp.yml
-# - phpcs.xml
-# In .circleci/config.yml you also need to add the following parameters and put
-# your webRoot directory name as the value, for example "web" or "docroot":
-# - To silta/drupal-validate job, add parameter web-root
-# - To silta/drupal-deploy-build job, add parameter nginx_build_context
+# See https://github.com/wunderio/silta/blob/master/docs/changing_the_webroot.md
 webRoot: /app/web
 
 # How many instances of the Drupal pod should be in our Kubernetes deployment.

--- a/charts/drupal/values.yaml
+++ b/charts/drupal/values.yaml
@@ -24,6 +24,9 @@ imagePullSecrets: []
 # The app label added to our Kubernetes resources.
 app: drupal
 
+# Path to the app root folder
+appPath: web
+
 # How many instances of the Drupal pod should be in our Kubernetes deployment.
 # A single pod (the default value) is good for development environments to minimise resource usage.
 # Multiple pods make sense for high availability.

--- a/charts/drupal/values.yaml
+++ b/charts/drupal/values.yaml
@@ -25,7 +25,20 @@ imagePullSecrets: []
 app: drupal
 
 # Path to the web root folder.
-# If you change this, make sure to check for any other instances of "/app/web" in this file.
+# If you change this, make sure to check for any other references to "/app/web" or "web/" in your project.
+# Some known references are:
+# - public-files mount in this file
+# - silta/nginx.Dockerfile
+# - composer.json & composer.lock
+# - .dockerignore
+# - .gitignore
+# - .lando.yml
+# - grumphp.yml
+# - phpcs.xml
+# In .circleci/config.yml you also need to add the following parameters and put
+# your webRoot directory name as the value, for example "web" or "docroot":
+# - To silta/drupal-validate job, add parameter web-root
+# - To silta/drupal-deploy-build job, add parameter nginx_build_context
 webRoot: /app/web
 
 # How many instances of the Drupal pod should be in our Kubernetes deployment.

--- a/charts/drupal/values.yaml
+++ b/charts/drupal/values.yaml
@@ -24,8 +24,8 @@ imagePullSecrets: []
 # The app label added to our Kubernetes resources.
 app: drupal
 
-# Path to the app root folder
-appPath: web
+# Path to the web root folder.
+webRoot: /app/web
 
 # How many instances of the Drupal pod should be in our Kubernetes deployment.
 # A single pod (the default value) is good for development environments to minimise resource usage.

--- a/charts/drupal/values.yaml
+++ b/charts/drupal/values.yaml
@@ -25,6 +25,7 @@ imagePullSecrets: []
 app: drupal
 
 # Path to the web root folder.
+# If you change this, make sure to check for any other instances of "/app/web" in this file.
 webRoot: /app/web
 
 # How many instances of the Drupal pod should be in our Kubernetes deployment.
@@ -308,6 +309,7 @@ mounts:
   public-files:
     enabled: true
     storage: 1G
+    # Assumes that webRoot is set to the default value "/app/web".
     mountPath: /app/web/sites/default/files
     storageClassName: silta-shared
     csiDriverName: csi-rclone


### PR DESCRIPTION
When running production on 3rd party hosting for example in Acquia cloud the Drupal installation path needs to be different from our standard `/web`.
We could move the `docroot` path under `/app/web` when building the image, but there are also dependencies on that folder e.g. in `composer.json`.

Related PR: https://github.com/wunderio/silta-circleci/pull/137