### PR TITLE
Feature/gdpr dump smile

### DIFF
--- a/charts/drupal/templates/checks.yaml
+++ b/charts/drupal/templates/checks.yaml
@@ -11,3 +11,6 @@
 {{- end }}
 {{- end }}
 {{- end }}
+{{- if .Values.referenceData.ignoreTableContent }}
+{{- fail "referenceData.ignoreTableContent is deprecated. See gdprDump.tables.[cache_*].truncate` key for table data removal." -}}
+{{- end}}

--- a/charts/drupal/templates/drupal-configmap.yaml
+++ b/charts/drupal/templates/drupal-configmap.yaml
@@ -6,8 +6,8 @@ metadata:
     {{- include "drupal.release_labels" . | nindent 4 }}
 data:
   gdpr-dump: |
-    # [mysqldump]
-    # gdpr-replacements='{{ .Values.gdprDump | toJson }}'
+    [mysqldump]
+    gdpr-replacements='{{ .Values.gdprDump | toJson }}'
 
   {{- if eq .Values.php.drupalCoreVersion "7" }}
   settings_silta_php: |{{ .Files.Get "files/settings.silta.d7.php" | nindent 4 }}

--- a/charts/drupal/templates/drupal-configmap.yaml
+++ b/charts/drupal/templates/drupal-configmap.yaml
@@ -6,8 +6,12 @@ metadata:
     {{- include "drupal.release_labels" . | nindent 4 }}
 data:
   gdpr-dump: |
-    [mysqldump]
-    gdpr-replacements='{{ .Values.gdprDump | toJson }}'
+    database:
+      host: '%env(DB_HOST)%'
+      user: '%env(DB_USER)%'
+      password: '%env(DB_PASS)%'
+      name: '%env(DB_NAME)%'
+    {{ .Values.gdprDump | toYaml | nindent 4 }}
 
   {{- if eq .Values.php.drupalCoreVersion "7" }}
   settings_silta_php: |{{ .Files.Get "files/settings.silta.d7.php" | nindent 4 }}

--- a/charts/drupal/templates/post-release.yaml
+++ b/charts/drupal/templates/post-release.yaml
@@ -28,10 +28,6 @@ spec:
         - |
             {{- include "drupal.post-release-command" . | nindent 12 }}
         volumeMounts:
-          - name: config
-            mountPath: /etc/my.cnf.d/gdpr-dump.cnf
-            readOnly: true
-            subPath: gdpr-dump
           {{- include "drupal.volumeMounts" . | nindent 10 }}
           {{- if .Values.referenceData.enabled }}
           {{- if or (eq .Values.referenceData.referenceEnvironment .Values.environmentName) (not .Values.referenceData.skipMount) }}

--- a/charts/drupal/templates/reference-data-cron.yaml
+++ b/charts/drupal/templates/reference-data-cron.yaml
@@ -24,10 +24,6 @@ spec:
               {{- include "drupal.volumeMounts" . | nindent 14 }}
               - name: reference-data-volume
                 mountPath: /app/reference-data
-              - name: config
-                mountPath: /etc/my.cnf.d/gdpr-dump.cnf
-                readOnly: true
-                subPath: gdpr-dump
             command: ["/bin/bash", "-c"]
             args:
               - |

--- a/charts/drupal/tests/backup_test.yaml
+++ b/charts/drupal/tests/backup_test.yaml
@@ -28,16 +28,3 @@ tests:
     - hasDocuments:
         count: 2
       template: backup-volume.yaml
-
-  - it: has no gdpr-dump configuration
-    template: backup-cron.yaml
-    set:
-      backup.enabled: true
-    asserts:
-    - notContains:
-        path: spec.jobTemplate.spec.template.spec.containers[0].volumeMounts
-        content:
-          name: gdpr-dump
-          mountPath: /etc/my.cnf.d/gdpr-dump.cnf
-          readOnly: true
-          subPath: gdpr-dump

--- a/charts/drupal/values.yaml
+++ b/charts/drupal/values.yaml
@@ -421,9 +421,13 @@ referenceData:
 # Uses formatters from fakerphp.github.io/formatters 
 gdprDump:
   tables:
+    cache:
+      truncate: true
     cache_*:
       truncate: true
     sessions:
+      truncate: true
+    watchdog:
       truncate: true
     commerce_payment_method*:
       truncate: true

--- a/charts/drupal/values.yaml
+++ b/charts/drupal/values.yaml
@@ -391,7 +391,8 @@ referenceData:
   # Update the reference data after deployments on the reference environment.
   updateAfterDeployment: true
 
-  ignoreTableContent: '(cache|cache_.*|sessions|watchdog)'
+  # Deprecated. See `gdprDump.tables.[cache_*].truncate` key for data removal
+  # ignoreTableContent: '(cache|cache_.*|sessions|watchdog)'
 
   # Matching folders will not be included in reference data.
   ignoreFolders:
