### PR TITLE
Fix for redis hpa resource error

### DIFF
--- a/charts/drupal/values.yaml
+++ b/charts/drupal/values.yaml
@@ -667,6 +667,8 @@ redis:
     password: ""
   replica:
     # replicaCount: 1
+    autoscaling:
+      enabled: false
   master:
     resources:
       limits:


### PR DESCRIPTION
When running tests with the latest helm release, it fails deployment with following error
> Error: INSTALLATION FAILED: template: drupal/charts/redis/templates/sentinel/hpa.yaml:1:18: executing "drupal/charts/redis/templates/sentinel/hpa.yaml" at <.Values.replica.autoscaling.enabled>: nil pointer evaluating interface {}.autoscaling

This pr sets `replica.autoscaling.enabled` value.