### PR TITLE
SLT-898: Redefine default cron schedules for different envs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,7 +164,7 @@ workflows:
       - site-test: &site-test
           name: "Site test"
           requires:
-            - "build-deploy"
+            - "build-deploy-master"
             - "Deploy master to AKS cluster"
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ workflows:
   version: 2
   commit:
     jobs:
-      - silta/drupal-validate:
+      - silta/drupal-validate: &drupal-validate
           name: validate
 
           # Use custom executor.
@@ -54,6 +54,8 @@ workflows:
                   helm unittest ./charts/silta-release --helm3
                   helm unittest ./charts/drupal --helm3
 
+      # Build and deploy job for feature environments.
+      # Other jobs defined below extend this job.
       - silta/drupal-build-deploy: &build-deploy
           name: build-deploy
 
@@ -87,17 +89,14 @@ workflows:
             branches:
               ignore:
                 - production
-                - feature/test-cluster
-                - /feature\/test-cluster\/.*/
-                - feature/aws-cluster
-                - /feature\/aws-cluster\/.*/
-                - feature/aks-cluster
-                - /feature\/aks-cluster\/.*/
-                - feature/Traefik-ratelimiting
-                - feature/cert-manager-upgrade
+                - master
+                - /feature\/test-cluster(\/.*)?/
+                - /feature\/aws-cluster(\/.*)?/
+                - /feature\/aks-cluster(\/.*)?/
 
+      # Build and deploy job for test cluster.
+      # Extends the job defined for feature environments.
       - silta/drupal-build-deploy:
-          # Extend the build-deploy configuration for the silta-test cluster environment.
           <<: *build-deploy
           name: build-deploy-test
           silta_config: silta/silta.yml,silta/silta-test.yml
@@ -105,25 +104,64 @@ workflows:
           filters:
             branches:
               only:
-                - feature/test-cluster
-                - /feature\/test-cluster\/.*/
-                - feature/Traefik-ratelimiting
-                - feature/cert-manager-upgrade
-                - feature/new-builder-images
+                - /feature\/test-cluster(\/.*)?/
 
-      - silta/drupal-build-deploy:
-          # Extend the build-deploy configuration testing master deployment to aks cluster.
+      # Build and deploy job for master environment.
+      # Extends the job defined for feature environments.
+      - silta/drupal-build-deploy: &build-deploy-master
           <<: *build-deploy
-          name: "Deploy master to AKS cluster"
-          silta_config: silta/silta.yml,silta/silta-master-aks.yml
-          context: silta_aks
+          name: build-deploy-master
+          silta_config: silta/silta.yml,silta/silta-master.yml
           filters:
             branches:
               only:
                 - master
-                - feature/new-builder-images
 
-      - site-test:
+      # Build and deploy job for master environment in AKS cluster.
+      # Extends the job defined for master environments.
+      - silta/drupal-build-deploy: &build-deploy-master-aks
+          <<: *build-deploy-master
+          name: "Deploy master to AKS cluster"
+          silta_config: silta/silta.yml,silta/silta-master-aks.yml
+          context: silta_aks
+
+      # Build and deploy job for AKS cluster.
+      # Extends the job defined for feature environments.
+      - silta/drupal-build-deploy:
+          <<: *build-deploy
+          name: build-deploy-aks
+          silta_config: silta/silta.yml,silta/silta-aks.yml
+          context: silta_aks
+          filters:
+            branches:
+              only:
+                - /feature\/aks-cluster(\/.*)?/
+
+      # Build and deploy job for AWS cluster.
+      # Extends the job defined for feature environments.
+      - silta/drupal-build-deploy:
+          <<: *build-deploy
+          name: build-deploy-aws
+          silta_config: silta/silta.yml,silta/silta-aws.yml
+          context: silta_aws
+          filters:
+            branches:
+              only:
+                - /feature\/aws-cluster(\/.*)?/
+
+      # Build and deploy job for production environment.
+      # Extends the job defined for feature environments.
+      - silta/drupal-build-deploy:
+          <<: *build-deploy
+          name: build-deploy-prod
+          silta_config: silta/silta.yml,silta/silta-prod.yml,silta/secrets_prod_signalsciences
+          decrypt_files: silta/secrets_prod_signalsciences
+          context: silta_finland
+          filters:
+            branches:
+              only: production
+
+      - site-test: &site-test
           name: "Site test"
           requires:
             - "build-deploy"
@@ -132,43 +170,8 @@ workflows:
             branches:
               only:
                 - master
-                - feature/new-builder-images
 
