### PR TITLE
SLT-901: Added cronjob defaults and updated cronjob resource inheritance logic

### DIFF
--- a/charts/drupal/templates/drupal-cron.yaml
+++ b/charts/drupal/templates/drupal-cron.yaml
@@ -98,23 +98,35 @@ spec:
                 exit "$exit_code"
 
             resources:
-              {{ if $job.resources }}
+              {{- if $job.resources }}
               {{- $job.resources | toYaml | nindent 14 }}
-              {{ else }}
+              {{- else }}
+              {{- if ($.Values.php.cronJobDefaults).resources }}
+              {{- $.Values.php.cronJobDefaults.resources | toYaml | nindent 14 }}
+              {{- else}}
               {{- $.Values.php.resources | toYaml | nindent 14 }}
+              {{- end }}
               {{- end }}
           restartPolicy: Never
           nodeSelector:
-            {{ if $job.nodeSelector }}
+            {{- if $job.nodeSelector }}
             {{- $job.nodeSelector | toYaml | nindent 12 }}
-            {{ else }}
+            {{- else }}
+            {{- if ($.Values.php.cronJobDefaults).nodeSelector }}
+            {{- $.Values.php.cronJobDefaults.nodeSelector | toYaml | nindent 12 }}
+            {{- else }}
             {{- $.Values.php.nodeSelector | toYaml | nindent 12 }}
             {{- end }}
+            {{- end }}
           tolerations:
-            {{ if $job.nodeSelector }}
+            {{- if $job.nodeSelector }}
             {{- include "drupal.tolerations" $job.nodeSelector | nindent 12 }}
-            {{ else }}
+            {{- else }}
+            {{- if ($.Values.php.cronJobDefaults).nodeSelector }}
+            {{- include "drupal.tolerations" $.Values.php.cronJobDefaults.nodeSelector | nindent 12 }}
+            {{- else }}
             {{- include "drupal.tolerations" $.Values.php.nodeSelector | nindent 12 }}
+            {{- end }}
             {{- end }}
 
           volumes:

--- a/charts/drupal/templates/drupal-cron.yaml
+++ b/charts/drupal/templates/drupal-cron.yaml
@@ -99,36 +99,47 @@ spec:
 
             resources:
               {{- if $job.resources }}
-              {{- $job.resources | toYaml | nindent 14 }}
+              {{- if ($.Values.php.cronJobDefaults).resources }}
+              {{- merge $job.resources (merge $.Values.php.cronJobDefaults.resources $.Values.php.resources) | toYaml | nindent 14 }}
+              {{- else }}
+              {{- merge $job.resources $.Values.php.resources | toYaml | nindent 14 }}
+              {{- end }}
               {{- else }}
               {{- if ($.Values.php.cronJobDefaults).resources }}
-              {{- $.Values.php.cronJobDefaults.resources | toYaml | nindent 14 }}
-              {{- else}}
+              {{- merge $.Values.php.cronJobDefaults.resources $.Values.php.resources | toYaml | nindent 14 }}
+              {{- else }}
               {{- $.Values.php.resources | toYaml | nindent 14 }}
               {{- end }}
               {{- end }}
           restartPolicy: Never
           nodeSelector:
             {{- if $job.nodeSelector }}
-            {{- $job.nodeSelector | toYaml | nindent 12 }}
+            {{- if ($.Values.php.cronJobDefaults).nodeSelector }}
+            {{- merge $job.nodeSelector (merge $.Values.php.cronJobDefaults.nodeSelector $.Values.php.nodeSelector) | toYaml | nindent 12 }}
+            {{- else }}
+            {{- merge $job.nodeSelector $.Values.php.nodeSelector | toYaml | nindent 12 }}
+            {{- end }}
             {{- else }}
             {{- if ($.Values.php.cronJobDefaults).nodeSelector }}
-            {{- $.Values.php.cronJobDefaults.nodeSelector | toYaml | nindent 12 }}
+            {{- merge $.Values.php.cronJobDefaults.nodeSelector $.Values.php.nodeSelector | toYaml | nindent 12 }}
             {{- else }}
             {{- $.Values.php.nodeSelector | toYaml | nindent 12 }}
             {{- end }}
             {{- end }}
           tolerations:
             {{- if $job.nodeSelector }}
