### PR TITLE
Mapping var, server block for proxy auth header

### DIFF
--- a/charts/drupal/templates/drupal-configmap.yaml
+++ b/charts/drupal/templates/drupal-configmap.yaml
@@ -314,12 +314,22 @@ data:
     # List health checks that need to return status 200 here
     map $http_user_agent $hc_ua { default 0; 'GoogleHC/1.0' 1; }
 
+    {{- if ne .Values.nginx.x_proxy_auth "" }}
+    # Verify if x_proxy_auth value is correct
+    map $http_x_proxy_auth $proxy_auth { default 0; '{{ .Values.nginx.x_proxy_auth }}' 1; }
+    {{- end}}
+
     server {
       server_name drupal;
       listen 8080;
 
       # Loadbalancer health checks need to be fed with http 200
       if ($hc_ua) { return 200; }
+
+      {{- if ne .Values.nginx.x_proxy_auth "" }}
+      # Block request if proxy header is set but does not match required value
+      if ($proxy_auth = 0) { return 403; }
+      {{- end}}
 
       {{- if .Values.nginx.redirects }}
       # Redirects to specified path if map returns anything
@@ -420,11 +430,6 @@ data:
       {{- end}}
 
       location / {
-
-        {{- if ne .Values.nginx.x_proxy_auth "" }}
-        # Verify if x_proxy_auth value is correct
-        if ( $http_x_proxy_auth != '{{ .Values.nginx.x_proxy_auth }}') { return 403; }
-        {{- end}}
 
         {{- if .Values.nginx.locationExtraConfig }}
         # Custom configuration gets included here


### PR DESCRIPTION
Previous approach allowed to bypass header from CDN in some scenarious. 
To not to mess with values and exposed hostnames test environment is created under 
feature/expose-fastly-domain branch
Hostname: 
drupal-project-k8s-staging.fastly.wdr.io

You can wake it up and check direct URL with
silta ci release wakeup --namespace drupal-project-k8s --release-name feature-expose-fastly-domain