### PR TITLE
Faster way of exporting and importing reference database for Drupal chart

### DIFF
--- a/charts/drupal/templates/_helpers.tpl
+++ b/charts/drupal/templates/_helpers.tpl
@@ -432,8 +432,11 @@ if [[ -f /app/reference-data/db.tar.gz || -f /app/reference-data/db.sql.gz ]]; t
   fi
 
   # Clear caches before doing anything else.
-  if [[ "${DRUPAL_CORE_VERSION}" -eq 7 ]] ; then drush cache-clear all;
-  else drush cache-rebuild; fi
+  if [[ "${DRUPAL_CORE_VERSION}" -eq 7 ]] ; then
+    drush cache-clear all;
+  else
+    drush cache-rebuild;
+  fi
 else
   printf "\e[33mNo reference data found, please install Drupal or import a database dump. See release information for instructions.\e[0m\n"
 fi

--- a/charts/drupal/templates/_helpers.tpl
+++ b/charts/drupal/templates/_helpers.tpl
@@ -432,6 +432,11 @@ if [[ "$(drush status --fields=bootstrap)" = *'Successful'* ]] ; then
   tar -cf /tmp/db.tar.gz -I 'gzip -1' -C "${dump_dir}" .
   cp /tmp/db.tar.gz /app/reference-data/db.tar.gz
 
+  # For backwards compability, we keep this older method of saving reference data. This way it will be easier to roll back if needed.
+  # This will be removed once the new method has successfully been rolled out.
+  gzip -1 /tmp/db.sql
+  cp /tmp/db.sql.gz /app/reference-data/db.sql.gz
+
   {{ range $index, $mount := .Values.mounts -}}
   {{- if eq $mount.enabled true -}}
   # File backup for {{ $index }} volume.

--- a/charts/drupal/templates/_helpers.tpl
+++ b/charts/drupal/templates/_helpers.tpl
@@ -381,7 +381,8 @@ if [[ "$(drush status --fields=bootstrap)" = *'Successful'* ]] ; then
     # Add --no-data parameter for tables that match .Values.referenceData.ignoreTableContent.
     [[ "${table}" =~ {{ .Values.referenceData.ignoreTableContent }} ]] && nodata='--no-data' || nodata=''
     echo "Dumping table: ${table}"
-    mysqldump --user="${DB_USER}" --password="${DB_PASS}" --host="${DB_HOST}" "${nodata}" "${DB_NAME}" "${table}" > "${dump_dir}${table}".sql
+    # The ${nodata} variable cannot be quoted in the mysqldump command because if it's empty, the command will fail.
+    mysqldump --user="${DB_USER}" --password="${DB_PASS}" --host="${DB_HOST}" ${nodata} "${DB_NAME}" "${table}" > "${dump_dir}${table}".sql
   done
 
   # Compress the sql files into a single file and copy it into the backup folder.

--- a/charts/drupal/templates/_helpers.tpl
+++ b/charts/drupal/templates/_helpers.tpl
@@ -382,7 +382,7 @@ if [[ "$(drush status --fields=bootstrap)" = *'Successful'* ]] ; then
     [[ "${table}" =~ {{ .Values.referenceData.ignoreTableContent }} ]] && nodata='--no-data' || nodata=''
     echo "Dumping table: ${table}"
     # The ${nodata} variable cannot be quoted in the mysqldump command because if it's empty, the command will fail.
-    mysqldump --user="${DB_USER}" --password="${DB_PASS}" --host="${DB_HOST}" ${nodata} "${DB_NAME}" "${table}" > "${dump_dir}${table}".sql
+    mysqldump --user="${DB_USER}" --password="${DB_PASS}" --host="${DB_HOST}" ${nodata} "${DB_NAME}" "${table}" > "${dump_dir}${table}.sql"
   done
 
   # Compress the sql files into a single file and copy it into the backup folder.
@@ -421,15 +421,15 @@ if [[ -f /app/reference-data/db.tar.gz || -f /app/reference-data/db.sql.gz ]]; t
   tmp_ref_data=/tmp/reference-data
 
   # New way of importing.
-  if [[ -f "${app_ref_data}"/db.tar.gz ]]; then
+  if [[ -f "${app_ref_data}/db.tar.gz" ]]; then
     mkdir "${tmp_ref_data}"
-    tar -xzf "${app_ref_data}"/db.tar.gz -C "${tmp_ref_data}"/
-    find "${tmp_ref_data}"/ -type f -name "*.sql" | xargs -P10 -I{} sh -c 'echo "Importing {}" && mysql -A --user="${DB_USER}" --password="${DB_PASS}" --host="${DB_HOST}" "${DB_NAME}" < {}'
+    tar -xzf "${app_ref_data}/db.tar.gz" -C "${tmp_ref_data}/"
+    find "${tmp_ref_data}/" -type f -name "*.sql" | xargs -P10 -I{} sh -c 'echo "Importing {}" && mysql -A --user="${DB_USER}" --password="${DB_PASS}" --host="${DB_HOST}" "${DB_NAME}" < {}'
 
   # Backwards compatibility for old way of importing.
-  elif [[ -f "${app_ref_data}"/db.sql.gz ]]; then
-    gunzip -c "${app_ref_data}"/db.sql.gz > "${tmp_ref_data}"-db.sql
-    pv -f "${tmp_ref_data}"-db.sql | drush sql-cli
+  elif [[ -f "${app_ref_data}/db.sql.gz" ]]; then
+    gunzip -c "${app_ref_data}/db.sql.gz" > "${tmp_ref_data}-db.sql"
+    pv -f "${tmp_ref_data}-db.sql" | drush sql-cli
   fi
 
   # Clear caches before doing anything else.


### PR DESCRIPTION
Changes proposed:
- Update drupal.extract-reference-data so that it exports one .sql file per database table, and saves them in db.tar.gz
- Update drupal.import-reference-db so that it supports importing the database from db.tar.gz, using xargs to run 10 simultaneous mysql commands, making the import roughly 60% faster than previously
- Keep backwards compability so that the older way of importing db.sql.gz still works
- Improve bash code style

**Note: The new way of importing reference database might consume more memory, so if pods get OOMKilled while importing, the mariadb memory limit needs to be increased.**

**Note 2: Any scripts or commands that developers have used for fetching the reference database manually will need to be updated.**