### PR TITLE
Feature/backup retention

### DIFF
--- a/charts/drupal/templates/_helpers.tpl
+++ b/charts/drupal/templates/_helpers.tpl
@@ -378,7 +378,7 @@ fi
 
   # Generate the id of the backup.
   BACKUP_ID=`date +%Y-%m-%d-%H-%M-%S`
-  BACKUP_LOCATION="/backups/$BACKUP_ID-{{ .Values.environmentName }}"
+  BACKUP_LOCATION="/backups/$BACKUP_ID"
 
   # Figure out which tables to skip.
   IGNORE_TABLES=""

--- a/charts/drupal/templates/backup-cron.yaml
+++ b/charts/drupal/templates/backup-cron.yaml
@@ -32,7 +32,7 @@ spec:
             {{- include "drupal.php-container" . | nindent 12 }}
             volumeMounts:
               {{- include "drupal.volumeMounts" . | nindent 14 }}
-              - name: {{ .Release.Name }}-backup
+              - name: {{ .Release.Name }}-backups
                 mountPath: /backups
             command: ["/bin/bash", "-c"]
             args:
@@ -56,9 +56,9 @@ spec:
           restartPolicy: Never
           volumes:
             {{- include "drupal.volumes" . | nindent 12 }}
-            - name: {{ .Release.Name }}-backup
+            - name: {{ .Release.Name }}-backups
               persistentVolumeClaim:
-                claimName: {{ .Release.Name }}-backup
+                claimName: {{ .Release.Name }}-backups
           {{- include "drupal.imagePullSecrets" . | nindent 10 }}
 {{- end }}
 

--- a/charts/drupal/templates/backup-cron.yaml
+++ b/charts/drupal/templates/backup-cron.yaml
@@ -52,7 +52,7 @@ spec:
               name: mariadb
             resources:
               requests:
-                {{- .Values.backup.resources.requests | default .Values.mariadb.master.resources.requests | toYaml | nindent 16 }}
+                {{- .Values.backup.resources | toYaml | nindent 14 }}
           restartPolicy: Never
           volumes:
             {{- include "drupal.volumes" . | nindent 12 }}

--- a/charts/drupal/templates/backup-cron.yaml
+++ b/charts/drupal/templates/backup-cron.yaml
@@ -40,7 +40,7 @@ spec:
                 {{ include "drupal.backup-command" (merge $params . ) | nindent 16 }}
                 {{ include "mariadb.db-validation" (merge $params . ) | nindent 16 }}
           - name: mariadb
-            image: docker.io/bitnami/mariadb:10.2
+            image: docker.io/bitnami/mariadb:10.3.24-debian-10-r49
             imagePullPolicy: IfNotPresent
             env:
             - name: MARIADB_ROOT_PASSWORD
@@ -51,7 +51,8 @@ spec:
             - containerPort: 3306
               name: mariadb
             resources:
-              {{- .Values.backup.resources | toYaml | nindent 14 }}
+              requests:
+                {{- .Values.backup.resources.requests | default .Values.mariadb.master.resources.requests | toYaml | nindent 16 }}
           restartPolicy: Never
           volumes:
             {{- include "drupal.volumes" . | nindent 12 }}

--- a/charts/drupal/templates/backup-volume.yaml
+++ b/charts/drupal/templates/backup-volume.yaml
@@ -2,9 +2,9 @@
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: {{ .Release.Name }}-{{ $.Release.Namespace | sha256sum | trunc 7 }}-backup
+  name: {{ .Release.Name }}-{{ $.Release.Namespace | sha256sum | trunc 7 }}-backups
   labels:
-    name: {{ .Release.Name }}-{{ $.Release.Namespace | sha256sum | trunc 7 }}-backup
+    name: {{ .Release.Name }}-{{ $.Release.Namespace | sha256sum | trunc 7 }}-backups
     {{- include "drupal.release_labels" . | nindent 4 }}
 spec:
   accessModes:
@@ -15,15 +15,15 @@ spec:
   {{- if .Values.backup.csiDriverName }}
   csi:
     driver: {{ .Values.backup.csiDriverName }}
-    volumeHandle: {{ .Release.Namespace }}-{{ $.Release.Namespace | sha256sum | trunc 7 }}-backup
+    volumeHandle: {{ .Release.Namespace }}-{{ $.Release.Namespace | sha256sum | trunc 7 }}-backups
     volumeAttributes:
