### PR TITLE
Log to STDERR instead of STDOUT with monolog 

### DIFF
--- a/charts/drupal/files/settings.silta.php
+++ b/charts/drupal/files/settings.silta.php
@@ -95,10 +95,7 @@ if (getenv('VARNISH_ADMIN_HOST')) {
 /**
  * Use our own services override.
  *
- * We don't include this when running on cli, for example when using drush,
- * because the output from monolog to stdout interferes with drush batch
- * processing, causing the process to die when drush tries to start a new batch.
+ * Add monolog config
+ * We avoid monolog interfering with drush batch processing by logging to STDERR
  */
-if (PHP_SAPI !== 'cli') {
-  $settings['container_yamls'][] = 'sites/default/silta.services.yml';
-}
+$settings['container_yamls'][] = 'sites/default/silta.services.yml';

--- a/charts/drupal/files/settings.silta.php
+++ b/charts/drupal/files/settings.silta.php
@@ -96,6 +96,7 @@ if (getenv('VARNISH_ADMIN_HOST')) {
  * Use our own services override.
  *
  * Add monolog config
- * We avoid monolog interfering with drush batch processing by logging to STDERR
+ * because the output from monolog to stdout interferes with drush batch
+ * processing we avoid it by logging to STDERR.
  */
 $settings['container_yamls'][] = 'sites/default/silta.services.yml';

--- a/charts/drupal/files/silta.services.yml
+++ b/charts/drupal/files/silta.services.yml
@@ -1,9 +1,10 @@
 parameters:
   monolog.channel_handlers:
-     # Log to the stdout by default.
-     default: ['stdout']
+     # Log to stderr by default.
+     default: ['stream']
 
 services:
-  monolog.handler.stdout:
+  monolog.handler.stream:
     class: Monolog\Handler\StreamHandler
-    arguments: ['php://stdout']
+    # The minimum logging level DEBUG = 100
+    arguments: ['php://stderr', 100]


### PR DESCRIPTION
### The Problem

Monolog is not included in CLI (cron commands) and we do not get cron logs in Sumo

### The Cause

Currently, this is due to `silta.services.yml` being excluded in `settings.silta.php`
```
/**
 * Use our own services override.
 *
 * We don't include this when running on CLI, for example when using Drush,
 * because the output from monolog to stdout interferes with the Drush batch
 * processing, causing the process to die when the Drush tries to start a new batch.
 */
if (PHP_SAPI !== 'cli') {
  $settings['container_yamls'][] = 'sites/default/silta.services.yml';
}
```

### The Goal

Get the Drupal cron messages in Sumo.

### The Solution

Use stderr instead of stdout

This was first discussed in this PR  https://github.com/wunderio/drupal-project-k8s/pull/560

Also added the Default log level of DEBUG so it is more visible
and changed the name of the default handler to "stream" ( as it uses the Streamhandler )
### Testing

A few commands that use batch processing 
`drush locale:check`
`drush en action` enabling any module

- Run commands in CLI that use drush batch processing 
- Check that there are no errors ( due to monolog spitting out logs)

STDOUT
![image](https://user-images.githubusercontent.com/107038594/203070610-70de5dd7-414b-408b-aa73-a57b7085151f.png)

STDERR
![image](https://user-images.githubusercontent.com/107038594/203071694-a3e5472c-6486-4e92-a3a4-3e70bd6dd23d.png)
