### PR TITLE
Feature/test cluster/nginx ingress

### DIFF
--- a/charts/drupal/templates/drupal-ingress.yaml
+++ b/charts/drupal/templates/drupal-ingress.yaml
@@ -39,6 +39,9 @@ metadata:
     {{- if eq $ingress.type "azure/application-gateway" }}
     appgw.ingress.kubernetes.io/ssl-redirect: {{ $redirect_https | quote }}
     {{- end }}
+    {{- if eq $ingress.type "nginx" }}
+    nginx.ingress.kubernetes.io/ssl-redirect: {{ $redirect_https | quote }}
+    {{- end }}
     {{- end }}
 
     {{- if eq $ingress.type "gce" }}
@@ -190,6 +193,9 @@ metadata:
     ingress.kubernetes.io/ssl-redirect: {{ $redirect_https | quote }}
     {{- if eq $ingress.type "azure/application-gateway" }}
     appgw.ingress.kubernetes.io/ssl-redirect: {{ $redirect_https | quote }}
+    {{- end }}
+    {{- if eq $ingress.type "nginx" }}
+    nginx.ingress.kubernetes.io/ssl-redirect: {{ $redirect_https | quote }}
     {{- end }}
     {{- end }}
 

--- a/charts/drupal/templates/drupal-ingress.yaml
+++ b/charts/drupal/templates/drupal-ingress.yaml
@@ -36,6 +36,9 @@ metadata:
     {{- end }}
     {{- if $redirect_https }}
     ingress.kubernetes.io/ssl-redirect: {{ $redirect_https | quote }}
+    {{- if eq $ingress.type "traefik" }}
+    nginx.ingress.kubernetes.io/ssl-redirect: {{ $redirect_https | quote }}
+    {{- end }}
     {{- if eq $ingress.type "azure/application-gateway" }}
     appgw.ingress.kubernetes.io/ssl-redirect: {{ $redirect_https | quote }}
     {{- end }}
@@ -191,6 +194,9 @@ metadata:
     {{- end }}
     {{- if $redirect_https }}
     ingress.kubernetes.io/ssl-redirect: {{ $redirect_https | quote }}
+    {{- if eq $ingress.type "traefik" }}
+    nginx.ingress.kubernetes.io/ssl-redirect: {{ $redirect_https | quote }}
+    {{- end }}
     {{- if eq $ingress.type "azure/application-gateway" }}
     appgw.ingress.kubernetes.io/ssl-redirect: {{ $redirect_https | quote }}
     {{- end }}

--- a/charts/drupal/templates/drupal-ingress.yaml
+++ b/charts/drupal/templates/drupal-ingress.yaml
@@ -38,12 +38,14 @@ metadata:
     ingress.kubernetes.io/ssl-redirect: {{ $redirect_https | quote }}
     {{- if eq $ingress.type "traefik" }}
     nginx.ingress.kubernetes.io/ssl-redirect: {{ $redirect_https | quote }}
+    nginx.org/redirect-to-https: {{ $redirect_https | quote }}
     {{- end }}
     {{- if eq $ingress.type "azure/application-gateway" }}
     appgw.ingress.kubernetes.io/ssl-redirect: {{ $redirect_https | quote }}
     {{- end }}
     {{- if eq $ingress.type "nginx" }}
     nginx.ingress.kubernetes.io/ssl-redirect: {{ $redirect_https | quote }}
+    nginx.org/redirect-to-https: {{ $redirect_https | quote }}
     {{- end }}
     {{- end }}
 
@@ -196,12 +198,14 @@ metadata:
     ingress.kubernetes.io/ssl-redirect: {{ $redirect_https | quote }}
     {{- if eq $ingress.type "traefik" }}
     nginx.ingress.kubernetes.io/ssl-redirect: {{ $redirect_https | quote }}
+    nginx.org/redirect-to-https: {{ $redirect_https | quote }}
     {{- end }}
     {{- if eq $ingress.type "azure/application-gateway" }}
     appgw.ingress.kubernetes.io/ssl-redirect: {{ $redirect_https | quote }}
     {{- end }}
     {{- if eq $ingress.type "nginx" }}
     nginx.ingress.kubernetes.io/ssl-redirect: {{ $redirect_https | quote }}
+    nginx.org/redirect-to-https: {{ $redirect_https | quote }}
     {{- end }}
     {{- end }}
 

