### PR TITLE
SLT-808: Add value to allow override of DRUSH_OPTIONS_URI

### DIFF
--- a/charts/drupal/templates/_helpers.tpl
+++ b/charts/drupal/templates/_helpers.tpl
@@ -180,7 +180,7 @@ imagePullSecrets:
 - name: RELEASE_NAME
   value: "{{ .Release.Name }}"
 - name: DRUSH_OPTIONS_URI
-  value: "http://{{- template "drupal.domain" . }}"
+  value: "{{- if .Values.drushUri }}{{ .Values.drushUri }}{{- else }}http://{{- template "drupal.domain" . }}{{- end }}"
 {{- include "drupal.db-env" . }}
 - name: ERROR_LEVEL
   value: {{ .Values.php.errorLevel }}

--- a/charts/drupal/values.schema.json
+++ b/charts/drupal/values.schema.json
@@ -134,6 +134,7 @@
       "properties": {
         "format": { "type": "string" }
       }
-    }
+    },
+    "drushUri": { "type": "string" }
   }
 }

--- a/charts/drupal/values.yaml
+++ b/charts/drupal/values.yaml
@@ -34,6 +34,9 @@ webRoot: /app/web
 # Multiple pods make sense for high availability.
 replicas: 1
 
+# Provide an override for the DRUSH_OPTIONS_URI The default is: http://{{- template "drupal.domain" . }}
+drushUri: ""
+
 # Enable autoscaling using HorizontalPodAutoscaler
 # see: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/
 autoscaling:


### PR DESCRIPTION
added `drushUri` value to `values.yml`
This allows developers to override the DRUSH_OPTIONS_URI in the template

## Testing
- SSH into current env and run `drush st` check that the `SITE URI` is correct
- create or check[ test branch](https://github.com/wunderio/drupal-project-k8s/tree/feature/SLT-808-test) SSH into it run `drush st` and check that the `SITE URI` is the same as set in `values.yml`

## Misc?

Should we actually check the `php.env.DRUSH_OPTIONS_URI` value for this? 

