### PR TITLE
Feature/backup storageclass

### DIFF
--- a/charts/drupal/templates/backup-volume.yaml
+++ b/charts/drupal/templates/backup-volume.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.backup.enabled }}
+{{- if eq .Values.backup.storageClassName "silta-shared" }}
 apiVersion: v1
 kind: PersistentVolume
 metadata:
@@ -20,6 +21,7 @@ spec:
       remotePathSuffix: /{{ .Release.Namespace }}/{{ .Values.environmentName }}/backups
   {{- end }}
 ---
+{{- end }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/charts/drupal/templates/drupal-volumes.yaml
+++ b/charts/drupal/templates/drupal-volumes.yaml
@@ -54,6 +54,7 @@ spec:
 
 {{- if .Values.referenceData.enabled }}
 {{- if eq .Values.referenceData.referenceEnvironment .Values.environmentName }}
+{{- if eq .Values.referenceData.storageClassName "silta-shared" }}
 apiVersion: v1
 kind: PersistentVolume
 metadata:
@@ -75,6 +76,7 @@ spec:
       remotePathSuffix: /{{ .Release.Namespace }}/{{ .Values.environmentName }}/reference-data
   {{- end }}
 ---
+{{- end }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/charts/drupal/templates/shell-volume.yaml
+++ b/charts/drupal/templates/shell-volume.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.shell.enabled }}
 {{- $releaseNameTrimmed := substr 0 (int (sub 54 (len "ssh-keys"))) $.Release.Name }}
+{{- if eq .Values.shell.mount.storageClassName "silta-shared" }}
 apiVersion: v1
 kind: PersistentVolume
 metadata:
@@ -22,6 +23,8 @@ spec:
       umask: "077"
   {{- end }}
 ---
+{{- end }}
+
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -47,7 +47,3 @@ nginx:
   extraConfig: |
     # Show server host name as header
     add_header X-Backend-Server $hostname;
-
-backup:
-  enabled: true
-  storageClassName: nfs-shared

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -50,3 +50,4 @@ nginx:
 
 backup:
   enabled: true
+  storageClassName: nfs-shared

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -47,3 +47,6 @@ nginx:
   extraConfig: |
     # Show server host name as header
     add_header X-Backend-Server $hostname;
+
+backup:
+  enabled: true


### PR DESCRIPTION
creates backup and referenceData PersistentVolume only when silta-shared storageclass is used (since silta-shared does not provision volumes).