### PR TITLE
Print mariadb disc usage before db service boot

### DIFF
--- a/charts/drupal/values.yaml
+++ b/charts/drupal/values.yaml
@@ -470,6 +470,15 @@ mariadb:
         memory: 384M
       limits:
         memory: 512M
+    extraInitContainers: |
+      - name: dbinfo
+        image: busybox:stable
+        command: ["/bin/sh", "-c"]
+        args:
+          - df -h /bitnami/mariadb;
+        volumeMounts:
+          - mountPath: /bitnami/mariadb
+            name: data
     affinity:
       nodeAffinity:
         preferredDuringSchedulingIgnoredDuringExecution:

--- a/charts/drupal/values.yaml
+++ b/charts/drupal/values.yaml
@@ -475,7 +475,7 @@ mariadb:
         image: busybox:stable
         command: ["/bin/sh", "-c"]
         args:
-          - df -h /bitnami/mariadb;
+          - df -h /bitnami/mariadb
         volumeMounts:
           - mountPath: /bitnami/mariadb
             name: data


### PR DESCRIPTION
Helps debugging cases when db crashes due to full storage.