### PR TITLE
Feature/red test

### DIFF
--- a/charts/drupal/Chart.lock
+++ b/charts/drupal/Chart.lock
@@ -8,6 +8,9 @@ dependencies:
 - name: memcached
   repository: https://charts.bitnami.com/bitnami
   version: 4.2.27
+- name: redis
+  repository: https://charts.bitnami.com/bitnami
+  version: 16.8.7
 - name: mailhog
   repository: https://codecentric.github.io/helm-charts
   version: 3.1.3
@@ -17,5 +20,5 @@ dependencies:
 - name: silta-release
   repository: file://../silta-release
   version: 0.1.1
-digest: sha256:17055f326935954f815a6a337b556b0c487391d6ac4ea6533151af403a787e88
-generated: "2022-04-21T16:56:04.883373952+03:00"
+digest: sha256:4998925a8a4dd89914789dfc4ee934c1ac5179f12f601c8baeb7aee83c6c9c97
+generated: "2022-04-25T08:47:01.004115611+03:00"

--- a/charts/drupal/Chart.yaml
+++ b/charts/drupal/Chart.yaml
@@ -14,6 +14,10 @@ dependencies:
   version: 4.2.x
   repository: https://charts.bitnami.com/bitnami
   condition: memcached.enabled
+- name: redis
+  version: 16.8.x
+  repository: https://charts.bitnami.com/bitnami
+  condition: redis.enabled
 - name: mailhog
   version: 3.1.x
   repository: https://codecentric.github.io/helm-charts

--- a/charts/drupal/templates/_helpers.tpl
+++ b/charts/drupal/templates/_helpers.tpl
@@ -179,10 +179,16 @@ imagePullSecrets:
 - name: ERROR_LEVEL
   value: {{ .Values.php.errorLevel }}
 {{- if .Values.memcached.enabled }}
+{{- if contains "memcache" .Release.Name -}}
+{{- fail "Do not use 'memcache' in release name or deployment will fail" -}}
+{{- end }}
 - name: MEMCACHED_HOST
   value: {{ .Release.Name }}-memcached
 {{- end }}
 {{- if .Values.redis.enabled }}
+{{- if contains "redis" .Release.Name -}}
+{{- fail "Do not use 'redis' in release name or deployment will fail" -}}
+{{- end }}
 {{- if eq .Values.redis.auth.password "" }}
 {{- fail ".Values.redis.auth.password value required." }}
 {{- end }}
@@ -199,6 +205,11 @@ imagePullSecrets:
   value: {{ .Release.Name }}-es
 {{- end }}
 {{- if or .Values.mailhog.enabled .Values.smtp.enabled }}
+{{- if .Values.mailhog.enabled }}
+{{- if contains "mailhog" .Release.Name -}}
+{{- fail "Do not use 'mailhog' in release name or deployment will fail" -}}
+{{- end }}
+{{- end }}
 {{ include "smtp.env" . }}
 {{- end}}
 {{- if .Values.varnish.enabled }}

--- a/charts/drupal/templates/_helpers.tpl
+++ b/charts/drupal/templates/_helpers.tpl
@@ -182,6 +182,18 @@ imagePullSecrets:
 - name: MEMCACHED_HOST
   value: {{ .Release.Name }}-memcached
 {{- end }}
+{{- if .Values.redis.enabled }}
+{{- if eq .Values.redis.auth.password "" }}
+{{- fail ".Values.redis.auth.password value required." }}
+{{- end }}
+- name: REDIS_HOST
+  value: {{ .Release.Name }}-redis-master
+- name: REDIS_PASS
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Release.Name }}-redis
+      key: redis-password
+{{- end }}
 {{- if .Values.elasticsearch.enabled }}
 - name: ELASTICSEARCH_HOST
   value: {{ .Release.Name }}-es
@@ -238,9 +250,9 @@ imagePullSecrets:
 - name: HTTPS_PROXY
   value: "{{ $proxy.url }}:{{ $proxy.port }}"
 - name: no_proxy
