### PR TITLE
Make `pv` output visible when importing reference database.

### DIFF
--- a/charts/drupal/templates/_helpers.tpl
+++ b/charts/drupal/templates/_helpers.tpl
@@ -416,7 +416,7 @@ if [ -f /app/reference-data/db.sql.gz ]; then
 
   echo "Importing reference database dump"
   gunzip -c /app/reference-data/db.sql.gz > /tmp/reference-data-db.sql
-  pv /tmp/reference-data-db.sql | drush sql-cli
+  pv -f /tmp/reference-data-db.sql | drush sql-cli
 
   # Clear caches before doing anything else.
   if [[ $DRUPAL_CORE_VERSION -eq 7 ]] ; then drush cache-clear all;


### PR DESCRIPTION
# The problem

Database import takes an hour or more. But I as a user don't know if it is 5min or more.

# The solution

`pv` command is already in the code, but it is useless, as it does not provide any output because it is not running on an active terminal. The `-f` flag forces `pv` to produce output, and that could be seen in the CircleCI task while importing the database.

# Testing

I don't know how to test this, but I assume Silta guys know how.