### PR TITLE
Feature/nginx variables

### DIFF
--- a/charts/drupal/templates/_helpers.tpl
+++ b/charts/drupal/templates/_helpers.tpl
@@ -173,6 +173,8 @@ imagePullSecrets:
   value: "{{ .Values.projectName | default .Release.Namespace }}"
 - name: ENVIRONMENT_NAME
   value: "{{ .Values.environmentName }}"
+- name: RELEASE_NAME
+  value: "{{ .Release.Name }}"
 - name: DRUSH_OPTIONS_URI
   value: "http://{{- template "drupal.domain" . }}"
 {{- include "drupal.db-env" . }}
@@ -486,7 +488,8 @@ fi
   {{ range $index, $mount := .Values.mounts -}}
   {{- if eq $mount.enabled true }}
   # File backup for {{ $index }} volume.
-  # If files get changed while the tar command is running, tar will exit with code 1. We ignore this as we want the rest of the job to still get run.
+  # If files get changed while the tar command is running, tar will exit with code 1. 
+  # We ignore this as we want the rest of the job to still get run.
   echo "Starting {{ $index }} volume backup."
   tar -czP --exclude=css --exclude=js --exclude=styles -f $BACKUP_LOCATION/{{ $index }}.tar.gz {{ $mount.mountPath }} || ( export exitcode=$?; [[ $exitcode -eq 1 ]] || exit )
   {{- end -}}

--- a/charts/drupal/templates/drupal-configmap.yaml
+++ b/charts/drupal/templates/drupal-configmap.yaml
@@ -313,7 +313,7 @@ data:
 
         {{- if .Values.nginx.serverExtraConfig }}
         # Custom configuration gets included here
-        {{- .Values.nginx.serverExtraConfig | nindent 8 }}
+        {{- tpl .Values.nginx.serverExtraConfig . | nindent 8 }}
         {{- end }}
 
         {{- if .Values.mailhog.enabled }}
@@ -354,7 +354,7 @@ data:
 
             # Custom configuration gets included here
             {{ if .Values.nginx.locationExtraConfig }}
-            {{ .Values.nginx.locationExtraConfig | nindent 10 }}
+            {{ tpl .Values.nginx.locationExtraConfig . | nindent 10 }}
             {{- end }}
 
             location ~* /system/files/ {
@@ -680,7 +680,7 @@ data:
 
 {{- if .Values.nginx.extraConfig }}
   extraConfig: |
-  {{ .Values.nginx.extraConfig | nindent 4 }}
+  {{ tpl .Values.nginx.extraConfig . | nindent 4 }}
 {{- end }}
 
 {{ $proxy := ( index .Values "silta-release" ).proxy }}

--- a/charts/drupal/templates/drupal-deployment.yaml
+++ b/charts/drupal/templates/drupal-deployment.yaml
@@ -52,6 +52,10 @@ spec:
       - name: nginx
         image: {{ .Values.nginx.image | quote }}
         env:
+        - name: RELEASE_NAME
+          value: "{{ .Release.Name }}"
+        - name: PROJECT_NAME
+          value: "{{ .Values.projectName | default .Release.Namespace }}"
         ports:
         - containerPort: 8080
           name: drupal

--- a/charts/drupal/tests/nginx-extra-config_test.yaml
+++ b/charts/drupal/tests/nginx-extra-config_test.yaml
@@ -6,6 +6,33 @@ capabilities:
   apiVersions:
     - pxc.percona.com/v1
 tests:
+  - it: extraConfig templating
+    template: drupal-configmap.yaml
+    set:
+      nginx.extraConfig: |
+        add_header X-Release-Name extraconfig-{{ .Release.Name }};  
+    asserts:
+    - matchRegex:
+        path: data.extraConfig
+        pattern: "add_header X-Release-Name extraconfig-RELEASE-NAME;"
+  - it: serverExtraConfig templating
+    template: drupal-configmap.yaml
+    set:
+      nginx.serverExtraConfig: |
+        # serverextraconfig test {{ .Release.Name }}  
+    asserts:
+    - matchRegex:
+        path: data.drupal_conf
+        pattern: "# serverextraconfig test RELEASE-NAME"
+  - it: locationExtraConfig templating
+    template: drupal-configmap.yaml
+    set:
+      nginx.locationExtraConfig: |
+        # locationextraconfig test {{ .Release.Name }}  
+    asserts:
+    - matchRegex:
+        path: data.drupal_conf
+        pattern: "# locationextraconfig test RELEASE-NAME"
   - it: populates extraConfig variable and check if its configmap gets mad
     template: drupal-deployment.yaml
     set:

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -47,4 +47,3 @@ nginx:
   extraConfig: |
     # Show server host name as header
     add_header X-Backend-Server $hostname;
-    add_header X-Release-Name release-name-{{ .Release.Name }};

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -47,3 +47,4 @@ nginx:
   extraConfig: |
     # Show server host name as header
     add_header X-Backend-Server $hostname;
+    add_header X-Release-Name release-name-{{ .Release.Name }};


### PR DESCRIPTION
1. Adds RELEASE_NAME and PROJECT_NAME environment variables to nginx container for potential envplate configuration file templating
2. Adds RELEASE_NAME environment variable to drupal/shell/cron containers. This can be used for pointing internal requests to related deployments.
3. Treat nginx extra configuration snippets as templates by wrapping variables into `tpl` function. This allows using helm variables in configuration snippets. Useful for internal request creation. See snippets below:
Usage:
```
nginx:
  extraConfig: |
    add_header X-Release-Name {{ .Release.Name }};
```
Testing:
```
~ curl <test-site> -I
(..)
x-release-name: feature-nginx-variables
```