### PR TITLE
fs retry fixes

### DIFF
--- a/charts/drupal/templates/drupal-configmap.yaml
+++ b/charts/drupal/templates/drupal-configmap.yaml
@@ -502,7 +502,9 @@ data:
         }
         location @files_retry {
             internal;
-            try_files $uri $uri/ =404;
+            # try_files $uri $uri/ =404;
+            # Pass file request to drupal as a final fallback. 
+            try_files $uri @drupal;
         }
         {{- end }}
 

--- a/charts/drupal/templates/drupal-configmap.yaml
+++ b/charts/drupal/templates/drupal-configmap.yaml
@@ -416,6 +416,13 @@ data:
                 try_files $uri @drupal;
             }
 
+            {{- if .Values.nginx.retry404s }}
+            # Retry file lookup in 5 seconds (fs sync workaround)
+            location ~* ^/sites/(.*)/files/(?:css|js)/(.*).(?:css|js)$ {
+                try_files $uri $uri/ @files_delay;
+            }
+            {{- end }}
+            
             ## Serve static files & images directly, without all standard drupal rewrites, php-fpm etc.
             location ~* ^.+\.(?:css|js|jpe?g|gif|png|ico|svg|swf|docx?|xlsx?|tiff?|txt|cgi|bat|pl|dll|exe|class)$ {
                 tcp_nodelay     off;
@@ -491,10 +498,6 @@ data:
         }
 
         {{- if .Values.nginx.retry404s }}
-        # Retry file lookup in 5 seconds (fs sync workaround)
-        location /sites/default/files/ {
-            try_files $uri $uri/ @files_delay;
-        }
         location @files_delay {
             internal;
             echo_sleep {{ .Values.nginx.retry404s }}.0;
@@ -502,12 +505,12 @@ data:
         }
         location @files_retry {
             internal;
-            # try_files $uri $uri/ =404;
             # Pass file request to drupal as a final fallback. 
             try_files $uri @drupal;
         }
         {{- end }}
 
+        
         location @drupal {
             include fastcgi.conf;
             fastcgi_param QUERY_STRING $query_string;

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -37,7 +37,3 @@ silta-release:
         - namespaceSelector:
             matchLabels:
               name: drupal-project
-
-nginx:
-  # Retry file lookup in 5 seconds (filesystem sync workaround)
-  retry404s: 5

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -37,3 +37,7 @@ silta-release:
         - namespaceSelector:
             matchLabels:
               name: drupal-project
+
+nginx:
+  # Retry file lookup in 5 seconds (filesystem sync workaround)
+  retry404s: 5


### PR DESCRIPTION
- Limits retry to css and js aggregation folders to prevent delay on derivatives
- Passing final 404 to @drupal as fallback 