### PR TITLE
Update drupal-project-k8s to use php 8.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,9 @@ executors:
   cicd80v1:
     docker:
       - image: wunderio/silta-cicd:circleci-php8.0-node14-composer2-v1
+  cicd82:
+    docker:
+      - image: wunderio/silta-cicd:circleci-php8.2-node20-composer2-v1
 
 jobs:
   site-test:
@@ -45,7 +48,7 @@ workflows:
           name: validate
 
           # Use custom executor.
-          executor: cicd80
+          executor: cicd82
 
           post-validation:
             - run:
@@ -60,7 +63,7 @@ workflows:
           name: build-deploy
 
           # Use custom executor.
-          executor: cicd80
+          executor: cicd82
 
           # Use a local chart during development.
           chart_name: "./charts/drupal"

--- a/silta/php.Dockerfile
+++ b/silta/php.Dockerfile
@@ -1,7 +1,5 @@
 # Dockerfile for the Drupal container.
-#FROM wunderio/silta-php-fpm:7.3-fpm-v1
-#FROM wunderio/silta-php-fpm:7.4-fpm-v1
-FROM wunderio/silta-php-fpm:8.0-fpm-v1
+FROM wunderio/silta-php-fpm:8.2-fpm-v1
 
 COPY --chown=www-data:www-data . /app
 

--- a/silta/shell.Dockerfile
+++ b/silta/shell.Dockerfile
@@ -1,6 +1,4 @@
 # Dockerfile for the Drupal container.
-#FROM wunderio/silta-php-shell:php7.3-v1
-#FROM wunderio/silta-php-shell:php7.4-v1
-FROM wunderio/silta-php-shell:php8.0-v1
+FROM wunderio/silta-php-shell:php8.2-v1
 
 COPY --chown=www-data:www-data . /app


### PR DESCRIPTION
While 8.0 still works, it does complain about drupal compatibility.
> [warning] Your PHP installation is too old. Drupal requires at least PHP /8.1/. It is  recommended to upgrade to PHP version /8.1.6/ or higher for the best ongoing support. See PHP's version support documentation [1] and the Drupal PHP requirements [2] page for more information.
> [1] http://php.net/supported-versions.php
> [2] https://www.drupal.org/docs/system-requirements/php-requirements
> (Currently using PHP 8.0.30)
> [success] No pending updates.

 This pr uses php 8.2 for project.