### PR TITLE
Silta container base image migration to Docker Hub

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,13 +6,13 @@ orbs:
 executors:
   cicd73:
     docker:
-      - image: eu.gcr.io/silta-images/cicd:circleci-php7.3-node12-composer1-v0.1
+      - image: wunderio/silta-cicd:circleci-php7.3-node12-composer1-v0.1
   cicd74:
     docker:
-      - image: eu.gcr.io/silta-images/cicd:circleci-php7.4-node14-composer1-v0.1
+      - image: wunderio/silta-cicd:circleci-php7.4-node14-composer1-v0.1
   cicd80:
     docker:
-      - image: eu.gcr.io/silta-images/cicd:circleci-php8.0-node14-composer2-v0.1
+      - image: wunderio/silta-cicd:circleci-php8.0-node14-composer2-v0.1
 
 jobs:
   site-test:

--- a/charts/drupal/values.yaml
+++ b/charts/drupal/values.yaml
@@ -505,7 +505,7 @@ varnish:
     requests:
       cpu: 25m
       memory: 32Mi
-  image: eu.gcr.io/silta-images/varnish
+  image: wunderio/silta-varnish
   imageTag: 6-v0.2
   # https://varnish-cache.org/docs/6.6/users-guide/storage-backends.html
   storageBackend: 'file,/var/lib/varnish/varnish_storage.bin,512M'
@@ -615,7 +615,7 @@ mailhog:
   enabled: false
   image:
     # Set image repository to "mailhog/mailhog" to reenable logging.
-    repository: eu.gcr.io/silta-images/silta-mailhog
+    repository: wunderio/silta-mailhog
     # Set image tag to "" to reenable logging.
     tag: silent
   resources:
@@ -635,7 +635,7 @@ smtp:
 solr:
   enabled: false
   # Available image tags: https://hub.docker.com/r/geerlingguy/solr/tags
-  image: eu.gcr.io/silta-images/solr
+  image: wunderio/silta-solr
   imageTag: 8
 
   # Solr 4.x and 5.x does not support "-force" argument (optional override)

--- a/silta/nginx.Dockerfile
+++ b/silta/nginx.Dockerfile
@@ -1,4 +1,4 @@
 # Dockerfile for building nginx.
-FROM eu.gcr.io/silta-images/nginx:latest
+FROM wunderio/silta-nginx:latest
 
 COPY . /app/web

--- a/silta/php.Dockerfile
+++ b/silta/php.Dockerfile
@@ -1,7 +1,7 @@
 # Dockerfile for the Drupal container.
-#FROM eu.gcr.io/silta-images/php:7.3-fpm-v0.1
-#FROM eu.gcr.io/silta-images/php:7.4-fpm-v0.1
-FROM eu.gcr.io/silta-images/php:8.0-fpm-v0.1
+#FROM wunderio/silta-php-fpm:7.3-fpm-v0.1
+#FROM wunderio/silta-php-fpm:7.4-fpm-v0.1
+FROM wunderio/silta-php-fpm:8.0-fpm-v0.1
 
 COPY --chown=www-data:www-data . /app
 

--- a/silta/shell.Dockerfile
+++ b/silta/shell.Dockerfile
@@ -1,6 +1,6 @@
 # Dockerfile for the Drupal container.
-#FROM eu.gcr.io/silta-images/shell:php7.3-v0.1
-#FROM eu.gcr.io/silta-images/shell:php7.4-v0.1
-FROM eu.gcr.io/silta-images/shell:php8.0-v0.1
+#FROM wunderio/silta-php-shell:php7.3-v0.1
+#FROM wunderio/silta-php-shell:php7.4-v0.1
+FROM wunderio/silta-php-shell:php8.0-v0.1
 
 COPY --chown=www-data:www-data . /app


### PR DESCRIPTION
Silta docker container images are being migrated from [Google Container Registry](https://eu.gcr.io/silta-images/) to [Docker Hub](https://hub.docker.com/u/wunderio).
This PR changes base image location to the new image registry and adjusts some image names.

Please review adjusted image paths and make sure this PR only changes relevant configuration files.

This pull request was created with https://github.com/wunderio/internal-mass-updater.