-      - silta/drupal-build-deploy:
-          # Extend the build-deploy configuration for the silta-test cluster environment.
-          <<: *build-deploy
-          name: build-deploy-aws
-          silta_config: silta/silta.yml,silta/silta-aws.yml
-          context: silta_aws
-          filters:
-            branches:
-              only:
-                - feature/aws-cluster
-                - /feature\/aws-cluster\/.*/
-
-      - silta/drupal-build-deploy:
-          # Extend the build-deploy configuration for the silta-test cluster environment.
-          <<: *build-deploy
-          name: build-deploy-aks
-          silta_config: silta/silta.yml,silta/silta-aks.yml
-          context: silta_aks
-          filters:
-            branches:
-              only:
-                - feature/aks-cluster
-                - /feature\/aks-cluster\/.*/
-
-      - silta/drupal-build-deploy:
-          # Extend the build-deploy configuration for the production environment.
-          <<: *build-deploy
-          name: build-deploy-prod
-          executor: cicd80
-          silta_config: silta/silta.yml,silta/silta-prod.yml,silta/secrets_prod_signalsciences
-          decrypt_files: silta/secrets_prod_signalsciences
-          context: silta_finland
-          filters:
-            branches:
-              only: production
+  # Weekly build and deploy master and master-aks environments.
   weekly-build:
     triggers:
       - schedule:
@@ -179,73 +182,13 @@ workflows:
                 - master
     jobs:
       - silta/drupal-validate:
-          name: validate
-
-          # Use custom executor.
-          executor: cicd80
-
-          post-validation:
-            - run:
-                name: Helm unit tests
-                command: |
-                  helm unittest ./charts/silta-release --helm3
-                  helm unittest ./charts/drupal --helm3
-
-      - silta/drupal-build-deploy: &build-deploy
-          name: build-deploy
-
-          # Use custom executor.
-          executor: cicd80
-
-          # Use a local chart during development.
-          chart_name: "./charts/drupal"
-          chart_repository: ""
-          silta_config: silta/silta.yml
-          codebase-build:
-            - silta/drupal-composer-install
-            - silta/npm-install-build
-            - run:
-                name: Build local helm chart
-                command: |
-                  helm repo add elastic https://helm.elastic.co
-                  helm repo add codecentric https://codecentric.github.io/helm-charts
-                  helm repo add percona https://percona.github.io/percona-helm-charts/
-                  helm dependency build ./charts/drupal
-          pre-release:
-            - run:
-                name: Dry-run helm install
-                command: helm install --dry-run --generate-name ./charts/drupal --values charts/drupal/test.values.yaml
-          context: silta_dev
-          filters:
-            branches:
-              ignore:
-                - production
-                - feature/test-cluster
-                - /feature\/test-cluster\/.*/
-                - feature/aws-cluster
-                - /feature\/aws-cluster\/.*/
-                - feature/aks-cluster
-                - /feature\/aks-cluster\/.*/
-                - feature/Traefik-ratelimiting
-                - feature/cert-manager-upgrade
+          <<: *drupal-validate
 
       - silta/drupal-build-deploy:
-          # Extend the build-deploy configuration testing master deployment to aks cluster.
-          <<: *build-deploy
-          name: "Deploy master to AKS cluster"
-          silta_config: silta/silta.yml,silta/silta-master-aks.yml
-          context: silta_aks
-          filters:
-            branches:
-              only:
-                - master
+          <<: *build-deploy-master
+
+      - silta/drupal-build-deploy:
+          <<: *build-deploy-master-aks
 
       - site-test:
-          name: "Site test"
-          requires:
-            - "build-deploy"
-            - "Deploy master to AKS cluster"
-          filters:
-            branches:
-              only:
-                - master
+          <<: *site-test

--- a/silta/silta-master.yml
+++ b/silta/silta-master.yml
@@ -1,0 +1,1 @@
+# Overrides used for master branch.

--- a/silta/silta-master.yml
+++ b/silta/silta-master.yml
@@ -1,1 +1,8 @@
 # Overrides used for master branch.
+
+php:
+  cron:
+    drupal:
+      # In master environment, run cron once an hour. Adjust as needed.
+      # ~ gets replaced with a random digit between 0 and 9 to prevent having all cron jobs at once.
+      schedule: '~ * * * *'

--- a/silta/silta-prod.yml
+++ b/silta/silta-prod.yml
@@ -1,3 +1,4 @@
+# Overrides used for production branch.
 
 exposeDomains:
   prod-traefik:

--- a/silta/silta-prod.yml
+++ b/silta/silta-prod.yml
@@ -35,7 +35,11 @@ backup:
   enabled: true
 
 php:
-  # Reserve more resources for our PHP containerss.
+  cron:
+    drupal:
+      # In production environments, run cron every 5 minutes. Adjust as needed.
+      schedule: '*/5 * * * *'
+  # Reserve more resources for our PHP containers.
   resources:
     requests:
       cpu: 200m

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -47,3 +47,10 @@ nginx:
   extraConfig: |
     # Show server host name as header
     add_header X-Backend-Server $hostname;
+
+php:
+  cron:
+    drupal:
+      # In feature environments, run cron jobs very seldom. Adjust as needed.
+      # ~ gets replaced with a random digit between 0 and 9 to prevent having all cron jobs at once.
+      schedule: '~ 0 1 2 *'


### PR DESCRIPTION
Proposed changes:
- Adds a new silta-master.yml, which will be used in master env
- Defines new default cron schedules separately for feature envs, master env and production env. The point here is to have cron jobs run very seldomly in feature envs unless specifically needed to run more frequently.
- Refactor circleci config by using more anchors, adding more comments and removing references to obsolete branches

If accepted, these changes will also be made to the drupal-project template.