### PR TITLE
removes port from local redirects

### DIFF
--- a/charts/drupal/templates/drupal-configmap.yaml
+++ b/charts/drupal/templates/drupal-configmap.yaml
@@ -317,6 +317,9 @@ data:
     server {
       server_name drupal;
       listen 8080;
+      
+      port_in_redirect off;
+      server_name_in_redirect off;
 
       # Loadbalancer health checks need to be fed with http 200
       if ($hc_ua) { return 200; }

--- a/charts/drupal/templates/drupal-configmap.yaml
+++ b/charts/drupal/templates/drupal-configmap.yaml
@@ -180,6 +180,8 @@ data:
       {{- end }}
 
       port_in_redirect off;
+      server_name_in_redirect off;
+      
       merge_slashes off;
 
       types_hash_max_size 8192;
@@ -317,9 +319,6 @@ data:
     server {
       server_name drupal;
       listen 8080;
-      
-      port_in_redirect off;
-      server_name_in_redirect off;
 
       # Loadbalancer health checks need to be fed with http 200
       if ($hc_ua) { return 200; }


### PR DESCRIPTION
Removes port from local redirect. Otherwise, users would get redirected to :8080 when using redirects without hostnames.

http://nginx.org/en/docs/http/ngx_http_core_module.html#port_in_redirect
http://nginx.org/en/docs/http/ngx_http_core_module.html#server_name_in_redirect