-            {{- include "drupal.tolerations" $job.nodeSelector | nindent 12 }}
+            {{- if ($.Values.php.cronJobDefaults).nodeSelector }}
+            {{- include "drupal.tolerations" (merge $job.nodeSelector (merge $.Values.php.cronJobDefaults.nodeSelector $.Values.php.nodeSelector)) | nindent 12 }}
+            {{- else }}
+            {{- include "drupal.tolerations" (merge $job.nodeSelector $.Values.php.nodeSelector) | nindent 12 }}
+            {{- end }}
             {{- else }}
             {{- if ($.Values.php.cronJobDefaults).nodeSelector }}
-            {{- include "drupal.tolerations" $.Values.php.cronJobDefaults.nodeSelector | nindent 12 }}
+            {{- include "drupal.tolerations" (merge $.Values.php.cronJobDefaults.nodeSelector $.Values.php.nodeSelector) | nindent 12 }}
             {{- else }}
             {{- include "drupal.tolerations" $.Values.php.nodeSelector | nindent 12 }}
             {{- end }}
             {{- end }}
-
           volumes:
             {{- include "drupal.volumes" $ | nindent 12 }}
 

--- a/charts/drupal/tests/drupal_cron_test.yaml
+++ b/charts/drupal/tests/drupal_cron_test.yaml
@@ -90,19 +90,43 @@ tests:
           limits:
             cpu: 234m
             memory: 2G
+
+  - it: uses default resource requests and limits overriden by cronJobDefaults resources
+    template: drupal-cron.yaml
+    set:
+      php:
+        # Unset cron-specific resources.
+        cron:
+          drupal:
+            resources: null
+        resources:
+          requests:
+            cpu: 111m
+            memory: 1G
+          limits:
+            cpu: 222m
+            memory: 2G
+        cronJobDefaults:
+          resources:
+            requests:
+              cpu: 333m
+              memory: 3G
+            limits:
+              cpu: 444m
+              memory: 4G
     asserts:
       - equal:
           path: spec.jobTemplate.spec.template.spec.containers[0].resources.requests.cpu
-          value: 123m
+          value: 333m
       - equal:
           path: spec.jobTemplate.spec.template.spec.containers[0].resources.requests.memory
-          value: 1G
+          value: 3G
       - equal:
           path: spec.jobTemplate.spec.template.spec.containers[0].resources.limits.cpu
-          value: 234m
+          value: 444m
       - equal:
           path: spec.jobTemplate.spec.template.spec.containers[0].resources.limits.memory
-          value: 2G
+          value: 4G
 
   - it: takes custom resource requests and limits
     template: drupal-cron.yaml

--- a/charts/drupal/values.schema.json
+++ b/charts/drupal/values.schema.json
@@ -240,6 +240,36 @@
             }
           }
         },
+        "cronJobDefaults": {
+          "type": ["object", "null"],
+          "additionalProperties": false,
+          "properties": {
+            "resources": {
+              "type": ["object", "null"],
+              "additionalProperties": false,
+              "properties": {
+                "requests": {
+                  "type": "object",
+                  "properties": {
+                    "cpu": { "type": ["integer", "string"] },
+                    "memory": { "type": "string" }
+                  }
+                },
+                "limits": {
+                  "type": "object",
+                  "properties": {
+                    "cpu": { "type": ["integer", "string"] },
+                    "memory": { "type": "string" }
+                  }
+                }
+              }
+            },
+            "nodeSelector": {
+              "type": "object",
+              "additionalProperties": { "type": "string" }
+            }
+          }
+        },
         "cron": {
           "type": "object",
           "additionalProperties": {

--- a/charts/drupal/values.yaml
+++ b/charts/drupal/values.yaml
@@ -253,6 +253,16 @@ php:
     status_page:
       enabled: true
 
+  cronJobDefaults:
+    # resources:
+    #   requests:
+    #     cpu: 500m
+    #     memory: 488Mi
+    #   limits:
+    #     memory: 488Mi
+    # nodeSelector:
+    #   cloud.google.com/gke-nodepool: static-ip
+
   # Cron tasks, each of which will be run into a dedicated temporary pod.
   cron:
     drupal:


### PR DESCRIPTION
Allows setting cronjob defaults like resources or nodeselector. This PR also updates the inheritance logic used for assigning resource definitions for cronjobs, so that it works in the same way as it does in the frontend chart.