### PR TITLE
Feature/referencedata rsync subfolders

### DIFF
--- a/charts/drupal/templates/_helpers.tpl
+++ b/charts/drupal/templates/_helpers.tpl
@@ -432,8 +432,12 @@ fi
   {{- if eq $mount.enabled true -}}
   if [ -d "/app/reference-data/{{ $index }}" ] && [ -n "$(ls /app/reference-data/{{ $index }})" ]; then
     echo "Importing {{ $index }} files"
-    for f in /app/reference-data/{{ $index }}/*; do
-      rsync -r --temp-dir=/tmp/ $f "{{ $mount.mountPath }}" &
+    # skip subfolders
+    rsync -r --delete --temp-dir=/tmp/ --filter "- */" "/app/reference-data/{{ $index }}/" "{{ $mount.mountPath }}" &
+    # run rsync for each subfolder
+    for f in /app/reference-data/{{ $index }}/*/; do
+      subfolder="$(realpath -s $f)"
+      rsync -r --delete --temp-dir=/tmp/ "${subfolder}" "{{ $mount.mountPath }}" &
     done
   fi
   {{ end -}}


### PR DESCRIPTION
Create rsync separate process for subfolders only to prevent a dedicated rsync process for each file in mount folder root

Test scenario:
```
mkdir source
mkdir source/aaa
mkdir source/bbb
mkdir source/ccc
touch source/111
touch source/222
touch source/333
touch source/aaa/444
touch source/aaa/555
touch source/bbb/666
touch source/bbb/777
```

```
ls target -R
```

```
# skip folders
rsync -avx --delete --filter "- */" source/ target

# create rsync process for each subfolder
for f in source/*/; do
  subfolder="$(realpath -s ${f})"
  rsync -r --delete --temp-dir=/tmp/ $subfolder target &
done
```

```
ls target -R
```

Test `--delete` flag by creating files, rsyncing, then removing source files and rsyncing again.
```
touch source/removeme
touch source/aaa/removeme
```