### PR TITLE
Change monolog config, Remove monolog restriction in CLI

### DIFF
--- a/charts/drupal/files/settings.silta.php
+++ b/charts/drupal/files/settings.silta.php
@@ -94,11 +94,5 @@ if (getenv('VARNISH_ADMIN_HOST')) {
 
 /**
  * Use our own services override.
- *
- * We don't include this when running on cli, for example when using drush,
- * because the output from monolog to stdout interferes with drush batch
- * processing, causing the process to die when drush tries to start a new batch.
  */
-if (PHP_SAPI !== 'cli') {
-  $settings['container_yamls'][] = 'sites/default/silta.services.yml';
-}
+$settings['container_yamls'][] = 'sites/default/silta.services.yml';

--- a/charts/drupal/files/silta.services.yml
+++ b/charts/drupal/files/silta.services.yml
@@ -1,9 +1,19 @@
 parameters:
   monolog.channel_handlers:
-     # Log to the stdout by default.
-     default: ['stdout']
+    # Log to the stdout by default.
+    default:
+      handlers:
+        - name: 'stream'
+          formatter: 'drush'
+  monolog.processors:
+    - 'message_placeholder'
+    - 'current_user'
+    - 'request_uri'
+    - 'ip'
+    - 'referer'
+    - 'filter_backtrace'
 
 services:
-  monolog.handler.stdout:
+  monolog.handler.stream:
     class: Monolog\Handler\StreamHandler
-    arguments: ['php://stdout']
+    arguments: ['php://stdout', 200]


### PR DESCRIPTION
Include monolog in CLI 

The reason why it was not included was that monolog interfered with drush batch processing

There are 2 solutions
One is to use stderr instead of stdout https://github.com/drush-ops/drush/issues/4790
The other requires monolog version  2.2.0 where "drush" formatted is included https://www.drupal.org/i/3223751

Things to do/argue about
- to use the Drush formatted would need to add a check to settings.php for the monolog version
- Is there any reason to log in to stdout instead of stderr?
- Are there any arguments against the processors or minimum log level of "info"
- Change the filename to "silta.monolog.servises.yml" as there is no other config there


A simple drush command that uses batch is locale:check and makes this easier to test