--- a/charts/drupal/templates/drupal-ingress.yaml
+++ b/charts/drupal/templates/drupal-ingress.yaml
@@ -224,6 +224,15 @@ metadata:
     {{- if $ingress.extraAnnotations }}
     {{- $ingress.extraAnnotations | toYaml | nindent 4 }}
     {{- end }}
+
+    {{- if (index $.Values "silta-release").downscaler.enabled }}
+    auto-downscale/down: "false"
+    auto-downscale/last-update: {{ dateInZone "2006-01-02T15:04:05.999Z" (now) "UTC" }}
+    auto-downscale/label-selector: "release={{ $.Release.Name }}"
+    auto-downscale/services: {{ include "drupal.servicename" $ }}
+    {{- end }}
+  labels:
+    {{- include "drupal.release_labels" $ | nindent 4 }}
 spec:
   {{- if $ingress.tls }}
   tls:

--- a/charts/drupal/values.yaml
+++ b/charts/drupal/values.yaml
@@ -89,6 +89,10 @@ ingress:
             period: 1s
             average: 32
             burst: 90
+      nginx.ingress.kubernetes.io/limit-rps: "32"
+      nginx.ingress.kubernetes.io/limit-rpm: "300"
+      nginx.ingress.kubernetes.io/limit-burst-multiplier: "3"
+      nginx.ingress.kubernetes.io/limit-connections: "20"
   gce:
     type: gce
     # The name of the reserved static IP address.

--- a/silta/silta-test.yml
+++ b/silta/silta-test.yml
@@ -17,6 +17,20 @@ ingress:
       nginx.ingress.kubernetes.io/enable-owasp-core-rules: "true"
       nginx.ingress.kubernetes.io/modsecurity-snippet: |
         SecRuleEngine On
+  nginx2:
+    type: traefik
+  nginx-notls2:
+    type: traefik
+    redirect-https: false
+    tls: false
+  nginx-modsecurity2:
+    type: traefik
+    extraAnnotations:
+      nginx.ingress.kubernetes.io/enable-modsecurity: "true"
+      nginx.ingress.kubernetes.io/enable-owasp-core-rules: "true"
+      nginx.ingress.kubernetes.io/modsecurity-snippet: |
+        SecRuleEngine On
+
 exposeDomains:
   test:
     hostname: test.drupal-project-k8s.nginx-silta-test.wdr.io
@@ -27,4 +41,14 @@ exposeDomains:
   modsecurity:
     hostname: sec.drupal-project-k8s.nginx-silta-test.wdr.io
     ingress: nginx-modsecurity
+    
+  test2:
+    hostname: test.drupal-project-k8s.silta-test.wdr.io
+    ingress: nginx2
+  notls2:
+    hostname: notls.drupal-project-k8s.silta-test.wdr.io
+    ingress: nginx-notls2
+  modsecurity2:
+    hostname: sec.drupal-project-k8s.silta-test.wdr.io
+    ingress: nginx-modsecurity2
     

--- a/silta/silta-test.yml
+++ b/silta/silta-test.yml
@@ -2,3 +2,65 @@
 referenceData:
   enabled: true
   referenceEnvironment: 'feature/test-cluster/reference'
+
+ingress:
+  nginx:
+    type: nginx
+  nginx-notls:
+    type: nginx
+    redirect-https: false
+    tls: false
+  nginx-rate1:
+    type: nginx
+    extraAnnotations:
+      nginx.ingress.kubernetes.io/limit-connections: "2"      
+  nginx-rate2:
+    type: nginx
+    extraAnnotations:
+      nginx.ingress.kubernetes.io/limit-rpm: "5"
+  nginx-modsecurity1:
+    type: nginx
+    extraAnnotations:
+      nginx.ingress.kubernetes.io/enable-modsecurity: "true"
+  nginx-modsecurity2:
+    type: nginx
+    extraAnnotations:
+      nginx.ingress.kubernetes.io/enable-owasp-core-rules: "true"
+  nginx-modsecurity3:
+    type: nginx
+    extraAnnotations:
+      nginx.ingress.kubernetes.io/enable-modsecurity: "true"
+      nginx.ingress.kubernetes.io/enable-owasp-core-rules: "true"    
+  nginx-modsecurity4:
+    type: nginx
+    extraAnnotations:
+      nginx.ingress.kubernetes.io/enable-modsecurity: "true"
+      nginx.ingress.kubernetes.io/enable-owasp-core-rules: "true"
+      nginx.ingress.kubernetes.io/modsecurity-snippet: |
+        SecRuleEngine On
+
+exposeDomains:
+  test1:
+    hostname: test1.drupal-project-k8s.nginx-silta-test.wdr.io
+    ingress: nginx
+  notls:
+    hostname: notls.drupal-project-k8s.nginx-silta-test.wdr.io
+    ingress: nginx-notls
+  rate1:
+    ingress: nginx-rate1
+    hostname: r1.drupal-project-k8s.nginx-silta-test.wdr.io
+  rate2:
+    ingress: nginx-rate2
+    hostname: r2.drupal-project-k8s.nginx-silta-test.wdr.io
+  modsecurity1:
+    ingress: nginx-modsecurity1
+    hostname: s1.drupal-project-k8s.nginx-silta-test.wdr.io
+  modsecurity2:
+    ingress: nginx-modsecurity2
+    hostname: s2.drupal-project-k8s.nginx-silta-test.wdr.io
+  modsecurity3:
+    ingress: nginx-modsecurity3
+    hostname: s3.drupal-project-k8s.nginx-silta-test.wdr.io
+  modsecurity4:
+    ingress: nginx-modsecurity4
+    hostname: s4.drupal-project-k8s.nginx-silta-test.wdr.io

