### PR TITLE
WNDR-281: Unpin patch version of mariadb, pin only major.minor versions.

### DIFF
--- a/charts/drupal/values.yaml
+++ b/charts/drupal/values.yaml
@@ -546,7 +546,7 @@ mariadb:
   enabled: true
   image:
     # https://hub.docker.com/r/bitnami/mariadb/tags
-    tag: 10.6.15-debian-11-r24
+    tag: 10.6-debian-12
   replication:
     enabled: false
   db:


### PR DESCRIPTION
Link to ticket: https://wunder.atlassian.net/browse/WNDR-281

Proposed changes:
- Pin only major and minor version of mariadb so that we get patch updates automatically
- Also use debian 12 instead of 11 since new patch updates for mariadb come only to debian 12