### PR TITLE
Allow security header customization

### DIFF
--- a/charts/drupal/templates/drupal-configmap.yaml
+++ b/charts/drupal/templates/drupal-configmap.yaml
@@ -142,13 +142,14 @@ data:
         gzip_disable                msie6;
 
         ## https://www.owasp.org/index.php/List_of_useful_HTTP_headers.
+        {{- range $header, $value := .Values.nginx.security_headers }}
+        add_header                  {{ $header }} {{ $value }};
+        {{- end }}
         add_header                  Strict-Transport-Security "max-age=31536000; {{ .Values.nginx.hsts_include_subdomains }} preload" always;
         {{- if .Values.nginx.content_security_policy }}
         add_header                  Content-Security-Policy "{{ .Values.nginx.content_security_policy }}" always;
         {{- end }}
-        add_header                  X-XSS-Protection "1; mode=block";
-        add_header                  Referrer-Policy "no-referrer, strict-origin-when-cross-origin" always;
-
+        
         port_in_redirect off;
         merge_slashes off;
 

--- a/charts/drupal/tests/drupal_configmap_test.yaml
+++ b/charts/drupal/tests/drupal_configmap_test.yaml
@@ -125,3 +125,38 @@ tests:
     - matchRegex:
         path: data.default_vcl
         pattern: "2.2.2.2"
+
+  - it: tests nginx security headers
+    template: drupal-configmap.yaml
+    set:
+      nginx:
+        security_headers: 
+          foo: bar
+        content_security_policy: "baz"
+    asserts:
+    - matchRegex:
+        path: data.nginx_conf
+        pattern: 'add_header                  X-XSS-Protection "1; mode=block";'
+    - matchRegex:
+        path: data.nginx_conf
+        pattern: 'add_header                  foo bar;'
+    - matchRegex:
+        path: data.nginx_conf
+        pattern: 'add_header                  Content-Security-Policy "baz" always;'
+
+  - it: tests ability to set empty nginx security headers
+    template: drupal-configmap.yaml
+    set:
+      nginx:
+        security_headers: []
+        content_security_policy: ""
+    asserts:
+    - notMatchRegex:
+        path: data.nginx_conf
+        pattern: 'add_header                  X-XSS-Protection "1; mode=block";'
+    - notMatchRegex:
+        path: data.nginx_conf
+        pattern: 'add_header                  header_foo value_bar;'
+    - notMatchRegex:
+        path: data.nginx_conf
+        pattern: 'add_header                  Content-Security-Policy "baz" always;'

--- a/charts/drupal/values.yaml
+++ b/charts/drupal/values.yaml
@@ -174,6 +174,12 @@ nginx:
     gce-health-check-2: 35.191.0.0/16
 
   # Security headers
+  security_headers:
+    # X-Frame-Options: 'SAMEORIGIN'
+    # X-Content-Type-Options: 'nosniff'
+    X-XSS-Protection: '"1; mode=block"'
+    Referrer-Policy: '"no-referrer, strict-origin-when-cross-origin" always'
+  
   # includeSubdomains should be used whenever possible, but before enabling it needs to be made sure there are no subdomains not using https:
   hsts_include_subdomains: ""
   #hsts_include_subdomains: " includeSubDomains;"


### PR DESCRIPTION
tip: remove security headers by setting `nginx.security_headers: ""`