-      remotePathSuffix: /{{ .Release.Namespace }}/backup
+      remotePathSuffix: /{{ .Release.Namespace }}/{{ .Values.environmentName }}/backups
   {{- end }}
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ .Release.Name }}-backup
+  name: {{ .Release.Name }}-backups
   labels:
     {{- include "drupal.release_labels" . | nindent 4 }}
 spec:
@@ -36,6 +36,6 @@ spec:
 {{- if eq .Values.backup.storageClassName "silta-shared" }}
   selector:
     matchLabels:
-      name: {{ .Release.Name }}-{{ $.Release.Namespace | sha256sum | trunc 7 }}-backup
+      name: {{ .Release.Name }}-{{ $.Release.Namespace | sha256sum | trunc 7 }}-backups
 {{- end }}
 {{- end }}

--- a/charts/drupal/templates/shell-deployment.yaml
+++ b/charts/drupal/templates/shell-deployment.yaml
@@ -53,7 +53,7 @@ spec:
         - name: ssh-keys
           mountPath: /etc/ssh/keys
         {{- if .Values.backup.enabled }}
-        - name: {{ .Release.Name }}-backup
+        - name: {{ .Release.Name }}-backups
           mountPath: /backups
           readOnly: true
         {{- end }}
@@ -77,9 +77,9 @@ spec:
         persistentVolumeClaim:
           claimName: {{ .Release.Name }}-ssh-keys
       {{- if .Values.backup.enabled }}
-      - name: {{ .Release.Name }}-backup
+      - name: {{ .Release.Name }}-backups
         persistentVolumeClaim:
-          claimName: {{ .Release.Name }}-backup
+          claimName: {{ .Release.Name }}-backups
       {{- end }}
       {{- include "drupal.imagePullSecrets" . | nindent 6 }}
 {{- end }}

--- a/charts/drupal/tests/shell_deployment_test.yaml
+++ b/charts/drupal/tests/shell_deployment_test.yaml
@@ -57,7 +57,7 @@ tests:
           path: spec.template.spec.containers[0].volumeMounts
           content:
             mountPath: /backups
-            name: RELEASE-NAME-backup
+            name: RELEASE-NAME-backups
             readOnly: true
 
   - it: does not mount backups volume when backups are disabled
@@ -70,6 +70,6 @@ tests:
           path: spec.template.spec.containers[0].volumeMounts
           content:
             mountPath: /backups
-            name: RELEASE-NAME-backup
+            name: RELEASE-NAME-backups
             readOnly: true
 

--- a/charts/drupal/values.yaml
+++ b/charts/drupal/values.yaml
@@ -417,12 +417,14 @@ backup:
   #skipFiles: true
 
   # Resources for the backup cron job.
-  resources:
-    requests:
-      cpu: 1000m
-      memory: 512M
-    limits:
-      memory: 512M
+  # Uses mariadb.master.resources by default, can be overriden here 
+  # if default db assignment is too generous.
+  # resources:
+  #   requests:
+  #     cpu: 1000m
+  #     memory: 512M
+  #   limits:
+  #     memory: 512M
 
 # Override the default values of the MariaDB subchart.
 # These settings are optimised for development environments.

--- a/charts/drupal/values.yaml
+++ b/charts/drupal/values.yaml
@@ -417,14 +417,10 @@ backup:
   #skipFiles: true
 
   # Resources for the backup cron job.
-  # Uses mariadb.master.resources by default, can be overriden here 
-  # if default db assignment is too generous.
-  # resources:
-  #   requests:
-  #     cpu: 1000m
-  #     memory: 512M
-  #   limits:
-  #     memory: 512M
+  resources:
+    requests:
+      cpu: 1000m
+      memory: 512M
 
 # Override the default values of the MariaDB subchart.
 # These settings are optimised for development environments.

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -37,3 +37,8 @@ silta-release:
         - namespaceSelector:
             matchLabels:
               name: drupal-project
+
+backup:
+  enabled: true
+  schedule: '*/10 * * * *'
+  retention: 2


### PR DESCRIPTION
This pr changes the way backup directories are removed. The old backup removal so far was removing files from within backup folder, leaving the folder as folders have no creation time in bucket based remotes. This solution parses folder name as date and does the retention calculation based on that (this code is borrowed from frontend chart).

This PR also changes backup folder location so that backups are located under relevant feature branch (so far backups in one branch might have affected backups in other branches, which never happens, but still). Changing this hit the immutable PV issue so the PV and PVC names were changed so helm would just deploy a new resource with a different path.