### PR TITLE
Increase worker_connections and worker_rlimit_nofile.

### DIFF
--- a/charts/drupal/templates/drupal-configmap.yaml
+++ b/charts/drupal/templates/drupal-configmap.yaml
@@ -74,11 +74,12 @@ data:
   nginx_conf: |
     user                            nginx;
     worker_processes                auto;
+    worker_rlimit_nofile            102400;
 
     error_log                       /proc/self/fd/2 {{ .Values.nginx.loglevel }};
 
     events {
-        worker_connections          1024;
+        worker_connections          102400;
         multi_accept                on;
     }
 


### PR DESCRIPTION
Added suggested mitigations # 1 and # 4 from https://hexadix.com/slowloris-dos-attack-mitigation-nginx-web-server/
Other limits were already appropriate.