### PR TITLE
Test/wildcard domains

### DIFF
--- a/charts/drupal/templates/drupal-certificate.yaml
+++ b/charts/drupal/templates/drupal-certificate.yaml
@@ -110,7 +110,7 @@ metadata:
 spec:
   secretName: {{ $.Release.Name }}-tls-{{ $index }}
   dnsNames:
-  - {{ $domain.hostname }}
+  - {{ $domain.hostname | quote }}
   issuerRef:
     name: {{ $domain.ssl.issuer }}
     kind: ClusterIssuer
@@ -120,7 +120,7 @@ spec:
       - http01:
           ingress: {{ $.Release.Name }}-drupal-{{ $domain.ingress }}
         domains:
-          - {{ $domain.hostname }}
+          - {{ $domain.hostname | quote }}
 {{- end }}
 ---
 
@@ -135,9 +135,9 @@ spec:
   secretName: {{ $.Release.Name }}-tls-{{ $index }}
   duration: 2160h
   renewBefore: 150h 
-  commonName: {{ $domain.hostname }}
+  commonName: {{ $domain.hostname | quote }}
   dnsNames:
-  - {{ $domain.hostname }}
+  - {{ $domain.hostname | quote }}
   issuerRef:
     name: {{ $domain.ssl.issuer }}
     kind: ClusterIssuer

--- a/charts/drupal/templates/drupal-ingress.yaml
+++ b/charts/drupal/templates/drupal-ingress.yaml
@@ -191,11 +191,11 @@ spec:
   {{- if $domain.ssl.existingTLSSecret }}
   - secretName: {{ $domain.ssl.existingTLSSecret }}
     hosts: 
-      - {{ $domain.hostname }}
+      - {{ $domain.hostname | quote }}
   {{- else }}
   - secretName: {{ $.Release.Name }}-tls-{{ $domain_index }}
     hosts: 
-      - {{ $domain.hostname }}
+      - {{ $domain.hostname | quote }}
   {{- end }}
   {{- end }}
   {{- end }}
@@ -206,7 +206,7 @@ spec:
   {{- range $domain_index, $domain := $.Values.exposeDomains }}
   {{- $domain := mergeOverwrite (deepCopy $.Values.exposeDomainsDefaults) $domain }}
   {{- if eq $domain.ingress $ingress_index }}
-  - host: {{ $domain.hostname }}
+  - host: {{ $domain.hostname | quote }}
     http:
       paths:
       - path: {{ if eq $ingress.type "gce" }}/*{{ else }}/{{ end }}

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -42,3 +42,14 @@ nginx:
   extraConfig: |
     # Show server host name as header
     add_header X-Backend-Server $hostname;
+
+exposeDomains:
+  wildcard-nossl:
+    hostname: '*.no-ssl.test-wildcard-domains.drupal-project-k8s.dev.wdr.io'
+    ssl:
+      enabled: false
+    
+  # wildcard-ssl:
+  #   hostname: '*.ssl.test-wildcard-domains.drupal-project-k8s.dev.wdr.io'
+  #   ssl:
+  #     issuer: selfsigned

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -49,7 +49,7 @@ exposeDomains:
     ssl:
       enabled: false
     
-  # wildcard-ssl:
-  #   hostname: '*.ssl.test-wildcard-domains.drupal-project-k8s.dev.wdr.io'
-  #   ssl:
-  #     issuer: selfsigned
+  wildcard-ssl:
+    hostname: '*.ssl.test-wildcard-domains.drupal-project-k8s.dev.wdr.io'
+    ssl:
+      issuer: selfsigned

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -42,14 +42,3 @@ nginx:
   extraConfig: |
     # Show server host name as header
     add_header X-Backend-Server $hostname;
-
-exposeDomains:
-  wildcard-nossl:
-    hostname: '*.no-ssl.test-wildcard-domains.drupal-project-k8s.dev.wdr.io'
-    ssl:
-      enabled: false
-    
-  wildcard-ssl:
-    hostname: '*.ssl.test-wildcard-domains.drupal-project-k8s.dev.wdr.io'
-    ssl:
-      issuer: selfsigned


### PR DESCRIPTION
Allows wildcard exposeDomains for custom and selfsigned certificates (does not work with letsencrypt) 

```yaml
exposeDomains:
  wildcard:
    hostname: *.test-wildcard-domains.drupal-project-k8s.dev.wdr.io
    ssl:
      issuer: selfsigned
```