### PR TITLE
Hotfix/cron test

### DIFF
--- a/charts/drupal/templates/drupal-configmap.yaml
+++ b/charts/drupal/templates/drupal-configmap.yaml
@@ -785,8 +785,9 @@ data:
     > /dev/null
 
 {{- range $index, $job := .Values.php.cron -}}
-{{ if $job.php_ini }}
+{{- $jobExists := $job | default dict }}
+{{- if $jobExists.php_ini }}
   php_ini_{{ $index }}: |
-    {{- tpl $job.php_ini . | nindent 4 }}
+    {{- tpl $jobExists.php_ini . | nindent 4 }}
 {{- end }}
 {{- end }}

--- a/charts/drupal/templates/drupal-cron.yaml
+++ b/charts/drupal/templates/drupal-cron.yaml
@@ -42,7 +42,7 @@ spec:
                 mountPath: /usr/local/etc/php/conf.d/silta_cron.ini
                 readOnly: true
                 subPath: php_ini_{{ $index }}
-              {{ end }}
+              {{- end }}
             command: ["/bin/bash", "-c"]
             args:
               - |

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -55,3 +55,14 @@ php:
       # The ~ symbol will be replaced by a random digit from 0 to 9.
       # This will avoid running all cron jobs at the same time.
       schedule: '~ 0 31 2 *'
+    drupal_with_override:
+      # Disable cron jobs in feature environments by using non-existing date.
+      # The ~ symbol will be replaced by a random digit from 0 to 9.
+      # This will avoid running all cron jobs at the same time.
+      schedule: '~ 0 31 2 *'
+      php_ini: |
+        [PHP]
+        memory_limit=1G
+        upload_max_filesize=100M
+        max_execution_time=120
+        max_input_vars=10000

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -55,19 +55,3 @@ php:
       # The ~ symbol will be replaced by a random digit from 0 to 9.
       # This will avoid running all cron jobs at the same time.
       schedule: '~ 0 31 2 *'
-      command: |
-        echo "drupal"
-    drupal_with_override:
-      # Disable cron jobs in feature environments by using non-existing date.
-      # The ~ symbol will be replaced by a random digit from 0 to 9.
-      # This will avoid running all cron jobs at the same time.
-      schedule: '~ 0 31 2 *'
-      command: |
-        echo "drupal_with_override"
-      php_ini: |
-        [PHP]
-        memory_limit = 1G
-        upload_max_filesize = 100M
-        max_execution_time = 120
-        max_input_vars = 10000
-    testjob: null

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -55,6 +55,12 @@ php:
       # The ~ symbol will be replaced by a random digit from 0 to 9.
       # This will avoid running all cron jobs at the same time.
       schedule: '~ 0 31 2 *'
+      php_ini: |
+        [PHP]
+        memory_limit=1G
+        upload_max_filesize=100M
+        max_execution_time=120
+        max_input_vars=10000
     drupal_with_override:
       # Disable cron jobs in feature environments by using non-existing date.
       # The ~ symbol will be replaced by a random digit from 0 to 9.

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -57,18 +57,16 @@ php:
       schedule: '~ 0 31 2 *'
       php_ini: |
         [PHP]
-        memory_limit=1G
-        upload_max_filesize=100M
-        max_execution_time=120
-        max_input_vars=10000
+        memory_limit = 1G
+        upload_max_filesize = 100M
+        max_execution_time = 120
+        max_input_vars = 10000
+      command: |
+        echo "drupal"
     drupal_with_override:
       # Disable cron jobs in feature environments by using non-existing date.
       # The ~ symbol will be replaced by a random digit from 0 to 9.
       # This will avoid running all cron jobs at the same time.
       schedule: '~ 0 31 2 *'
-      php_ini: |
-        [PHP]
-        memory_limit=1G
-        upload_max_filesize=100M
-        max_execution_time=120
-        max_input_vars=10000
+      command: |
+        echo "drupal_with_override"

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -55,12 +55,6 @@ php:
       # The ~ symbol will be replaced by a random digit from 0 to 9.
       # This will avoid running all cron jobs at the same time.
       schedule: '~ 0 31 2 *'
-      php_ini: |
-        [PHP]
-        memory_limit = 1G
-        upload_max_filesize = 100M
-        max_execution_time = 120
-        max_input_vars = 10000
       command: |
         echo "drupal"
     drupal_with_override:
@@ -70,3 +64,10 @@ php:
       schedule: '~ 0 31 2 *'
       command: |
         echo "drupal_with_override"
+      php_ini: |
+        [PHP]
+        memory_limit = 1G
+        upload_max_filesize = 100M
+        max_execution_time = 120
+        max_input_vars = 10000
+    testjob: null


### PR DESCRIPTION
```
php:
  cron:
    uclean: null
```

Deals with this case, where a cronjob is declared as null