### PR TITLE
SLT-918: Use latest silta-nginx image

### DIFF
--- a/silta/nginx.Dockerfile
+++ b/silta/nginx.Dockerfile
@@ -1,5 +1,4 @@
 # Dockerfile for building nginx.
-# Cache 17.8.2023.
-FROM wunderio/silta-nginx:1.17-v1
+FROM wunderio/silta-nginx:1.24-v1
 
 COPY . /app/web


### PR DESCRIPTION
Bump silta/nginx.Dockerfile to use the latest version of wunderio/silta-nginx image.