### PR TITLE
SLT-883: Upgrade default Maria DB version to 10.6

### DIFF
--- a/charts/drupal/values.yaml
+++ b/charts/drupal/values.yaml
@@ -514,6 +514,9 @@ backup:
 # see: https://github.com/bitnami/charts/blob/91fcd1eb5d00c33cc74e24502a85ce656ac1e963/bitnami/mariadb/values.yaml
 mariadb:
   enabled: true
+  image:
+    # https://hub.docker.com/r/bitnami/mariadb/tags
+    tag: 10.6.15-debian-11-r24
   replication:
     enabled: false
   db:


### PR DESCRIPTION
tested: installing 10.3, upgrading to 10.6. Also, doing a clean 10.6 install. No issues met.