### PR TITLE
Multivalue nginx.realipfrom

### DIFF
--- a/charts/drupal/templates/drupal-configmap.yaml
+++ b/charts/drupal/templates/drupal-configmap.yaml
@@ -87,9 +87,18 @@ data:
     }
 
     http {
+        
+        # List of upstream proxies we trust to set X-Forwarded-For correctly.
+        {{- if kindIs "string" .Values.nginx.realipfrom }}
+        set_real_ip_from            {{ .Values.nginx.realipfrom }};
+        {{- end }}
+        {{- if kindIs "map" .Values.nginx.realipfrom }}
+        {{- range .Values.nginx.realipfrom }}
+        set_real_ip_from            {{ . }};
+        {{- end }}
+        {{- end }}
 
-        set_real_ip_from                {{ .Values.nginx.realipfrom }};
-        real_ip_header                  {{ .Values.nginx.real_ip_header }};
+        real_ip_header              {{ .Values.nginx.real_ip_header }};
 
         include                     /etc/nginx/mime.types;
         default_type                application/octet-stream;

--- a/charts/drupal/templates/varnish-configmap-vcl.yaml
+++ b/charts/drupal/templates/varnish-configmap-vcl.yaml
@@ -38,7 +38,14 @@ data:
 
     # List of upstream proxies we trust to set X-Forwarded-For correctly.
     acl upstream_proxy {
+      {{- if kindIs "string" .Values.nginx.realipfrom }}
       {{ .Values.nginx.realipfrom | quote }};
+      {{- end }}
+      {{- if kindIs "map" .Values.nginx.realipfrom }}
+      {{- range .Values.nginx.realipfrom }}
+      {{ . | quote }};
+      {{- end }}
+      {{- end }}
     }
 
     sub vcl_init {

--- a/charts/drupal/tests/drupal_configmap_test.yaml
+++ b/charts/drupal/tests/drupal_configmap_test.yaml
@@ -1,6 +1,7 @@
 suite: drupal ConfigMaps
 templates:
   - drupal-configmap.yaml
+  - varnish-configmap-vcl.yaml
 tests:
   - it: is a ConfigMap
     template: drupal-configmap.yaml
@@ -67,3 +68,57 @@ tests:
     - matchRegex:
         path: data.drupal_conf
         pattern: 'auth_basic "Restricted";'
+
+  - it: tests realipfrom nginx configuration (legacy string value)
+    template: drupal-configmap.yaml
+    set:
+      nginx:
+        realipfrom: '1.2.3.4'
+    asserts:
+    - matchRegex:
+        path: data.nginx_conf
+        pattern: 'set_real_ip_from *1.2.3.4'
+ 
+  - it: tests realipfrom nginx configuration (multivalue object)
+    template: drupal-configmap.yaml
+    set:
+      nginx:
+        realipfrom: 
+          foo: '1.1.1.1'
+          bar: '2.2.2.2'
+    asserts:
+    - matchRegex:
+        path: data.nginx_conf
+        pattern: 'set_real_ip_from *1.1.1.1'
+    - matchRegex:
+        path: data.nginx_conf
+        pattern: 'set_real_ip_from *2.2.2.2'
+
+  - it: tests realipfrom varnish configuration (legacy string value)
+    template: varnish-configmap-vcl.yaml
+    set:
+      nginx:
+        realipfrom: '1.1.1.1'
+      varnish:
+        enabled: true
+    asserts:
+    - matchRegex:
+        path: data.default_vcl
+        pattern: "1.1.1.1"
+
+  - it: tests realipfrom varnish configuration (multivalue object)
+    template: varnish-configmap-vcl.yaml
+    set:
+      nginx:
+        realipfrom: 
+          foo: '1.1.1.1'
+          bar: '2.2.2.2'
+      varnish:
+        enabled: true
+    asserts:
+    - matchRegex:
+        path: data.default_vcl
+        pattern: "1.1.1.1"
+    - matchRegex:
+        path: data.default_vcl
+        pattern: "2.2.2.2"

--- a/charts/drupal/tests/shell_deployment_test.yaml
+++ b/charts/drupal/tests/shell_deployment_test.yaml
@@ -1,7 +1,6 @@
 suite: shell deployment
 templates:
   - shell-deployment.yaml
-  - drupal-configmap.yaml
 tests:
   - it: is a deployment with default values
     template: shell-deployment.yaml

--- a/charts/drupal/values.schema.json
+++ b/charts/drupal/values.schema.json
@@ -92,7 +92,10 @@
             }
           }
         },
-        "realipfrom": { "type": "string"},
+        "realipfrom": {
+          "type": ["string","object"],
+          "additionalProperties": { "type": "string"}
+        },
         "noauthips": {
           "type": "object",
           "additionalProperties": { "type": "string"}

--- a/charts/drupal/values.yaml
+++ b/charts/drupal/values.yaml
@@ -155,7 +155,10 @@ nginx:
   expose_cache_headers: false
 
   # Trust X-Forwarded-For from these hosts for getting external IP
-  realipfrom: 10.0.0.0/8
+  realipfrom: 
+    gke-internal: 10.0.0.0/8
+    gce-health-check-1: 130.211.0.0/22
+    gce-health-check-2: 35.191.0.0/16
 
   # Define the internal network access.
   # These are used below to allow internal access to certain files

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -37,8 +37,3 @@ silta-release:
         - namespaceSelector:
             matchLabels:
               name: drupal-project
-
-backup:
-  enabled: true
-  schedule: '*/10 * * * *'
-  retention: 2


### PR DESCRIPTION
Allows having multivalue `nginx.realipfrom` list (map). 
Existing deployments overriding `nginx.realipfrom` might get notice, that will be removed after they change the configuration structure. The message (warning) won't affect deployment, it still works as expected and does override the default value.
```
coalesce.go:196: warning: cannot overwrite table with non table for realipfrom (map[gke-internal:10.0.0.0/8])
```