### PR TITLE
Timezone support

### DIFF
--- a/charts/drupal/templates/_helpers.tpl
+++ b/charts/drupal/templates/_helpers.tpl
@@ -191,6 +191,10 @@ imagePullSecrets:
 - name: DRUSH_OPTIONS_URI
   value: "http://{{- template "drupal.domain" . }}"
 {{- end }}
+{{- if .Values.timezone }}
+- name: TZ
+  value: {{ .Values.timezone | quote }}
+{{- end }}
 {{- include "drupal.db-env" . }}
 - name: ERROR_LEVEL
   value: {{ .Values.php.errorLevel }}
@@ -655,6 +659,12 @@ if [ -f /silta/entrypoint.sh ] ; then /silta/entrypoint.sh ; fi
 batch/v1
 {{- else }}
 batch/v1beta1
+{{- end }}
+{{- end }}
+
+{{- define "drupal.cron.timezone-support" }}
+{{- if and ( ge $.Capabilities.KubeVersion.Major "1") ( ge $.Capabilities.KubeVersion.Minor "25" ) }}true
+{{- else }}false
 {{- end }}
 {{- end }}
 

--- a/charts/drupal/templates/backup-cron.yaml
+++ b/charts/drupal/templates/backup-cron.yaml
@@ -9,6 +9,11 @@ metadata:
     {{- include "drupal.release_labels" . | nindent 4 }}
     cronjob-type: backup
 spec:
+  {{- if .Values.timezone }}
+  {{- if eq ( include "drupal.cron.timezone-support" . ) "true" }}
+  timeZone: {{ .Values.timezone | quote }}
+  {{- end }}
+  {{- end }}
   schedule: {{ .Values.backup.schedule | replace "~" (randNumeric 1) | quote }}
   concurrencyPolicy: Forbid
   startingDeadlineSeconds: 3600

--- a/charts/drupal/templates/drupal-cron.yaml
+++ b/charts/drupal/templates/drupal-cron.yaml
@@ -9,6 +9,11 @@ metadata:
   labels:
     {{- include "drupal.release_labels" $ | nindent 4 }}
 spec:
+  {{- if $.Values.timezone }}
+  {{- if eq ( include "drupal.cron.timezone-support" $ ) "true" }}
+  timeZone: {{ $.Values.timezone | quote }}
+  {{- end }}
+  {{- end }}
   schedule: {{ $job.schedule | replace "~" (randNumeric 1) | quote }}
   concurrencyPolicy: Forbid
   startingDeadlineSeconds: 3600

--- a/charts/drupal/templates/drupal-deployment.yaml
+++ b/charts/drupal/templates/drupal-deployment.yaml
@@ -59,6 +59,10 @@ spec:
           value: "{{ .Release.Name }}"
         - name: PROJECT_NAME
           value: "{{ .Values.projectName | default .Release.Namespace }}"
+        {{- if .Values.timezone }}
+        - name: TZ
+          value: {{ .Values.timezone | quote }}
+        {{- end }}
         ports:
         - containerPort: 8080
           name: drupal

--- a/charts/drupal/templates/reference-data-cron.yaml
+++ b/charts/drupal/templates/reference-data-cron.yaml
@@ -7,6 +7,11 @@ metadata:
   labels:
     {{- include "drupal.release_labels" . | nindent 4 }}
 spec:
+  {{- if .Values.timezone }}
+  {{- if eq ( include "drupal.cron.timezone-support" . ) "true" }}
+  timeZone: {{ .Values.timezone | quote }}
+  {{- end }}
+  {{- end }}
   schedule: {{ .Values.referenceData.schedule | replace "~" (randNumeric 1) | quote }}
   concurrencyPolicy: Forbid
   startingDeadlineSeconds: 3600

--- a/charts/drupal/tests/drupal_cron_test.yaml
+++ b/charts/drupal/tests/drupal_cron_test.yaml
@@ -23,6 +23,35 @@ tests:
           path: spec.jobTemplate.spec.template.spec.containers[0].image
           value: 'drupal-12345'
 
+  - it: can set timezone
+    template: drupal-cron.yaml
+    set:
+      timezone: 'Foo/Bar'
+    capabilities:
+      majorVersion: 1
+      minorVersion: 25
+    asserts:
+      - equal:
+          path: spec.timeZone
+          value: 'Foo/Bar'
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].env
+          content:
+            name: TZ
+            value: Foo/Bar
+
+  # notExists is not supported in the current version of the test framework
+  # - it: timezone is not set for api versions that do not support it
+  #   template: drupal-cron.yaml
+  #   capabilities:
+  #     majorVersion: 1
+  #     minorVersion: 24
+  #   set:
+  #     timezone: 'Foo/Bar'
+  #   asserts:
+  #     - notExists:
+  #         path: spec.timeZone
+
   - it: sets environment variables correctly
     template: drupal-cron.yaml
     set:

--- a/charts/drupal/tests/drupal_deployment_test.yaml
+++ b/charts/drupal/tests/drupal_deployment_test.yaml
@@ -332,3 +332,18 @@ tests:
               secretKeyRef:
                 key: control_key
                 name: RELEASE-NAME-secrets-varnish
+  - it: can set timezone for php and nginx containers
+    template: drupal-deployment.yaml
+    set:
+      timezone: 'Foo/Bar'
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TZ
+            value: Foo/Bar
+      - contains:
+          path: spec.template.spec.containers[1].env
+          content:
+            name: TZ
+            value: Foo/Bar

--- a/charts/drupal/values.schema.json
+++ b/charts/drupal/values.schema.json
@@ -106,6 +106,7 @@
         "vpcNative": { "type": "boolean" }
       }
     },
+    "timezone": { "type": "string" },
     "nginx": {
       "type": "object",
       "additionalProperties": false,

--- a/charts/drupal/values.yaml
+++ b/charts/drupal/values.yaml
@@ -115,6 +115,8 @@ backendConfig:
   securityPolicy:
     name: "silta-ingress"
 
+timezone: ""
+
 # Add prefixes to the generated per-branch domains, to be used for projects that need to respond
 # on multiple domains, for example using Drupal's domain module, or using different domains for different languages.
 # domainPrefixes: ['en', 'fi']

--- a/charts/drupal/values.yaml
+++ b/charts/drupal/values.yaml
@@ -115,6 +115,9 @@ backendConfig:
   securityPolicy:
     name: "silta-ingress"
 
+# Timezone to be used by the services that support it.
+# List of timezones: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List (use the TZ identifier column)
+# The default timezone for most container images is UTC.
 timezone: ""
 
 # Add prefixes to the generated per-branch domains, to be used for projects that need to respond


### PR DESCRIPTION
Allows setting timezone for cronjobs ([beta since 1.25](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#time-zones)) and TZ environment variables for nginx and php related pods (shell, drupal, referenceData, backups, cronjobs).

TZ environment variable will work only when tzdata package is added. No errors will occur if the package is absent.
https://github.com/wunderio/silta-images/pull/170
https://github.com/wunderio/silta-images/pull/171

Value is empty by default so it won't affect existing deployments but enables them to do so.