### PR TITLE
Varnish resource assignment tweaks

### DIFF
--- a/charts/drupal/values.yaml
+++ b/charts/drupal/values.yaml
@@ -452,8 +452,11 @@ varnish:
   enabled: false
   resources:
     requests:
-      cpu: 25m
-      memory: 32Mi
+      cpu: 50m
+      memory: 256Mi
+    limits:
+      cpu: 100m
+      memory: 512Mi
   image: eu.gcr.io/silta-images/varnish
   imageTag: 6-v0.1
   # https://varnish-cache.org/docs/6.0/users-guide/storage-backends.html


### PR DESCRIPTION
Increasing varnish resource requests to reflect a real world deployment and setting limits to avoid shared resource hogging