### PR TITLE
Forward js and css to drupal in nginx

### DIFF
--- a/charts/drupal/templates/drupal-configmap.yaml
+++ b/charts/drupal/templates/drupal-configmap.yaml
@@ -473,8 +473,8 @@ data:
         {{- end }}
         {{- end }}
 
-        ## Handle D7 image styles
-        location ~* /files/styles/ {
+        ## Passes image style and asset generation to PHP.
+        location ~ ^(/[a-z\-]+)?/sites/.*/files/(css|js|styles)/ {
           expires 365d;
           try_files $uri @drupal;
         }


### PR DESCRIPTION
In Drupal 10.1 Aggregation has been changed 
Now we should pass the css/js request to drupal
https://www.drupal.org/node/2888767
https://www.drupal.org/node/3301716

The code change provided in the above Drupal org pages does not take into account the langcode that may be in the Url.
the proposed code is from Lando D10 nginx conf :) 
https://github.com/lando/drupal/blob/c787282143af609482369efa135e2ad7c0c9d64a/recipes/drupal10/default.conf.tpl#L99