### PR TITLE
Allows custom locations for retry404s. Deprecates old configuration schema

### DIFF
--- a/charts/drupal/templates/drupal-configmap.yaml
+++ b/charts/drupal/templates/drupal-configmap.yaml
@@ -445,10 +445,15 @@ data:
             }
 
             {{- if .Values.nginx.retry404s }}
-            # Retry file lookup in 5 seconds (fs sync workaround)
-            location ~* ^/sites/(.*)/files/(?:css|js)/(.*).(?:css|js)$ {
+            {{- if kindIs "float64" .Values.nginx.retry404s }}
+            {{- fail ".Values.nginx.retry404s configuration schema has been changed. Please check chart values file for updates." }}
+            {{- end }}
+            # Retry file lookup in {{ .Values.nginx.retry404s.delay }} seconds (fs sync workaround)
+            {{- range .Values.nginx.retry404s.paths }}
+            location ~* {{ . }} {
                 try_files $uri $uri/ @files_delay;
             }
+            {{- end }}
             {{- end }}
             
             ## Serve static files & images directly, without all standard drupal rewrites, php-fpm etc.
@@ -528,7 +533,7 @@ data:
         {{- if .Values.nginx.retry404s }}
         location @files_delay {
             internal;
-            echo_sleep {{ .Values.nginx.retry404s }}.0;
+            echo_sleep {{ .Values.nginx.retry404s.delay }}.0;
             echo_exec @files_retry;
         }
         location @files_retry {

--- a/charts/drupal/values.yaml
+++ b/charts/drupal/values.yaml
@@ -180,7 +180,11 @@ nginx:
   comp_level: 6
 
   # Retry file lookup in 5 seconds (filesystem sync workaround)
-  # retry404s: 5
+  # retry404s:
+  #   delay: 5
+  #   paths:
+  #     - "^/sites/(.*)/files/(?:css|js)/(.*).(?:css|js)$"
+
 
   # Extra configuration block in server context.
   serverExtraConfig: |

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -37,10 +37,3 @@ silta-release:
         - namespaceSelector:
             matchLabels:
               name: drupal-project
-
-nginx:
-  retry404s:
-    delay: 5
-    paths:
-      - "^/sites/(.*)/files/(?:css|js)/(.*).(?:css|js)$"
-      - "^/sites/(.*)/files/(.*).(?:png|jpg)$"

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -37,3 +37,10 @@ silta-release:
         - namespaceSelector:
             matchLabels:
               name: drupal-project
+
+nginx:
+  retry404s:
+    delay: 5
+    paths:
+      - "^/sites/(.*)/files/(?:css|js)/(.*).(?:css|js)$"
+      - "^/sites/(.*)/files/(.*).(?:png|jpg)$"


### PR DESCRIPTION
- Allows custom locations for retry404s. 
- Deprecates old configuration schema (with failure message)

Old configuration syntax:
```
nginx:
  retry404s: 5
```
New configuration syntax:
```
nginx:
  retry404s:
    delay: 5
    paths:
      - "^/sites/(.*)/files/(?:css|js)/(.*).(?:css|js)$"
      - "^/sites/(.*)/files/(.*).(?:png|jpg)$"
```