### PR TITLE
SLT-846: 15s sleep in preStop hooks for php and nginx container

### DIFF
--- a/charts/drupal/templates/drupal-deployment.yaml
+++ b/charts/drupal/templates/drupal-deployment.yaml
@@ -46,7 +46,7 @@ spec:
         lifecycle:
           preStop:
             exec:
-              command: [ "/bin/sleep", "5" ]
+              command: [ "/bin/sleep", "15" ]
         resources:
           {{- .Values.php.resources | toYaml | nindent 10 }}
 
@@ -100,7 +100,7 @@ spec:
         lifecycle:
           preStop:
             exec:
-              command: ["/bin/sleep", "5"]
+              command: ["/bin/sleep", "15"]
         resources:
           {{- .Values.nginx.resources | toYaml | nindent 10 }}
 

--- a/charts/drupal/templates/drupal-deployment.yaml
+++ b/charts/drupal/templates/drupal-deployment.yaml
@@ -43,6 +43,10 @@ spec:
         readinessProbe:
           exec:
             command: ['/bin/bash', '-c', '/php-fpm-probe.sh']
+        lifecycle:
+          preStop:
+            exec:
+              command: [ "/bin/sleep", "5" ]
         resources:
           {{- .Values.php.resources | toYaml | nindent 10 }}
 
@@ -83,7 +87,7 @@ spec:
           mountPath: /etc/nginx/conf.d/misc.conf
           readOnly: true
           subPath: extraConfig
-        {{- end }}  
+        {{- end }}
         {{- if .Values.nginx.basicauth.enabled }}
         - name: nginx-basicauth
           mountPath: /etc/nginx/.htaccess


### PR DESCRIPTION
Proposed changes:
- Adds an identical preStop hook to the php container as we have in the nginx container
- Increase the sleep time in nginx and php preStop hooks in order to prevent errors as much as possible. This was tested with different settings, and for now 15s seemed good.

Related PR: https://github.com/wunderio/charts/pull/368

Related previous PR that did not get merged: https://github.com/wunderio/charts/pull/309