### PR TITLE
Feature/autoscaling requests

### DIFF
--- a/charts/drupal/templates/checks.yaml
+++ b/charts/drupal/templates/checks.yaml
@@ -1,0 +1,13 @@
+{{- if index (index .Values "silta-release") "branchName" }}
+{{- if eq (index (index .Values "silta-release") "branchName") "production" }}
+{{- if .Values.mailhog.enabled }}
+{{- fail "Mailhog should not be enabled in production" -}}
+{{- end }}
+{{- if eq .Values.nginx.resources.requests.cpu "1m" }}
+{{- fail "Raise nginx.resources.requests.cpu for production environment" -}}
+{{- end }}
+{{- if eq .Values.php.resources.requests.cpu "5m" }}
+{{- fail "Raise php.resources.requests.cpu for production environment" -}}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/drupal/values.schema.json
+++ b/charts/drupal/values.schema.json
@@ -1,52 +1,5 @@
 {
   "type": "object",
-  "if": {
-    "properties": {
-      "silta-release": {
-        "type": "object",
-        "properties": {
-          "branchName": { "const": "feature/autoscaling-requests"}
-        },
-        "required": ["branchName"]
-      }
-    }
-  },
-  "then": {
-    "properties": {
-      "mailhog": {
-        "$comment": "Mailhog should not be enabled in production",
-        "properties": { "enabled": { "const": false }}
-      },
-      "php": {
-        "properties": {
-          "resources": {
-            "properties": {
-              "requests": {
-                "$comment": "Raise php.resources.requests.cpu for production environment",
-                "properties": {
-                  "cpu": { "type": "string", "not": { "const": "5m"}}
-                }
-              }
-            }
-          }
-        }
-      },
-      "nginx": {
-        "properties": {
-          "resources": {
-            "properties": {
-              "requests": {
-                "$comment": "Raise nginx.resources.requests.cpu for production environment",
-                "properties": {
-                  "cpu": { "type": "string", "not": { "const": "1m"}}
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  },
   "additionalProperties": false,
   "properties": {
     "clusterDomain": { "type": "string" },

--- a/charts/drupal/values.schema.json
+++ b/charts/drupal/values.schema.json
@@ -5,7 +5,7 @@
       "silta-release": {
         "type": "object",
         "properties": {
-          "branchName": { "const": "production"}
+          "branchName": { "const": "feature/autoscaling-requests"}
         },
         "required": ["branchName"]
       }

--- a/charts/drupal/values.schema.json
+++ b/charts/drupal/values.schema.json
@@ -22,8 +22,9 @@
           "resources": {
             "properties": {
               "requests": {
+                "$comment": "Raise php.resources.requests.cpu for production environment",
                 "properties": {
-                  "cpu": { "type": "string", "not": { "const": "3m"}}
+                  "cpu": { "type": "string", "not": { "const": "5m"}}
                 }
               }
             }
@@ -35,8 +36,9 @@
           "resources": {
             "properties": {
               "requests": {
+                "$comment": "Raise nginx.resources.requests.cpu for production environment",
                 "properties": {
-                  "cpu": { "type": "string", "not": { "const": "3m"}}
+                  "cpu": { "type": "string", "not": { "const": "1m"}}
                 }
               }
             }


### PR DESCRIPTION
- Adapts resource request schema to current chart values
- Moves sanity checks from chart schema to a "template" to improve error readability

Check failure for schema implementation:
```
Helm output:
Release "feature-autoscaling-requests" does not exist. Installing it now.
Error: values don't meet the specifications of the schema(s) in the following chart(s):
drupal:
- (root): Must validate "then" as "if" was valid
- php.resources.requests.cpu: Must not validate the schema (not)
- nginx.resources.requests.cpu: Must not validate the schema (not)

2022/07/13 11:17:19 Error (Wait): exit status 1

Exited with code exit status 1
```

Check failure for template implementation (fails one issue at a time. could implement combined checks, but not at this time):
```
Helm output:
Release "feature-autoscaling-requests" does not exist. Installing it now.
Error: execution error at (drupal/templates/checks.yaml:7:4): Raise nginx.resources.requests.cpu for production environment
2022/07/13 11:46:48 Error (Wait): exit status 1

Exited with code exit status 1
```