--- a/silta/silta-test.yml
+++ b/silta/silta-test.yml
@@ -10,57 +10,21 @@ ingress:
     type: nginx
     redirect-https: false
     tls: false
-  nginx-rate1:
-    type: nginx
-    extraAnnotations:
-      nginx.ingress.kubernetes.io/limit-connections: "2"      
-  nginx-rate2:
-    type: nginx
-    extraAnnotations:
-      nginx.ingress.kubernetes.io/limit-rpm: "5"
-  nginx-modsecurity1:
-    type: nginx
-    extraAnnotations:
-      nginx.ingress.kubernetes.io/enable-modsecurity: "true"
-  nginx-modsecurity2:
-    type: nginx
-    extraAnnotations:
-      nginx.ingress.kubernetes.io/enable-owasp-core-rules: "true"
-  nginx-modsecurity3:
-    type: nginx
-    extraAnnotations:
-      nginx.ingress.kubernetes.io/enable-modsecurity: "true"
-      nginx.ingress.kubernetes.io/enable-owasp-core-rules: "true"    
-  nginx-modsecurity4:
+  nginx-modsecurity:
     type: nginx
     extraAnnotations:
       nginx.ingress.kubernetes.io/enable-modsecurity: "true"
       nginx.ingress.kubernetes.io/enable-owasp-core-rules: "true"
       nginx.ingress.kubernetes.io/modsecurity-snippet: |
         SecRuleEngine On
-
 exposeDomains:
-  test1:
-    hostname: test1.drupal-project-k8s.nginx-silta-test.wdr.io
+  test:
+    hostname: test.drupal-project-k8s.nginx-silta-test.wdr.io
     ingress: nginx
   notls:
     hostname: notls.drupal-project-k8s.nginx-silta-test.wdr.io
     ingress: nginx-notls
-  rate1:
-    ingress: nginx-rate1
-    hostname: r1.drupal-project-k8s.nginx-silta-test.wdr.io
-  rate2:
-    ingress: nginx-rate2
-    hostname: r2.drupal-project-k8s.nginx-silta-test.wdr.io
-  modsecurity1:
-    ingress: nginx-modsecurity1
-    hostname: s1.drupal-project-k8s.nginx-silta-test.wdr.io
-  modsecurity2:
-    ingress: nginx-modsecurity2
-    hostname: s2.drupal-project-k8s.nginx-silta-test.wdr.io
-  modsecurity3:
-    ingress: nginx-modsecurity3
-    hostname: s3.drupal-project-k8s.nginx-silta-test.wdr.io
-  modsecurity4:
-    ingress: nginx-modsecurity4
-    hostname: s4.drupal-project-k8s.nginx-silta-test.wdr.io
+  modsecurity:
+    hostname: sec.drupal-project-k8s.nginx-silta-test.wdr.io
+    ingress: nginx-modsecurity
+    


### PR DESCRIPTION
- Adds nginx ingress annotations to default configuration (allows switching out traefik ingress while keeping the same name):
  - http->https redirect abstraction
  - rate limits
- Adds downscaler annotation to `exposeDomains`, allowing wakeup via `exposeDomain` entries
Once reviewed, test domain entries will be removed.