### PR TITLE
Feature/disable sigsci on probe

### DIFF
--- a/charts/drupal/templates/drupal-configmap.yaml
+++ b/charts/drupal/templates/drupal-configmap.yaml
@@ -545,9 +545,9 @@ data:
           add_header  Content-Type  text/plain;
           access_log  off;
           try_files $uri @drupal;
-        {{- if .Values.signalsciences.enabled }}
+          {{- if .Values.signalsciences.enabled }}
           sigsci_enabled off;
-        {{- end }}
+          {{- end }}
         }
 
         location = /radioactivity_node.php {

--- a/charts/drupal/templates/drupal-configmap.yaml
+++ b/charts/drupal/templates/drupal-configmap.yaml
@@ -545,6 +545,9 @@ data:
           add_header  Content-Type  text/plain;
           access_log  off;
           try_files $uri @drupal;
+        {{- if .Values.signalsciences.enabled }}
+        sigsci_enabled off;
+        {{- end }}
         }
 
         location = /radioactivity_node.php {
@@ -654,6 +657,9 @@ data:
         fastcgi_param  SCRIPT_FILENAME    $document_root/_ping.php;
         fastcgi_pass php;
         access_log off;
+        {{- if .Values.signalsciences.enabled }}
+        sigsci_enabled off;
+        {{- end }}
       }
       # Following directive is commented out since it produces notes in logs
       # on every http request where parameter q= is not present

--- a/charts/drupal/templates/drupal-configmap.yaml
+++ b/charts/drupal/templates/drupal-configmap.yaml
@@ -546,7 +546,7 @@ data:
           access_log  off;
           try_files $uri @drupal;
         {{- if .Values.signalsciences.enabled }}
-        sigsci_enabled off;
+          sigsci_enabled off;
         {{- end }}
         }
 

--- a/silta/silta-prod.yml
+++ b/silta/silta-prod.yml
@@ -33,17 +33,6 @@ autoscaling:
 backup:
   enabled: true
 
-# Uncomment these lines to disable basic auth protection.
-# nginx:
-#   basicauth:
-#     enabled: false
-
-nginx:
-  resources:
-    requests:
-      cpu: 10m
-      memory: 30M
-
 php:
   # Reserve more resources for our PHP containerss.
   resources:
@@ -58,6 +47,9 @@ php:
   errorLevel: "hide"
 
 nginx:
+# Uncomment these lines to disable basic auth protection.
+#  basicauth:
+#    enabled: false
   resources:
     requests:
       cpu: 50m


### PR DESCRIPTION
Remove robots.txt, _ping.php from paths scanned by SignalSciences.
Also removed redundant nginx config.