@@ -419,18 +420,45 @@ referenceData:
     limits:
       memory: 488Mi
 
-# Parameters for sanitizing reference data with gdpr-dump.
-# Uses formatters from https://packagist.org/packages/fzaninotto/faker.
+# Parameters for sanitizing reference data with github.com/Smile-SA/gdpr-dump
+# Uses formatters from fakerphp.github.io/formatters 
 gdprDump:
-  users_field_data:
-    name:
-      formatter: name
-    pass:
-      formatter: password
-    mail:
-      formatter: safeEmail
-    init:
-      formatter: clear
+  tables:
+    cache_*:
+      truncate: true
+    sessions:
+      truncate: true
+    commerce_payment_method*:
+      truncate: true
+    users_field_data:
+      converters:
+        mail:
+          converter: 'randomizeEmail'
+          unique: true
+        init:
+          converter: 'fromContext'
+          parameters:
+            key: 'processed_data.mail'
+        name:
+          converter: 'faker'
+          parameters:
+            formatter: 'name'
+        pass:
+          converter: 'randomizeText'
+    commerce_order:
+      converters:
+        mail:
+          converter: 'randomizeEmail'
+          unique: true
+        ip_address:
+          converter: 'faker'
+          parameters:
+            formatter: 'ipv4'
+    commerce_store_field_data:
+      converters:
+        mail:
+          converter: 'randomizeEmail'
+          unique: true
 
 backup:
   # Whether backups should be taken for the current environment.

--- a/charts/drupal/values.yaml
+++ b/charts/drupal/values.yaml
@@ -391,9 +391,6 @@ referenceData:
   # Update the reference data after deployments on the reference environment.
   updateAfterDeployment: true
 
-  # Deprecated. See `gdprDump.tables.[cache_*].truncate` key for data removal
-  # ignoreTableContent: '(cache|cache_.*|sessions|watchdog)'
-
   # Matching folders will not be included in reference data.
   ignoreFolders:
     - css

--- a/silta/php.Dockerfile
+++ b/silta/php.Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for the Drupal container.
-# im02
+# im04
 #FROM wunderio/silta-php-fpm:7.3-fpm-v0.1
 #FROM wunderio/silta-php-fpm:7.4-fpm-v0.1
 # FROM wunderio/silta-php-fpm:8.0-fpm-v0.1

--- a/silta/php.Dockerfile
+++ b/silta/php.Dockerfile
@@ -1,9 +1,7 @@
 # Dockerfile for the Drupal container.
-# im04
 #FROM wunderio/silta-php-fpm:7.3-fpm-v0.1
 #FROM wunderio/silta-php-fpm:7.4-fpm-v0.1
-# FROM wunderio/silta-php-fpm:8.0-fpm-v0.1
-FROM eu.gcr.io/silta-images/php:8.0-fpm-gdpr-test
+FROM wunderio/silta-php-fpm:8.0-fpm-v0.1
 
 COPY --chown=www-data:www-data . /app
 

--- a/silta/php.Dockerfile
+++ b/silta/php.Dockerfile
@@ -1,8 +1,9 @@
 # Dockerfile for the Drupal container.
-# im01
+# im02
 #FROM wunderio/silta-php-fpm:7.3-fpm-v0.1
 #FROM wunderio/silta-php-fpm:7.4-fpm-v0.1
-FROM wunderio/silta-php-fpm:8.0-fpm-v0.1
+# FROM wunderio/silta-php-fpm:8.0-fpm-v0.1
+FROM eu.gcr.io/silta-images/php:8.0-fpm-gdpr-test
 
 COPY --chown=www-data:www-data . /app
 

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -47,10 +47,3 @@ nginx:
   extraConfig: |
     # Show server host name as header
     add_header X-Backend-Server $hostname;
-
-
-# Configure reference data that will be used when creating new environments.
-referenceData:
-  enabled: true
-  referenceEnvironment: 'feature/gdpr-dump-smile'
-  schedule: '*/5 * * * *'

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -47,3 +47,10 @@ nginx:
   extraConfig: |
     # Show server host name as header
     add_header X-Backend-Server $hostname;
+
+
+# Configure reference data that will be used when creating new environments.
+referenceData:
+  enabled: true
+  referenceEnvironment: 'feature/gdpr-dump-smile'
+  schedule: '*/5 * * * *'


### PR DESCRIPTION
! Merge to charts repository only when https://github.com/wunderio/silta-images/pull/52 is merged and php images are built. 

- Smile-SA/gdpr-dump for sanitized reference data creation
- `/app/gdpr-dump.yaml` replacement file is always created
- `referenceData.ignoreTableContent` deprecation and override check (since it's incompatible with `Smile-SA/gdpr-dump` at this point). See gdprDump.tables.[cache_*].truncate` key for table data removal.