### PR TITLE
Reenabling gdpr-dump. Requires php images to support it.

### DIFF
--- a/charts/drupal/templates/drupal-configmap.yaml
+++ b/charts/drupal/templates/drupal-configmap.yaml
@@ -6,8 +6,8 @@ metadata:
     {{- include "drupal.release_labels" . | nindent 4 }}
 data:
   gdpr-dump: |
-    # [mysqldump]
-    # gdpr-replacements='{{ .Values.gdprDump | toJson }}'
+    [mysqldump]
+    gdpr-replacements='{{ .Values.gdprDump | toJson }}'
 
   {{- if eq .Values.php.drupalCoreVersion "7" }}
   settings_silta_php: |{{ .Files.Get "files/settings.silta.d7.php" | nindent 4 }}

--- a/charts/drupal/values.yaml
+++ b/charts/drupal/values.yaml
@@ -421,7 +421,6 @@ referenceData:
 
 # Parameters for sanitizing reference data with gdpr-dump.
 # Uses formatters from https://packagist.org/packages/fzaninotto/faker.
-# ! This functionality has been temporary disabled
 gdprDump:
   users_field_data:
     name:


### PR DESCRIPTION
Reverts https://github.com/wunderio/drupal-project-k8s/pull/393

## Do not merge before https://github.com/wunderio/silta-images/pull/49