### PR TITLE
Feature/secrets mount

### DIFF
--- a/charts/drupal/templates/_helpers.tpl
+++ b/charts/drupal/templates/_helpers.tpl
@@ -57,11 +57,19 @@ ports:
 {{- end }}
 
 {{- define "drupal.volumes" -}}
-{{- range $index, $mount := $.Values.mounts }}
+{{- range $index, $mount := $.Values.mounts -}}
 {{- if eq $mount.enabled true }}
 - name: drupal-{{ $index }}
+{{- if hasKey $mount "secretName" }}
+  secret:
+    secretName: {{ $mount.secretName }}
+{{- else if hasKey $mount "configMapName" }}
+  configMap:
+    name: {{ $mount.configMapName }}
+{{- else }}
   persistentVolumeClaim:
     claimName: {{ $.Release.Name }}-{{ $index }}
+{{- end }}
 {{- end }}
 {{- end }}
 - name: config

--- a/charts/drupal/templates/drupal-volumes.yaml
+++ b/charts/drupal/templates/drupal-volumes.yaml
@@ -2,6 +2,7 @@
 #Trimmed release name to fit *it*, sha256sum(7 chars), $index and '-' separators together into a single 63 character string
 {{- $releaseNameTrimmed := substr 0 (int (sub 54 (len $index))) $.Release.Name }}
 {{- if eq $mount.enabled true }}
+{{- if and (not (hasKey $mount "configMapName")) (not (hasKey $mount "secretName")) -}}
 {{- if eq $mount.storageClassName "silta-shared" }}
 # Mount-enabled: {{ $mount.enabled  }}
 apiVersion: v1
@@ -48,6 +49,7 @@ spec:
 {{- end }}
 ---
 {{- end -}}
+{{- end }}
 {{- end }}
 
 {{- if .Values.referenceData.enabled }}

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -5,7 +5,7 @@
 # for all possible options.
 
 varnish:
-  enabled: true
+  enabled: false
 
 elasticsearch:
   enabled: true
@@ -21,6 +21,14 @@ redis:
 mounts:
   private-files:
     enabled: true
+  test-secret:
+    enabled: true
+    secretName: test-secret
+    mountPath: /a-secret
+  test-cm:
+    enabled: true
+    configMapName: test-cm
+    mountPath: /a-cm
 
 # Allow access from another namespace for testing purposes.
 silta-release:

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -5,7 +5,7 @@
 # for all possible options.
 
 varnish:
-  enabled: false
+  enabled: true
 
 elasticsearch:
   enabled: true
@@ -21,14 +21,6 @@ redis:
 mounts:
   private-files:
     enabled: true
-  test-secret:
-    enabled: true
-    secretName: test-secret
-    mountPath: /a-secret
-  test-cm:
-    enabled: true
-    configMapName: test-cm
-    mountPath: /a-cm
 
 # Allow access from another namespace for testing purposes.
 silta-release:


### PR DESCRIPTION
Option to reference secrets, configmaps in mounts.

### Testing
1. Create a secret `kubectl create secret generic test-secret --from-literal=somefield=somedata -n drupal-project-k8s`
2. Create a configmap `kubectl create configmap test-cm --from-literal=special.how=very --from-literal=special.type=charm -n drupal-project-k8s`
3. Add both mount types to `mounts:` in silta.yml
```
  test-secret:
    enabled: true
    secretName: test-secret
    mountPath: /a-secret
  test-cm:
    enabled: true
    configMapName: test-cm
    mountPath: /a-cm
```

4. After deployment, exec into php container. There should directories `/a-cm` and `/a-secret` at the root.