### PR TITLE
Feature/ingress v1 api

### DIFF
--- a/charts/drupal/templates/_helpers.tpl
+++ b/charts/drupal/templates/_helpers.tpl
@@ -484,6 +484,14 @@ certmanager.k8s.io/v1alpha1
 {{- end }}
 {{- end }}
 
+{{- define "ingress.api-version" }}
+{{- if semverCompare ">=1.18" .Capabilities.KubeVersion.Version }}
+networking.k8s.io/v1
+{{- else }}
+networking.k8s.io/v1beta1
+{{- end }}
+{{- end }}
+
 {{- define "cron.entrypoints" -}}
 
 set -e

--- a/charts/drupal/templates/_helpers.tpl
+++ b/charts/drupal/templates/_helpers.tpl
@@ -478,9 +478,9 @@ fi
 
 {{- define "cert-manager.api-version" }}
 {{- if ( .Capabilities.APIVersions.Has "cert-manager.io/v1" ) }}
-apiVersion: cert-manager.io/v1
+cert-manager.io/v1
 {{- else }}
-apiVersion: certmanager.k8s.io/v1alpha1
+certmanager.k8s.io/v1alpha1
 {{- end }}
 {{- end }}
 

--- a/charts/drupal/templates/drupal-certificate.yaml
+++ b/charts/drupal/templates/drupal-certificate.yaml
@@ -2,7 +2,7 @@
 {{- $context_ssl := .Values.ssl }}
 {{- if $context_ingress.tls }}
 {{- if has $context_ssl.issuer (list "letsencrypt" "letsencrypt-staging") }}
-{{- include "cert-manager.api-version" $ }}
+apiVersion: {{ include "cert-manager.api-version" $ | trim }}
 kind: Certificate
 metadata:
   name: {{ .Release.Name }}-crt
@@ -17,7 +17,7 @@ spec:
   issuerRef:
     name: {{ $context_ssl.issuer }}
     kind: ClusterIssuer
-{{- if not ( .Capabilities.APIVersions.Has "cert-manager.io/v1" ) }}
+{{- if eq ( include "cert-manager.api-version" . | trim ) "certmanager.k8s.io/v1alpha1" }}
   acme:
     config:
       - http01:
@@ -27,7 +27,7 @@ spec:
 {{- end }}
 ---
 {{- range $index, $prefix := .Values.domainPrefixes }}
-{{- include "cert-manager.api-version" $ }}
+apiVersion: {{ include "cert-manager.api-version" $ | trim }}
 kind: Certificate
 metadata:
   name: {{ $.Release.Name }}-crt-p{{ $index }}
@@ -40,7 +40,7 @@ spec:
   issuerRef:
     name: {{ $context_ssl.issuer }}
     kind: ClusterIssuer
-{{- if not ( $.Capabilities.APIVersions.Has "cert-manager.io/v1" ) }}
+{{- if eq ( include "cert-manager.api-version" $ | trim ) "certmanager.k8s.io/v1alpha1" }}
   acme:
     config:
       - http01:
@@ -52,7 +52,7 @@ spec:
 {{- end }}
 
 {{- else if eq $context_ssl.issuer "selfsigned" }}
-{{- include "cert-manager.api-version" . }}
+apiVersion: {{ include "cert-manager.api-version" . | trim }}
 kind: Certificate
 metadata:
   name: {{ .Release.Name }}-crt
@@ -93,7 +93,7 @@ data:
 {{- if $domain.ssl }}
 {{- if $domain.ssl.enabled }}
 {{- if has $domain.ssl.issuer (list "letsencrypt" "letsencrypt-staging") }}
-{{- include "cert-manager.api-version" $ }}
+apiVersion: {{ include "cert-manager.api-version" $ | trim }}
 kind: Certificate
 metadata:
   name: {{ $.Release.Name }}-crt-{{ $index }}
@@ -108,7 +108,7 @@ spec:
   issuerRef:
     name: {{ $domain.ssl.issuer }}
     kind: ClusterIssuer
-{{- if not ( $.Capabilities.APIVersions.Has "cert-manager.io/v1" ) }}
+{{- if eq ( include "cert-manager.api-version" $ | trim ) "certmanager.k8s.io/v1alpha1" }}
   acme:
     config:
       - http01:
@@ -119,7 +119,7 @@ spec:
 ---
 
 {{- else if eq $domain.ssl.issuer "selfsigned" }}
-{{- include "cert-manager.api-version" $ }}
+apiVersion: {{ include "cert-manager.api-version" $ | trim }}
 kind: Certificate
 metadata:
   name: {{ $.Release.Name }}-crt-{{ $index }}

--- a/charts/drupal/templates/drupal-certificate.yaml
+++ b/charts/drupal/templates/drupal-certificate.yaml
@@ -2,7 +2,7 @@
 {{- $context_ssl := .Values.ssl }}
 {{- if $context_ingress.tls }}
 {{- if has $context_ssl.issuer (list "letsencrypt" "letsencrypt-staging") }}
-apiVersion: {{ include "cert-manager.api-version" $ | trim }}
+apiVersion: {{ include "cert-manager.api-version" . | trim }}
 kind: Certificate
 metadata:
   name: {{ .Release.Name }}-crt

--- a/charts/drupal/templates/drupal-ingress.yaml
+++ b/charts/drupal/templates/drupal-ingress.yaml
@@ -1,5 +1,5 @@
 {{- $ingress := .Values.ingress.default }}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: {{ include "ingress.api-version" . | trim }}
 kind: Ingress
 metadata:
   name: {{ .Release.Name }}-drupal
@@ -67,16 +67,30 @@ spec:
       paths:
       - path: /
         backend:
