### PR TITLE
Moving hc_ua to a different context for openresty compatability

### DIFF
--- a/charts/drupal/templates/drupal-configmap.yaml
+++ b/charts/drupal/templates/drupal-configmap.yaml
@@ -149,9 +149,6 @@ data:
             ~^/(?<no_slash>.*)$ $no_slash;
         }
 
-        # List health checks that need to return status 200 here
-        map $http_user_agent $hc_ua { default 0; 'GoogleHC/1.0' 1; }
-
         include conf.d/*.conf;
     }
 
@@ -253,6 +250,9 @@ data:
         {{- end }}
     }
     {{- end }}
+    
+    # List health checks that need to return status 200 here
+    map $http_user_agent $hc_ua { default 0; 'GoogleHC/1.0' 1; }
 
     server {
         server_name drupal;


### PR DESCRIPTION
UA exceptions still work:
```
curl -H "User-Agent: test"   https://feature-hc-ua-context.drupal-project-k8s.dev.wdr.io/abc -I
HTTP/2 401 

curl -H "User-Agent: GoogleHC/1.0"   https://feature-hc-ua-context.drupal-project-k8s.dev.wdr.io/abc -I
HTTP/2 200 
```