### PR TITLE
Feature/memcache networkpolicy

### DIFF
--- a/charts/silta-release/templates/_networkPolicy.tpl
+++ b/charts/silta-release/templates/_networkPolicy.tpl
@@ -6,10 +6,37 @@ metadata:
   name: {{ .Release.Name }}-{{ .id | lower }}
   labels:
     release: {{ .Release.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
 spec:
   podSelector:
     matchLabels:
       release: {{ .Release.Name }}
+{{- if .additionalPodSelectors -}}
+      {{ .additionalPodSelectors | toYaml | nindent 6}}
+{{- end }}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    {{ if .from -}}
+    {{ .from | toYaml | nindent 4 }}
+    {{ else }}
+    - namespaceSelector:
+        matchLabels:
+          name: {{ .Release.Namespace }}
+    {{ end }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ .Release.Name }}-{{ .id | lower }}-2
+  labels:
+    release: {{ .Release.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: {{ .Release.Name }}
 {{- if .additionalPodSelectors -}}
       {{ .additionalPodSelectors | toYaml | nindent 6}}
 {{- end }}

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -11,7 +11,7 @@ elasticsearch:
   enabled: true
 
 memcached:
-  enabled: false
+  enabled: true
 
 mounts:
   private-files:

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -11,7 +11,7 @@ elasticsearch:
   enabled: true
 
 memcached:
-  enabled: true
+  enabled: false
 
 mounts:
   private-files:


### PR DESCRIPTION
Cloning networkpolicy objects to target resources with `app.kubernetes.io/instance` label (memcached mainly). `-2` was the best name i could come up with.