### PR TITLE
Set vfs-cache-mode to "off" for backup volumes

### DIFF
--- a/charts/drupal/templates/backup-cron.yaml
+++ b/charts/drupal/templates/backup-cron.yaml
@@ -32,7 +32,7 @@ spec:
             {{- include "drupal.php-container" . | nindent 12 }}
             volumeMounts:
               {{- include "drupal.volumeMounts" . | nindent 14 }}
-              - name: {{ .Release.Name }}-backups
+              - name: {{ .Release.Name }}-backup
                 mountPath: /backups
             command: ["/bin/bash", "-c"]
             args:
@@ -56,9 +56,9 @@ spec:
           restartPolicy: Never
           volumes:
             {{- include "drupal.volumes" . | nindent 12 }}
-            - name: {{ .Release.Name }}-backups
+            - name: {{ .Release.Name }}-backup
               persistentVolumeClaim:
-                claimName: {{ .Release.Name }}-backups
+                claimName: {{ .Release.Name }}-backup
           {{- include "drupal.imagePullSecrets" . | nindent 10 }}
 {{- end }}
 

--- a/charts/drupal/templates/backup-volume.yaml
+++ b/charts/drupal/templates/backup-volume.yaml
@@ -3,9 +3,9 @@
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: {{ .Release.Name }}-{{ $.Release.Namespace | sha256sum | trunc 7 }}-backups
+  name: {{ .Release.Name }}-{{ $.Release.Namespace | sha256sum | trunc 7 }}-backup
   labels:
-    name: {{ .Release.Name }}-{{ $.Release.Namespace | sha256sum | trunc 7 }}-backups
+    name: {{ .Release.Name }}-{{ $.Release.Namespace | sha256sum | trunc 7 }}-backup
     {{- include "drupal.release_labels" . | nindent 4 }}
 spec:
   accessModes:
@@ -16,7 +16,7 @@ spec:
   {{- if .Values.backup.csiDriverName }}
   csi:
     driver: {{ .Values.backup.csiDriverName }}
-    volumeHandle: {{ .Release.Namespace }}-{{ $.Release.Namespace | sha256sum | trunc 7 }}-backups
+    volumeHandle: {{ .Release.Namespace }}-{{ $.Release.Namespace | sha256sum | trunc 7 }}-backup
     volumeAttributes:
       remotePathSuffix: /{{ .Release.Namespace }}/{{ .Values.environmentName }}/backups
       vfs-cache-mode: "off"
@@ -26,7 +26,7 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ .Release.Name }}-backups
+  name: {{ .Release.Name }}-backup
   labels:
     {{- include "drupal.release_labels" . | nindent 4 }}
   annotations:
@@ -41,6 +41,6 @@ spec:
 {{- if eq .Values.backup.storageClassName "silta-shared" }}
   selector:
     matchLabels:
-      name: {{ .Release.Name }}-{{ $.Release.Namespace | sha256sum | trunc 7 }}-backups
+      name: {{ .Release.Name }}-{{ $.Release.Namespace | sha256sum | trunc 7 }}-backup
 {{- end }}
 {{- end }}

--- a/charts/drupal/templates/backup-volume.yaml
+++ b/charts/drupal/templates/backup-volume.yaml
@@ -19,6 +19,7 @@ spec:
     volumeHandle: {{ .Release.Namespace }}-{{ $.Release.Namespace | sha256sum | trunc 7 }}-backups
     volumeAttributes:
       remotePathSuffix: /{{ .Release.Namespace }}/{{ .Values.environmentName }}/backups
+      vfs-cache-mode: "off"
   {{- end }}
 ---
 {{- end }}

--- a/charts/drupal/templates/shell-deployment.yaml
+++ b/charts/drupal/templates/shell-deployment.yaml
@@ -61,7 +61,7 @@ spec:
           subPath: authorizedKeys
           readOnly: true
         {{- if .Values.backup.enabled }}
-        - name: {{ .Release.Name }}-backups
+        - name: {{ .Release.Name }}-backup
           mountPath: /backups
           readOnly: true
         {{- end }}
@@ -88,9 +88,9 @@ spec:
         configMap:
           name: {{ .Release.Name }}-shell
       {{- if .Values.backup.enabled }}
-      - name: {{ .Release.Name }}-backups
+      - name: {{ .Release.Name }}-backup
         persistentVolumeClaim:
-          claimName: {{ .Release.Name }}-backups
+          claimName: {{ .Release.Name }}-backup
       {{- end }}
       {{- include "drupal.imagePullSecrets" . | nindent 6 }}
 {{- end }}

--- a/charts/drupal/tests/shell_deployment_test.yaml
+++ b/charts/drupal/tests/shell_deployment_test.yaml
@@ -59,7 +59,7 @@ tests:
           path: spec.template.spec.containers[0].volumeMounts
           content:
             mountPath: /backups
-            name: RELEASE-NAME-backups
+            name: RELEASE-NAME-backup
             readOnly: true
 
   - it: does not mount backups volume when backups are disabled
@@ -72,6 +72,6 @@ tests:
           path: spec.template.spec.containers[0].volumeMounts
           content:
             mountPath: /backups
-            name: RELEASE-NAME-backups
+            name: RELEASE-NAME-backup
             readOnly: true
 

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -54,8 +54,3 @@ php:
       # In feature environments, run cron jobs very seldom. Adjust as needed.
       # ~ gets replaced with a random digit between 0 and 9 to prevent having all cron jobs at once.
       schedule: '~ 0 1 2 *'
-
-backup:
-  enabled: true
-  schedule: '0 * * * *'
-  retention: 2

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -54,3 +54,8 @@ php:
       # In feature environments, run cron jobs very seldom. Adjust as needed.
       # ~ gets replaced with a random digit between 0 and 9 to prevent having all cron jobs at once.
       schedule: '~ 0 1 2 *'
+
+backup:
+  enabled: true
+  schedule: '0 * * * *'
+  retention: 2


### PR DESCRIPTION
This sets [vfs-cache-mode](https://rclone.org/commands/rclone_mount/#vfs-file-caching) to off for silta-shared backup pvc mounts and changes pvc & pv names to avoid immutable field issue with existing deployments.

Should solve backup unreliability issue where rclone process is stopped before it has fully copied file from .cache folder to remote.

Testing:
```yaml
backup:
  enabled: true
  schedule: '0 * * * *'
  retention: 2
```