### PR TITLE
Ingress tls test

### DIFF
--- a/charts/drupal/Chart.yaml
+++ b/charts/drupal/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: drupal
-version: 0.3.97
+version: 0.3.99
 apiVersion: v2
 dependencies:
 - name: mariadb

--- a/charts/drupal/templates/drupal-certificate.yaml
+++ b/charts/drupal/templates/drupal-certificate.yaml
@@ -8,6 +8,7 @@ metadata:
   name: {{ .Release.Name }}-crt
   annotations:
     cert-manager.io/issue-temporary-certificate: "true" 
+    acme.cert-manager.io/http01-override-ingress-name: "{{ $.Release.Name }}-drupal"
   labels:
     {{- include "drupal.release_labels" . | nindent 4 }}
 spec:
@@ -31,6 +32,9 @@ spec:
 kind: Certificate
 metadata:
   name: {{ $.Release.Name }}-crt-p{{ $index }}
+  annotations:
+    cert-manager.io/issue-temporary-certificate: "true" 
+    acme.cert-manager.io/http01-override-ingress-name: "{{ $.Release.Name }}-drupal"
   labels:
     {{- include "drupal.release_labels" $ | nindent 4 }}
 spec:
@@ -98,7 +102,8 @@ kind: Certificate
 metadata:
   name: {{ $.Release.Name }}-crt-{{ $index }}
   annotations:
-    cert-manager.io/issue-temporary-certificate: "true" 
+    cert-manager.io/issue-temporary-certificate: "true"
+    acme.cert-manager.io/http01-override-ingress-name: "{{ $.Release.Name }}-drupal-{{ $domain.ingress }}"
   labels:
     {{- include "drupal.release_labels" $ | nindent 4 }}
 spec:

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -50,3 +50,8 @@ exposeDomains:
     ssl:
       enabled: true
       issuer: letsencrypt-staging
+  domain3:
+    hostname: domain-test-3.wdr.io
+    ssl:
+      enabled: true
+      issuer: letsencrypt

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -8,7 +8,7 @@ varnish:
   enabled: false
 
 elasticsearch:
-  enabled: false
+  enabled: true
 
 memcached:
   enabled: false
@@ -37,21 +37,3 @@ silta-release:
         - namespaceSelector:
             matchLabels:
               name: drupal-project
-
-exposeDomains:
-  # Uncomment production domains when going live
-  domain1:
-    hostname: domain-test-1.wdr.io
-    ssl:
-      enabled: true
-      issuer: letsencrypt-staging
-  domain2:
-    hostname: domain-test-2.wdr.io
-    ssl:
-      enabled: true
-      issuer: letsencrypt-staging
-  domain3:
-    hostname: domain-test-3.wdr.io
-    ssl:
-      enabled: true
-      issuer: letsencrypt

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -8,7 +8,7 @@ varnish:
   enabled: false
 
 elasticsearch:
-  enabled: true
+  enabled: false
 
 memcached:
   enabled: false
@@ -37,3 +37,16 @@ silta-release:
         - namespaceSelector:
             matchLabels:
               name: drupal-project
+
+exposeDomains:
+  # Uncomment production domains when going live
+  domain1:
+    hostname: domain-test-1.wdr.io
+    ssl:
+      enabled: true
+      issuer: letsencrypt-staging
+  domain2:
+    hostname: domain-test-2.wdr.io
+    ssl:
+      enabled: true
+      issuer: letsencrypt-staging


### PR DESCRIPTION
Solves issue where cert-manager creates an extra ingress for well-known validation path which does not play nicely with gcs type ingress.
Possibly related issue: https://github.com/jetstack/cert-manager/issues/2538#issuecomment-922901920