### PR TITLE
SLT-855: Allow DRUSH_OPTIONS_URI override

### DIFF
--- a/charts/drupal/templates/_helpers.tpl
+++ b/charts/drupal/templates/_helpers.tpl
@@ -179,8 +179,10 @@ imagePullSecrets:
   value: "{{ .Values.environmentName }}"
 - name: RELEASE_NAME
   value: "{{ .Release.Name }}"
+{{- if not .Values.php.env.DRUSH_OPTIONS_URI }}
 - name: DRUSH_OPTIONS_URI
   value: "http://{{- template "drupal.domain" . }}"
+{{- end }}
 {{- include "drupal.db-env" . }}
 - name: ERROR_LEVEL
   value: {{ .Values.php.errorLevel }}

--- a/charts/drupal/tests/drupal_php_env_test.yaml
+++ b/charts/drupal/tests/drupal_php_env_test.yaml
@@ -1,0 +1,29 @@
+suite: drupal php env
+templates:
+  - shell-deployment.yaml
+capabilities:
+  apiVersions:
+    - pxc.percona.com/v1
+tests:
+  - it: uses fallback drush options uri value when not provided
+    template: shell-deployment.yaml
+    set:
+      environmentName: "testing"
+      projectName: "example"
+    asserts:
+      - contains:
+          path: template.spec.containers[0].env
+          content:
+            name: DRUSH_OPTIONS_URI
+            value: http://testing.example.silta.wdr.io
+  - it: uses provided drush options uri value when it is provided in php.env
+    template: shell-deployment.yaml
+    set:
+      php.env:
+        DRUSH_OPTIONS_URI: http://some-custom.example.com
+    asserts:
+      - contains:
+          path: template.spec.containers[0].env
+          content:
+            name: DRUSH_OPTIONS_URI
+            value: http://some-custom.example.com


### PR DESCRIPTION
These changes should allow projects to set `DRUSH_OPTIONS_URI` PHP environment variable without causing deployment error.

If `DRUSH_OPTIONS_URI` is not set, the output manifest should remain with the default/fallback value which uses `drupal.domain` value.

Note: I'm uncertain of how to test this locally, so I wish that someone is able to actually run these changes and confirm them working.