### PR TITLE
reenabling nginx vhost_traffic_status_module

### DIFF
--- a/charts/drupal/templates/drupal-configmap.yaml
+++ b/charts/drupal/templates/drupal-configmap.yaml
@@ -86,7 +86,7 @@ data:
 
   {{- if .Values.nginx.status_page.enabled }}
   nginx_status_conf: |
-    # load_module modules/ngx_http_vhost_traffic_status_module.so;
+    load_module modules/ngx_http_vhost_traffic_status_module.so;
   {{- end }}
     
   nginx_conf: |
@@ -111,9 +111,9 @@ data:
       sigsci_agent_host unix:/sigsci/tmp/sigsci.sock;
       {{- end }}
 
-      # {{- if .Values.nginx.status_page.enabled }}
-      # vhost_traffic_status_zone;
-      # {{- end }}
+      {{- if .Values.nginx.status_page.enabled }}
+      vhost_traffic_status_zone;
+      {{- end }}
 
       # List of upstream proxies we trust to set X-Forwarded-For correctly.
       {{- if kindIs "string" .Values.nginx.realipfrom }}
@@ -355,17 +355,17 @@ data:
         stub_status on;
       }
       # Disabled until base images images are updated
-      # location /nginx_vts {
-      #   satisfy any;
-      #   allow 127.0.0.1;
-      #   {{- range .Values.nginx.noauthips }}
-      #   allow {{ . }};
-      #   {{- end }}
-      #   deny all;
+      location /nginx_vts {
+        satisfy any;
+        allow 127.0.0.1;
+        {{- range .Values.nginx.noauthips }}
+        allow {{ . }};
+        {{- end }}
+        deny all;
 
-      #   vhost_traffic_status_display;
-      #   vhost_traffic_status_display_format html;
-      # }
+        vhost_traffic_status_display;
+        vhost_traffic_status_display_format html;
+      }
       {{- end }}
 
       {{- if .Values.php.fpm.status_page.enabled }}


### PR DESCRIPTION
re-enables vhost traffic status module at `nginx_vts`
Related PR: https://github.com/wunderio/drupal-project-k8s/pull/644
Vts was removed due to missing module in older base images and lack of ability to trigger rebuild. Cache prefix has been adjusted couple times, since.