### PR TITLE
Improve documentation for uploading files. Reason: rsync and "No such file or directory"

### DIFF
--- a/charts/drupal/templates/NOTES.txt
+++ b/charts/drupal/templates/NOTES.txt
@@ -62,7 +62,11 @@ Importing data into server (use this with caution!)
   {{ range $index, $mount := .Values.mounts -}}
   {{ if eq $mount.enabled true -}}
   Uploading files to {{ $index }}:
-  rsync -azv --temp-dir=/tmp/ -e 'ssh -A -J {{ include "drupal.jumphost" $ }}' local_folder/ {{ include "drupal.shellHost" $ }}:{{ $mount.mountPath }}
+  1. rsync -azv --temp-dir=/tmp/ -e 'ssh -A -J {{ include "drupal.jumphost" $ }}' local_folder/ {{ include "drupal.shellHost" $ }}:/app/files
+  2. ssh {{ include "drupal.shellHost" . }} -J {{ include "drupal.jumphost" . }}
+  3. nohup cp --recursive /app/files/. {{ $mount.mountPath }}
+  4. rm -rf /app/files
+  (Note: Due to Google Filestore architecture, direct rsync or mv to {{ $mount.mountPath }} mount will fail.)
   {{ end }}
   {{ end -}}
   {{- end -}}


### PR DESCRIPTION
https://wunder.slack.com/archives/C8UN6AG9W/p1637562569252600

**The problem**

People try to use Silta instructions for uploading files but fail.

```
rsync -azv --temp-dir=/tmp/ -e 'ssh -A -J www-admin@ssh.dev.wdr.io' files/ www-admin@master-shell.client-fi-turku-kasiohjelma:/app/web/sites/default/files

rsync: [receiver] rename "/tmp//view_unpublished-8.x-1.0-alpha1.fi.po.FonBkJ" -> "translations/view_unpublished-8.x-1.0-alpha1.fi.po": No such file or directory (2)
```

This is due to Google Filestore architecture where dirs do not actually exist. (See longer description in the thread 10:56).

**The solution**

The "quick fix" is that we update the documentation on how to copy files without running into problems.
This is a bit ugly, but at least people won't keep stumbling on this regularly and bugging the Silta team for support.