### PR TITLE
Support for secrets as environment variables

### DIFF
--- a/charts/drupal/templates/_helpers.tpl
+++ b/charts/drupal/templates/_helpers.tpl
@@ -244,8 +244,10 @@ imagePullSecrets:
 {{- end }}
 # Environment overrides via values file
 {{- range $key, $val := .Values.php.env }}
+#- name: {{ $key }}
+#  value: {{ $val.valueFrom.secretKeyRef.name | quote }}
 - name: {{ $key }}
-  value: {{ $val | quote }}
+  {{ $val | toYaml | indent 4 | trim }}
 {{- end }}
 {{- range $index, $mount := $.Values.mounts }}
 {{- if eq $mount.enabled true }}

--- a/charts/drupal/templates/_helpers.tpl
+++ b/charts/drupal/templates/_helpers.tpl
@@ -244,10 +244,12 @@ imagePullSecrets:
 {{- end }}
 # Environment overrides via values file
 {{- range $key, $val := .Values.php.env }}
-#- name: {{ $key }}
-#  value: {{ $val.valueFrom.secretKeyRef.name | quote }}
 - name: {{ $key }}
+{{- if kindIs "string" $val }}
+  value: {{ $val | quote }}
+{{- else }}
   {{ $val | toYaml | indent 4 | trim }}
+{{- end }}
 {{- end }}
 {{- range $index, $mount := $.Values.mounts }}
 {{- if eq $mount.enabled true }}

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -47,12 +47,3 @@ nginx:
   extraConfig: |
     # Show server host name as header
     add_header X-Backend-Server $hostname;
-
-php:
-  env:
-    #TESTING: testval
-    secret_TEST:
-      valueFrom:
-        secretKeyRef:
-          name: secret-resource
-          key: somefield

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -47,3 +47,12 @@ nginx:
   extraConfig: |
     # Show server host name as header
     add_header X-Backend-Server $hostname;
+
+# php:
+#   env:
+#     TESTING: testval
+#     secret_TEST:
+#       valueFrom:
+#         secretKeyRef:
+#         name: secret-resource
+#         key: somefield

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -48,11 +48,11 @@ nginx:
     # Show server host name as header
     add_header X-Backend-Server $hostname;
 
-# php:
-#   env:
-#     TESTING: testval
-#     secret_TEST:
-#       valueFrom:
-#         secretKeyRef:
-#         name: secret-resource
-#         key: somefield
+php:
+  env:
+    #TESTING: testval
+    secret_TEST:
+      valueFrom:
+        secretKeyRef:
+          name: secret-resource
+          key: somefield


### PR DESCRIPTION
Secrets can be referenced as environment variables for PHP containers.

### Testing
1. Create a secret `kubectl create secret generic secret-resource --from-literal=somefield=somedata -n drupal-project-k8s`
2. Add a sample config for env vars in `silta.yml`
```
php:
  env:
    TESTING: testval
    secret_TEST:
      valueFrom:
        secretKeyRef:
          name: secret-resource
          key: somefield
```
4. After deployment, exec into PHP container. There should be 2 environment variables added:
 `TESTING`, with a value from `silta.yml`
 `secret_TEST`, with a value defined in secret `secret-resource`, from a field `somefield`