### PR TITLE
php-fpm configuration file is copied in php container init scripts now

### DIFF
--- a/charts/drupal/templates/drupal-deployment.yaml
+++ b/charts/drupal/templates/drupal-deployment.yaml
@@ -43,13 +43,6 @@ spec:
         readinessProbe:
           exec:
             command: ['/bin/bash', '-c', '/php-fpm-probe.sh']
-        lifecycle:
-          postStart:
-            exec:
-              command:
-              - bash
-              - -c
-              - cp /tmp/zz-custom.conf /usr/local/etc/php-fpm.d/zz-custom.conf
         resources:
           {{- .Values.php.resources | toYaml | nindent 10 }}
 


### PR DESCRIPTION
## Merge this PR only after https://github.com/wunderio/silta-images/pull/64 is merged and images are released!

-- 
php-fpm configuration file (/tmp/zz-custom.conf -> /usr/local/etc/php-fpm.d/zz-custom.conf) is copied in php container init scripts now.