### PR TITLE
Sync nginx client_header_timeout and client_body_timeout with php max_execution_time

### DIFF
--- a/charts/drupal/templates/drupal-configmap.yaml
+++ b/charts/drupal/templates/drupal-configmap.yaml
@@ -40,6 +40,7 @@ data:
     request_order = GP
     post_max_size = {{ .Values.php.php_ini.post_max_size }}
     upload_max_filesize = {{ .Values.php.php_ini.upload_max_filesize }}
+    max_execution_time = {{ .Values.php.php_ini.max_execution_time }}
 
     [Date]
     date.timezone = Europe/Helsinki
@@ -142,8 +143,8 @@ data:
 
       send_timeout                60s;
       sendfile                    on;
-      client_body_timeout         60s;
-      client_header_timeout       60s;
+      client_body_timeout         {{ .Values.php.php_ini.max_execution_time }}s;
+      client_header_timeout       {{ .Values.php.php_ini.max_execution_time }}s;
       ## This value is set to be identical with PHP's post_max_size.
       client_max_body_size        {{ .Values.php.php_ini.post_max_size }};
       client_body_buffer_size     128k;

--- a/charts/drupal/templates/drupal-configmap.yaml
+++ b/charts/drupal/templates/drupal-configmap.yaml
@@ -30,7 +30,7 @@ data:
     serialize_precision = -1
     realpath_cache_size = 256k
     realpath_cache_ttl = 7200
-    max_execution_time = 60
+    max_execution_time = {{ .Values.php.php_ini.max_execution_time }}
     max_input_time = 60
     memory_limit = {{ .Values.php.php_ini.memory_limit | default "256M" }}
     error_reporting = E_ALL
@@ -40,7 +40,6 @@ data:
     request_order = GP
     post_max_size = {{ .Values.php.php_ini.post_max_size }}
     upload_max_filesize = {{ .Values.php.php_ini.upload_max_filesize }}
-    max_execution_time = {{ .Values.php.php_ini.max_execution_time }}
 
     [Date]
     date.timezone = Europe/Helsinki

--- a/charts/drupal/values.schema.json
+++ b/charts/drupal/values.schema.json
@@ -324,6 +324,7 @@
             "upload_max_filesize": { "type": "string" },
             "post_max_size": { "type": "string" },
             "memory_limit": { "type": "string" },
+            "max_execution_time": { "type": "string" },
             "extraConfig": { "type": "string" }
           }
         },

--- a/charts/drupal/values.schema.json
+++ b/charts/drupal/values.schema.json
@@ -324,7 +324,7 @@
             "upload_max_filesize": { "type": "string" },
             "post_max_size": { "type": "string" },
             "memory_limit": { "type": "string" },
-            "max_execution_time": { "type": "string" },
+            "max_execution_time": { "type": "integer" },
             "extraConfig": { "type": "string" }
           }
         },

--- a/charts/drupal/values.yaml
+++ b/charts/drupal/values.yaml
@@ -349,6 +349,7 @@ php:
     upload_max_filesize: 60M
     post_max_size: 60M
     memory_limit: 256M
+    max_execution_time: 60
     # Custom php settings block. May override parameters previously defined.
     # Note: include correct php ini section, i.e. "[PHP]" or "[Date]".
     extraConfig: |

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -49,6 +49,8 @@ nginx:
     add_header X-Backend-Server $hostname;
 
 php:
+  php_ini:
+    max_execution_time: 90
   cron:
     drupal:
       # Disable cron jobs in feature environments by using non-existing date.

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -49,8 +49,6 @@ nginx:
     add_header X-Backend-Server $hostname;
 
 php:
-  php_ini:
-    max_execution_time: 90
   cron:
     drupal:
       # Disable cron jobs in feature environments by using non-existing date.


### PR DESCRIPTION
In case there is a need to increase PHP's `max_execution_time` value the current implementation doesn't have any effect unless `client_body_timeout` / `client_header_timeout` in nginx config are also adjusted accordingly.

This allows both to override these values and keep them in sync with `max_execution_time` while keeping the current default of `60` seconds.