-  value: .svc.cluster.local,{{ .Release.Name }}-memcached,{{ .Release.Name }}-es,{{ .Release.Name }}-varnish,{{ .Release.Name }}-solr{{ if $proxy.no_proxy }},{{$proxy.no_proxy}}{{ end }}
+  value: .svc.cluster.local,{{ .Release.Name }}-memcached,{{ .Release.Name }}-redis,{{ .Release.Name }}-es,{{ .Release.Name }}-varnish,{{ .Release.Name }}-solr{{ if $proxy.no_proxy }},{{$proxy.no_proxy}}{{ end }}
 - name: NO_PROXY
-  value: .svc.cluster.local,{{ .Release.Name }}-memcached,{{ .Release.Name }}-es,{{ .Release.Name }}-varnish,{{ .Release.Name }}-solr{{ if $proxy.no_proxy }},{{$proxy.no_proxy}}{{ end }}
+  value: .svc.cluster.local,{{ .Release.Name }}-memcached,{{ .Release.Name }}-redis,{{ .Release.Name }}-es,{{ .Release.Name }}-varnish,{{ .Release.Name }}-solr{{ if $proxy.no_proxy }},{{$proxy.no_proxy}}{{ end }}
 {{- end }}
 {{- end }}
 

--- a/charts/drupal/test.values.yaml
+++ b/charts/drupal/test.values.yaml
@@ -20,6 +20,11 @@ varnish:
 memcached:
   enabled: true
 
+redis:
+  enabled: true
+  auth:
+    password: foo
+
 elasticsearch:
   enabled: true
 

--- a/charts/drupal/tests/redis_test.yaml
+++ b/charts/drupal/tests/redis_test.yaml
@@ -1,0 +1,32 @@
+suite: drupal redis
+templates:
+  - drupal-deployment.yaml
+  - drupal-configmap.yaml
+capabilities:
+  apiVersions:
+    - pxc.percona.com/v1
+tests:
+  - it: sets redis hostname in drupal environment if redis is enabled
+    template: drupal-deployment.yaml
+    set:
+      redis:
+        enabled: true
+        auth:
+          password: "foo"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_HOST
+            value: RELEASE-NAME-redis-master
+
+  - it: sets no redis hostname in drupal environment if redis is disabled
+    template: drupal-deployment.yaml
+    set:
+      redis.enabled: false
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_HOST
+            value: RELEASE-NAME-redis-master

--- a/charts/drupal/values.schema.json
+++ b/charts/drupal/values.schema.json
@@ -146,6 +146,12 @@
         "enabled": { "type": "boolean" }
       }
     },
+    "redis": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" }
+      }
+    },
     "mailhog": {
       "type": "object",
       "properties": {

--- a/charts/drupal/values.yaml
+++ b/charts/drupal/values.yaml
@@ -575,6 +575,22 @@ memcached:
     # MaxItemSize
     - -I 4M
 
+# https://github.com/bitnami/charts/blob/master/bitnami/redis/values.yaml
+redis:
+  architecture: standalone
+  auth:
+    # mandatory value
+    password: ""
+  replica:
+    # replicaCount: 1
+    resources:
+      limits: 
+        cpu: 250m
+        memory: 512Mi
+      requests:
+        cpu: 50m
+        memory: 256Mi
+
 # Mailhog service overrides
 # see: https://github.com/codecentric/helm-charts/blob/master/charts/mailhog/values.yaml
 mailhog:

--- a/charts/drupal/values.yaml
+++ b/charts/drupal/values.yaml
@@ -577,6 +577,7 @@ memcached:
 
 # https://github.com/bitnami/charts/blob/master/bitnami/redis/values.yaml
 redis:
+  enabled: false
   architecture: standalone
   auth:
     # mandatory value

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -13,6 +13,11 @@ elasticsearch:
 memcached:
   enabled: false
 
+redis:
+  enabled: true
+  auth:
+    password: "foo"
+
 mounts:
   private-files:
     enabled: true

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -14,7 +14,7 @@ memcached:
   enabled: false
 
 redis:
-  enabled: true
+  enabled: false
   auth:
     password: "foo"
 


### PR DESCRIPTION
- Initial redis subchart integration
- Chart name validation (will fail if contains one of enabled subcharts like "mailhog", "memcache" or "redis"). This is a special quirk for resource naming in bitnami subcharts https://github.com/bitnami/charts/blob/master/bitnami/common/templates/_names.tpl#L26