### PR TITLE
Mailhog chart upgrade

### DIFF
--- a/charts/drupal/Chart.lock
+++ b/charts/drupal/Chart.lock
@@ -13,12 +13,12 @@ dependencies:
   version: 16.8.10
 - name: mailhog
   repository: https://codecentric.github.io/helm-charts
-  version: 3.1.3
+  version: 5.1.0
 - name: elasticsearch
   repository: file://../elasticsearch
   version: 7.8.1
 - name: silta-release
   repository: file://../silta-release
   version: 0.1.1
-digest: sha256:823cb88a03560c779bcee85b2ba9ec036fbe0cb769108f69339e91906c4f5d0b
-generated: "2022-06-02T16:46:22.620314421+03:00"
+digest: sha256:b7aff2317b5ee097ce16c3ee029382368bce5d40a2d991a3e9dea50c051202b9
+generated: "2022-08-01T13:20:22.864690261+03:00"

--- a/charts/drupal/Chart.yaml
+++ b/charts/drupal/Chart.yaml
@@ -19,7 +19,7 @@ dependencies:
   repository: https://charts.bitnami.com/bitnami
   condition: redis.enabled
 - name: mailhog
-  version: 3.1.x
+  version: 5.1.x
   repository: https://codecentric.github.io/helm-charts
   condition: mailhog.enabled
 - name: elasticsearch

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -48,5 +48,3 @@ nginx:
     # Show server host name as header
     add_header X-Backend-Server $hostname;
 
-mailhog:
-  enabled: true

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -48,3 +48,5 @@ nginx:
     # Show server host name as header
     add_header X-Backend-Server $hostname;
 
+mailhog:
+  enabled: true


### PR DESCRIPTION
Mailhog chart upgrade. Tested, works. Includes mailhog chart release that fixes unset replica issue (`https://github.com/codecentric/helm-charts/pull/626`). It caused downscaled mailhog instances to stay at `replicas: 0` even after redeployment since mailhog resource did not define `replicas: 1`.