### PR TITLE
tls hosts definition for ingress resources

### DIFF
--- a/charts/drupal/templates/drupal-ingress.yaml
+++ b/charts/drupal/templates/drupal-ingress.yaml
@@ -54,10 +54,16 @@ spec:
   tls:
   {{- if .Values.ssl.existingTLSSecret }}
   - secretName: {{ .Values.ssl.existingTLSSecret }}
+    hosts: 
+      - {{ include "drupal.domain" . | quote }}
   {{- else }}
   - secretName: {{ .Release.Name }}-tls
+    hosts: 
+      - {{ include "drupal.domain" . | quote }}
   {{- range $index, $prefix := .Values.domainPrefixes }}
   - secretName: {{ $.Release.Name }}-tls-p{{ $index }}
+    hosts: 
+      - '{{ $prefix }}.{{ template "drupal.domain" $ }}'
   {{- end }}
   {{- end }}
   {{- end }}
@@ -162,8 +168,12 @@ spec:
   {{- if $domain.ssl.enabled }}
   {{- if $domain.ssl.existingTLSSecret }}
   - secretName: {{ $domain.ssl.existingTLSSecret }}
+    hosts: 
+      - {{ $domain.hostname }}
   {{- else }}
   - secretName: {{ $.Release.Name }}-tls-{{ $domain_index }}
+    hosts: 
+      - {{ $domain.hostname }}
   {{- end }}
   {{- end }}
   {{- end }}


### PR DESCRIPTION
GCP ingress returns following 
> TLS entry 0 is invalid: secret "feature-sticky-sessions-tls-sticky" for ingress TLS has no hosts specified

It seems to be related to this issue: `https://github.com/cert-manager/website/issues/475`

Ingress TLS documentation:
https://kubernetes.io/docs/concepts/services-networking/ingress/#tls 