### PR TITLE
Feature/nginx backend fix

### DIFF
--- a/charts/drupal/templates/_helpers.tpl
+++ b/charts/drupal/templates/_helpers.tpl
@@ -63,6 +63,7 @@ ports:
 - name: config
   configMap:
     name: {{ .Release.Name }}-drupal
+    defaultMode: 0777
 {{- end }}
 
 {{- define "drupal.imagePullSecrets" }}

--- a/charts/drupal/templates/drupal-configmap.yaml
+++ b/charts/drupal/templates/drupal-configmap.yaml
@@ -621,6 +621,8 @@ data:
 {{- end }}
 
   php-fpm-probe.sh: |
+    #!/bin/bash
+    
     # Prevent requests during the site installation process.
     if [ {{ include "drupal.installation-in-progress-test" . }} ]; then 
         exit 1; 

--- a/charts/drupal/templates/drupal-configmap.yaml
+++ b/charts/drupal/templates/drupal-configmap.yaml
@@ -621,5 +621,14 @@ data:
 {{- end }}
 
   php-fpm-probe.sh: |
-    # Prevent coming in during the installation process.
-    if [ {{ include "drupal.installation-in-progress-test" . }} ]; then exit 1; fi
+    # Prevent requests during the site installation process.
+    if [ {{ include "drupal.installation-in-progress-test" . }} ]; then 
+        exit 1; 
+    fi
+
+    # Ping php-fpm process
+    SCRIPT_NAME=/ping \
+    SCRIPT_FILENAME=/ping \
+    REQUEST_METHOD=GET \
+    cgi-fcgi -bind -connect localhost:9000 \
+    > /dev/null

--- a/charts/drupal/templates/drupal-configmap.yaml
+++ b/charts/drupal/templates/drupal-configmap.yaml
@@ -619,3 +619,7 @@ data:
     Host *
     ProxyCommand=nc -X connect -x {{ $proxy.url }}:{{ $proxy.port }} %h %p
 {{- end }}
+
+  php-fpm-probe.sh: |
+    # Prevent coming in during the installation process.
+    if [ {{ include "drupal.installation-in-progress-test" . }} ]; then exit 1; fi

--- a/charts/drupal/templates/drupal-deployment.yaml
+++ b/charts/drupal/templates/drupal-deployment.yaml
@@ -31,6 +31,9 @@ spec:
           tcpSocket:
             port: 9000
         readinessProbe:
+          tcpSocket:
+            port: 9000
+        startupProbe:
           exec:
             # Prevent coming in during the installation process.
             command: ['/bin/bash', '-c', 'if [ {{ include "drupal.installation-in-progress-test" . }} ]; then exit 1; fi']

--- a/charts/drupal/templates/drupal-deployment.yaml
+++ b/charts/drupal/templates/drupal-deployment.yaml
@@ -27,16 +27,15 @@ spec:
         {{- include "drupal.php-container" . | nindent 8}}
         volumeMounts:
           {{- include "drupal.volumeMounts" . | nindent 10 }}
+          - name: config
+            mountPath: /php-fpm-probe.sh
+            subPath: php-fpm-probe.sh
         livenessProbe:
           tcpSocket:
             port: 9000
         readinessProbe:
-          tcpSocket:
-            port: 9000
-        startupProbe:
           exec:
-            # Prevent coming in during the installation process.
-            command: ['/bin/bash', '-c', 'if [ {{ include "drupal.installation-in-progress-test" . }} ]; then exit 1; fi']
+            command: ['/bin/bash', '-c', '/php-fpm-probe.sh']
         resources:
           {{- .Values.php.resources | toYaml | nindent 10 }}
 

--- a/charts/drupal/values.yaml
+++ b/charts/drupal/values.yaml
@@ -111,6 +111,9 @@ ssl:
 nginx:
   image: 'you need to pass in a value for nginx.image to your helm chart'
 
+  # Possible Values: debug, info, notice, warn, error, crit, alert, or emerg.
+  loglevel: error
+
   # The Kubernetes resources for the nginx container.
   # These values are optimised for development environments.
   resources:
@@ -250,7 +253,6 @@ php:
 
   # PHP settings
   php_ini:
-    loglevel: notice  # Possible Values: alert, error, warning, notice, debug
     upload_max_filesize: 60M
     post_max_size: 60M
     memory_limit: 256M

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -37,3 +37,13 @@ silta-release:
         - namespaceSelector:
             matchLabels:
               name: drupal-project
+
+autoscaling:
+  enabled: true
+  minReplicas: 1
+  maxReplicas: 5
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: 80

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -37,13 +37,3 @@ silta-release:
         - namespaceSelector:
             matchLabels:
               name: drupal-project
-
-autoscaling:
-  enabled: true
-  minReplicas: 1
-  maxReplicas: 5
-  metrics:
-    - type: Resource
-      resource:
-        name: cpu
-        targetAverageUtilization: 80


### PR DESCRIPTION
Replaces liveness probe with a combined check that both tries to prevent requests during the site installation process and checks the php-fpm process readiness before marking container as Ready.
This should prevent `"no live upstreams while connecting to upstream"` errors when the php-fpm process has not fully started up yet.

Plus, this PR removes the unused `.Values.php_ini.loglevel` and replaces with `.Values.nginx.loglevel`