+          {{- if eq ( include "ingress.api-version" . | trim ) "networking.k8s.io/v1" }}
+          service:
+            name: {{ include "drupal.servicename" . }}
+            port: 
+              number: 80
+          {{- else }}
           serviceName: {{ include "drupal.servicename" . }}
           servicePort: 80
+          {{- end }}
 {{- range $index, $prefix := .Values.domainPrefixes }}
   - host: '{{ $prefix }}.{{ template "drupal.domain" $ }}'
     http:
       paths:
       - path: /
         backend:
+          {{- if eq ( include "ingress.api-version" $ | trim ) "networking.k8s.io/v1" }}
+          service:
+            name: {{ include "drupal.servicename" $ }}
+            port: 
+              number: 80
+          {{- else }}
           serviceName: {{ include "drupal.servicename" $ }}
           servicePort: 80
+          {{- end }}
 {{- end }}
 ---
 
@@ -96,7 +110,7 @@ spec:
 {{- end }}
 
 {{- if $ingress_in_use }}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: {{ include "ingress.api-version" $ | trim }}
 kind: Ingress
 metadata:
   name: {{ $.Release.Name }}-drupal-{{ $ingress_index }}
@@ -165,8 +179,15 @@ spec:
       paths:
       - path: {{ if eq $ingress.type "gce" }}/*{{ else }}/{{ end }}
         backend:
+          {{- if eq ( include "ingress.api-version" $ | trim ) "networking.k8s.io/v1" }}
+          service:
+            name: {{ include "drupal.servicename" $ }}
+            port: 
+              number: 80
+          {{- else }}
           serviceName: {{ include "drupal.servicename" $ }}
           servicePort: 80
+          {{- end }}
   {{- end }}
   {{- end }}
 ---

--- a/charts/drupal/templates/drupal-ingress.yaml
+++ b/charts/drupal/templates/drupal-ingress.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: {{ $ingress.type | quote }}
     {{- if $ingress.tls }}
-    {{- if ( .Capabilities.APIVersions.Has "cert-manager.io/v1" ) }}
+    {{- if eq ( include "cert-manager.api-version" $ | trim ) "cert-manager.io/v1" }}
     acme.cert-manager.io/http01-edit-in-place: "true"
     {{- else }}
     certmanager.k8s.io/acme-http01-edit-in-place: "true"
@@ -103,7 +103,7 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: {{ $ingress.type | quote }}
     {{- if $ingress.tls }}
-    {{- if ( $.Capabilities.APIVersions.Has "cert-manager.io/v1" ) }}
+    {{- if eq ( include "cert-manager.api-version" $ | trim ) "cert-manager.io/v1" }}
     acme.cert-manager.io/http01-edit-in-place: "true"
     {{- else }}
     certmanager.k8s.io/acme-http01-edit-in-place: "true"

--- a/charts/drupal/tests/drupal_ingress_test.yaml
+++ b/charts/drupal/tests/drupal_ingress_test.yaml
@@ -36,21 +36,83 @@ tests:
           path: spec.rules[0].host
           value: 'foo.namespace.baz'
 
-  - it: directs traefik requests to drupal service by default
+  - it: directs traefik requests to drupal service by default (cm 0.8)
     template: drupal-ingress.yaml
+    capabilities:
+      majorVersion: 1
+      minorVersion: 17
+      apiVersions:
+        - certmanager.k8s.io/v1alpha1
     asserts:
       - equal:
           path: spec.rules[0].http.paths[0].backend.serviceName
           value: 'RELEASE-NAME-drupal'
 
-  - it: directs traefik requests to varnish service when varnish is enabled
+  - it: directs traefik requests to drupal service by default (cm 1.4+)
+    template: drupal-ingress.yaml
+    capabilities:
+      majorVersion: 1
+      minorVersion: 18
+      apiVersions:
+        - cert-manager.io/v1
+    asserts:
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.name
+          value: 'RELEASE-NAME-drupal'
+  
+  - it: directs traefik requests to varnish service when varnish is enabled (cm 0.8)
     template: drupal-ingress.yaml
     set:
       varnish.enabled: true
+    capabilities:
+      majorVersion: 1
+      minorVersion: 17
+      apiVersions:
+        - certmanager.k8s.io/v1alpha1
     asserts:
       - equal:
           path: spec.rules[0].http.paths[0].backend.serviceName
           value: 'RELEASE-NAME-varnish'
+
+  - it: directs traefik requests to varnish service when varnish is enabled (cm 1.4+)
+    template: drupal-ingress.yaml
+    capabilities:
+      majorVersion: 1
+      minorVersion: 18
+      apiVersions:
+        - cert-manager.io/v1
+    set:
+      varnish.enabled: true
+    asserts:
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.name
+          value: 'RELEASE-NAME-varnish'
+
+  - it: uses correct ingress api version (1.17)
+    template: drupal-ingress.yaml
+    capabilities:
+      majorVersion: 1
+      minorVersion: 17
+    asserts:
+      - equal:
+          path: apiVersion
+          value: 'networking.k8s.io/v1beta1'
+
+  - it: uses correct ingress api version (1.18+)
+    template: drupal-ingress.yaml
+    capabilities:
+      majorVersion: 1
+      minorVersion: 18
+    asserts:
+      - equal:
+          path: apiVersion
+          value: 'networking.k8s.io/v1'
+
+
+
+
+
+
 
   - it: shortens long project names
     template: drupal-ingress.yaml


### PR DESCRIPTION
- Unifies certificate apiVersion conditionals 
- Uses Ingress API v1 when kubernetes version is above 1.18
- Ingress resource adjustments according to https://kubernetes.io/docs/reference/using-api/deprecation-guide/#ingress-v122
- Adjusted chart unittests