### PR TITLE
Enable Elastichsearch pinging by Drupal Ping

### DIFF
--- a/charts/drupal/files/settings.silta.php
+++ b/charts/drupal/files/settings.silta.php
@@ -30,16 +30,30 @@ if (getenv('PRIVATE_FILES_PATH')) {
  * Set Elasticsearch Helper module configuration if needed.
  */
 if ($elasticsearch_host = getenv('ELASTICSEARCH_HOST')) {
+
+  $elasticsearch_port = 9200;
+
   // Elasticsearch Helper 6.x compatible configuration override.
   $config['elasticsearch_helper.settings']['elasticsearch_helper']['host'] = $elasticsearch_host;
-  $config['elasticsearch_helper.settings']['elasticsearch_helper']['port'] = 9200;
+  $config['elasticsearch_helper.settings']['elasticsearch_helper']['port'] = $elasticsearch_port;
 
   // Elasticsearch Helper 7.x compatible configuration override.
   $config['elasticsearch_helper.settings']['hosts'] = [
     [
       'host' => $elasticsearch_host,
-      'port' => 9200,
+      'port' => $elasticsearch_port,
     ],
+  ];
+
+  // Enable Drupal Ping to survey the Elasticsearch connection
+  // https://github.com/wunderio/drupal-ping#elasticsearch
+  $settings['ping_elasticsearch_connections'] = [
+    [
+      'severity' => 'warning',
+      'proto' => 'http',
+      'host' => $elasticsearch_host,
+      'port' => $elasticsearch_port,
+    ]
   ];
 }
 

--- a/charts/drupal/files/settings.silta.php
+++ b/charts/drupal/files/settings.silta.php
@@ -53,7 +53,7 @@ if ($elasticsearch_host = getenv('ELASTICSEARCH_HOST')) {
       'proto' => 'http',
       'host' => $elasticsearch_host,
       'port' => $elasticsearch_port,
-    ]
+    ],
   ];
 }
 


### PR DESCRIPTION
Added a bit of php for `settings.php` to enable Drupal Ping to survey the Elasticsearch connection.

https://github.com/wunderio/drupal-ping#elasticsearch

Not sure if relevant, but here are more details about the implementation details, why this is separate variable.
https://wunder.slack.com/archives/C54RM7G4F/p1648463185202509

I'm not sure how to test this properly.
Copied the relevant code to one of my current projects, and ping recognized the connection and tested positive.

Not sure about adding automated tests.