### PR TITLE
Use bash for initContainers

### DIFF
--- a/charts/elasticsearch/templates/statefulset.yaml
+++ b/charts/elasticsearch/templates/statefulset.yaml
@@ -225,7 +225,7 @@ spec:
         readinessProbe:
           exec:
             command:
-              - sh
+              - bash
               - -c
               - |
                 #!/usr/bin/env bash -e

--- a/charts/elasticsearch/templates/statefulset.yaml
+++ b/charts/elasticsearch/templates/statefulset.yaml
@@ -174,10 +174,9 @@ spec:
         image: "{{ .Values.image }}:{{ .Values.imageTag }}"
         imagePullPolicy: "{{ .Values.imagePullPolicy }}"
         command:
-        - sh
+        - bash
         - -c
         - |
-          #!/usr/bin/env bash
           set -euo pipefail
 
           elasticsearch-keystore create
@@ -228,7 +227,7 @@ spec:
               - bash
               - -c
               - |
-                #!/usr/bin/env bash -e
+                set -e
                 # If the node is starting up wait for the cluster to be ready (request params: "{{ .Values.clusterHealthCheckParams }}" )
                 # Once it has started only check that the node itself is responding
                 START_FILE=/tmp/.es_start_file
@@ -363,11 +362,10 @@ spec:
         image: "{{ .Values.image }}:{{ .Values.imageTag }}"
         imagePullPolicy: "{{ .Values.imagePullPolicy }}"
         command:
-        - "sh"
+        - "bash"
         - -c
         - |
-          #!/usr/bin/env bash
-          set -eo pipefail
+          set -euo pipefail
 
           http () {
               local path="${1}"

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -9,7 +9,7 @@ varnish:
 
 elasticsearch:
   enabled: true
-  imageTag: 6.8.3
+  imageTag: 7.16.1
 
 memcached:
   enabled: false

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -9,7 +9,7 @@ varnish:
 
 elasticsearch:
   enabled: true
-  imageTag: 7.16.1
+  imageTag: 6.8.3
 
 memcached:
   enabled: false

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -9,6 +9,7 @@ varnish:
 
 elasticsearch:
   enabled: true
+  imageTag: 6.8.3
 
 memcached:
   enabled: false

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -9,6 +9,7 @@ varnish:
 
 elasticsearch:
   enabled: true
+  imageTag: 7.16.1
 
 memcached:
   enabled: false

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -9,7 +9,6 @@ varnish:
 
 elasticsearch:
   enabled: true
-  imageTag: 7.16.1
 
 memcached:
   enabled: false

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -9,7 +9,6 @@ varnish:
 
 elasticsearch:
   enabled: true
-  imageTag: 6.8.3
 
 memcached:
   enabled: false


### PR DESCRIPTION
 #https://github.com/elastic/helm-charts/commit/4e31e0cf3d025f9ce877ac52d218f49d72e26447

Excerpt:
```
..Updating the keystore initContainer to also use bash instead of sh. This is required for
Elasticsearch > 7.16.0 because the Docker image is now based on Ubuntu
instead of CentOS 8, and sh on Ubuntu isn't compatible with the
`if [[... -eq ... ]]` statements.
```