### PR TITLE
Added webp to the list of image extensions in nginx and varnish configs.

### DIFF
--- a/charts/drupal/templates/drupal-configmap.yaml
+++ b/charts/drupal/templates/drupal-configmap.yaml
@@ -469,7 +469,7 @@ data:
         }
 
         ## Serve static files & images directly, without all standard drupal rewrites, php-fpm etc.
-        location ~* ^.+\.(?:css|js|jpe?g|gif|png|ico|svg|swf|docx?|xlsx?|tiff?|txt|cgi|bat|pl|dll|exe|class)$ {
+        location ~* ^.+\.(?:css|js|jpe?g|gif|png|ico|webp|svg|swf|docx?|xlsx?|tiff?|txt|cgi|bat|pl|dll|exe|class)$ {
           tcp_nodelay     off;
           expires         365d;
           add_header Cache-Control "public";
@@ -559,7 +559,7 @@ data:
       }
       location @files_retry {
         internal;
-        # Pass file request to drupal as a final fallback. 
+        # Pass file request to drupal as a final fallback.
         try_files $uri @drupal;
       }
       {{- end }}
@@ -698,12 +698,12 @@ data:
 
   php-fpm-probe.sh: |
     #!/bin/bash
-    
+
     # Prevent requests during the site installation process.
     if [ {{ include "drupal.installation-in-progress-test" $ }} ]; then
       exit 1;
     fi
-    
+
     # Ping php-fpm process
     SCRIPT_NAME=/ping \
     SCRIPT_FILENAME=/ping \

--- a/charts/drupal/templates/varnish-configmap-vcl.yaml
+++ b/charts/drupal/templates/varnish-configmap-vcl.yaml
@@ -183,7 +183,7 @@ data:
         set beresp.http.x-ttl = "10m";
       }
 
-      if (bereq.url ~ "\.(jpg|jpeg|gif|png|svg|ico|css|js|zip|tgz|gz|rar|bz2|pdf|txt|tar|wav|bmp|rtf|flv|swf|html|htm|otf)\??.*$") {
+      if (bereq.url ~ "\.(jpg|jpeg|gif|png|svg|ico|webp|css|js|zip|tgz|gz|rar|bz2|pdf|txt|tar|wav|bmp|rtf|flv|swf|html|htm|otf)\??.*$") {
         # Strip any cookies before static files are inserted into cache.
         unset beresp.http.set-cookie;
         if(beresp.status == 200){
@@ -395,7 +395,7 @@ data:
         return (pass);
       }
 
-      if (req.url ~ "\.(png|gif|jpg|tif|tiff|ico|swf|css|js|pdf|doc|xls|ppt|zip)(\?.*)?$") {
+      if (req.url ~ "\.(png|gif|jpg|tif|tiff|ico|webp|swf|css|js|pdf|doc|xls|ppt|zip)(\?.*)?$") {
         // Forcing a lookup with static file requests
         return (hash);
       }
@@ -420,7 +420,7 @@ data:
       }
 
       if (req.http.Cookie) {
-        if (req.url ~ "\.(png|gif|jpg|svg|tif|tiff|ico|swf|css|js|pdf|doc|xls|ppt|zip|woff|eot|ttf|bmp|bz2)$") {
+        if (req.url ~ "\.(png|gif|jpg|svg|tif|tiff|ico|webp|swf|css|js|pdf|doc|xls|ppt|zip|woff|eot|ttf|bmp|bz2)$") {
           # Static file request do not vary on cookies
           unset req.http.Cookie;
           return (hash);
@@ -441,7 +441,7 @@ data:
       }
 
       if (req.http.Accept-Encoding) {
-        if (req.url ~ "\.(jpg|png|gif|svg|tif|tiff|ico|gz|tgz|bz2|tbz|mp3|ogg|swf|zip|pdf|woff|eot|ttf)(\?.*)?$") {
+        if (req.url ~ "\.(jpg|png|gif|svg|tif|tiff|ico|webp|gz|tgz|bz2|tbz|mp3|ogg|swf|zip|pdf|woff|eot|ttf)(\?.*)?$") {
           # No point in compressing these
           unset req.http.Accept-Encoding;
         } elsif (req.http.Accept-Encoding ~ "gzip") {


### PR DESCRIPTION
Currently we define certain headers and/or cache settings for images, but not for webp files.

This PR adds webp to the list of image extensions in both nginx and varnish configs.