### PR TITLE
Testing forked solr 8 image

### DIFF
--- a/charts/drupal/Chart.yaml
+++ b/charts/drupal/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: drupal
-version: 0.3.107
+version: 0.3.108
 dependencies:
 - name: mariadb
   version: 7.5.x

--- a/charts/drupal/templates/solr-statefulset.yaml
+++ b/charts/drupal/templates/solr-statefulset.yaml
@@ -34,7 +34,7 @@ spec:
           mountPath: /var/solr/search
       containers:
       - name: solr
-        image: {{ printf "%s:%s" .Values.solr.image .Values.solr.imageTag | quote }}
+        image: "{{ .Values.solr.image }}:{{ .Values.solr.imageTag }}"
         ports:
         - containerPort: 8983
         command: {{ .Values.solr.command }}

--- a/charts/drupal/values.yaml
+++ b/charts/drupal/values.yaml
@@ -508,7 +508,7 @@ elasticsearch:
 
   # The elasticsearch version to use.
   # It's a good idea to tag this in your silta.yml
-  imageTag: 6.8.3
+  imageTag: 6.8.21
 
   replicas: 1
   minimumMasterNodes: 1
@@ -587,8 +587,8 @@ smtp:
 solr:
   enabled: false
   # Available image tags: https://hub.docker.com/r/geerlingguy/solr/tags
-  image: geerlingguy/solr
-  imageTag: latest
+  image: eu.gcr.io/silta-images/solr
+  imageTag: 8
 
   # Solr 4.x and 5.x does not support "-force" argument (optional override)
   command: ["/opt/solr/bin/solr"]

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -42,6 +42,3 @@ nginx:
   extraConfig: |
     # Show server host name as header
     add_header X-Backend-Server $hostname;
-
-solr:
-  enabled: true

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -42,3 +42,6 @@ nginx:
   extraConfig: |
     # Show server host name as header
     add_header X-Backend-Server $hostname;
+
+solr:
+  enabled: true


### PR DESCRIPTION
Temporary switching to forked solr 8 image [with CVE-2021-44228 and CVE 2021-45046 mitigation](https://github.com/wunderio/silta-images/commit/9060b7eb2e9431434a718311fe4e02a8b0f1c859)