### PR TITLE
SLT-1026: Update helm unit tests to work with latest version of the helm-unittest plugin

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,8 +97,8 @@ workflows:
             - run:
                 name: Helm unit tests
                 command: |
-                  helm unittest ./charts/silta-release --helm3
-                  helm unittest ./charts/drupal --helm3
+                  helm unittest ./charts/silta-release
+                  helm unittest ./charts/drupal
 
       # Build job for feature environments.
       # Other jobs defined below extend this job.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ executors:
       - image: wunderio/silta-cicd:circleci-php8.0-node14-composer2-v1
   cicd82:
     docker:
-      - image: wunderio/silta-cicd:circleci-php8.2-node20-composer2-helm-unittest-upgrade-test20240614
+      - image: wunderio/silta-cicd:circleci-php8.2-node20-composer2-v1
 
 jobs:
   site-test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ executors:
       - image: wunderio/silta-cicd:circleci-php8.0-node14-composer2-v1
   cicd82:
     docker:
-      - image: wunderio/silta-cicd:circleci-php8.2-node20-composer2-v1
+      - image: wunderio/silta-cicd:circleci-php8.2-node20-composer2-helm-unittest-upgrade-test20240614
 
 jobs:
   site-test:

--- a/charts/drupal/templates/backup-cron.yaml
+++ b/charts/drupal/templates/backup-cron.yaml
@@ -61,8 +61,7 @@ spec:
             - containerPort: 3306
               name: mariadb
             resources:
-              requests:
-                {{- .Values.backup.resources | toYaml | nindent 14 }}
+              {{- .Values.backup.resources | toYaml | nindent 14 }}
           restartPolicy: Never
           volumes:
             {{- include "drupal.volumes" . | nindent 12 }}

--- a/charts/drupal/templates/varnish-deployment.yaml
+++ b/charts/drupal/templates/varnish-deployment.yaml
@@ -31,9 +31,6 @@ spec:
           name: web
         - containerPort: 6082
           name: admin
-        livenessProbe:
-          tcpSocket:
-            port: 80
         env:
         - name: VARNISH_STORAGE_BACKEND
           value: {{ .Values.varnish.storageBackend | quote }}

--- a/charts/drupal/tests/db_test.yaml
+++ b/charts/drupal/tests/db_test.yaml
@@ -1,7 +1,8 @@
 suite: drupal database
 templates:
-  - drupal-deployment.yaml
   - drupal-configmap.yaml
+  - drupal-deployment.yaml
+  - drupal-secret.yaml
 capabilities:
   apiVersions:
     - pxc.percona.com/v1
@@ -96,5 +97,3 @@ tests:
           content:
             name: DB_HOST
             value: RELEASE-NAME-proxysql
-
-  

--- a/charts/drupal/tests/drupal_cache_tags_test.yaml
+++ b/charts/drupal/tests/drupal_cache_tags_test.yaml
@@ -1,7 +1,7 @@
 suite: drupal cache tag exposure
 templates:
-  - varnish-configmap-vcl.yaml
   - drupal-configmap.yaml
+  - varnish-configmap-vcl.yaml
 capabilities:
   apiVersions:
     - pxc.percona.com/v1

--- a/charts/drupal/tests/drupal_cron_test.yaml
+++ b/charts/drupal/tests/drupal_cron_test.yaml
@@ -119,6 +119,19 @@ tests:
           limits:
             cpu: 234m
             memory: 2G
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].resources.requests.cpu
+          value: 123m
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].resources.requests.memory
+          value: 1G
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].resources.limits.cpu
+          value: 234m
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].resources.limits.memory
+          value: 2G
 
   - it: uses default resource requests and limits overriden by cronJobDefaults resources
     template: drupal-cron.yaml

--- a/charts/drupal/tests/drupal_deployment_test.yaml
+++ b/charts/drupal/tests/drupal_deployment_test.yaml
@@ -145,12 +145,12 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: boolean_on
-            value: "true"
+            value: "on"
       - contains:
           path: spec.template.spec.containers[0].env
           content:
             name: boolean_off
-            value: "false"
+            value: "off"
       - contains:
           path: spec.template.spec.containers[0].env
           content:

--- a/charts/drupal/tests/drupal_deployment_test.yaml
+++ b/charts/drupal/tests/drupal_deployment_test.yaml
@@ -1,7 +1,8 @@
 suite: drupal deployment
 templates:
-  - drupal-deployment.yaml
   - drupal-configmap.yaml
+  - drupal-deployment.yaml
+  - drupal-secret.yaml
 capabilities:
   apiVersions:
     - pxc.percona.com/v1

--- a/charts/drupal/tests/drupal_hpa_test.yaml
+++ b/charts/drupal/tests/drupal_hpa_test.yaml
@@ -1,6 +1,8 @@
 suite: HorizontalPodAutoscaler
 templates:
+  - drupal-configmap.yaml
   - drupal-deployment.yaml
+  - drupal-secret.yaml
 tests:
   - it: HPA resource is present when autoscaler is enabled
     template: drupal-deployment.yaml

--- a/charts/drupal/tests/drupal_ingress_test.yaml
+++ b/charts/drupal/tests/drupal_ingress_test.yaml
@@ -20,7 +20,7 @@ tests:
         - networking.k8s.io/v1beta1
     asserts:
       - equal:
-          path: 'metadata.annotations.kubernetes\.io/ingress\.class'
+          path: metadata.annotations['kubernetes.io/ingress.class']
           value: 'traefik'
 
   - it: uses traefik ingress class (1.18+)
@@ -39,18 +39,18 @@ tests:
     template: drupal-ingress.yaml
     set:
       environmentName: 'foo'
-      projectName: 'bar' 
-      clusterDomain: 'baz' 
+      projectName: 'bar'
+      clusterDomain: 'baz'
     asserts:
       - equal:
           path: spec.rules[0].host
           value: 'foo.bar.baz'
-  
+
   - it: sets correct hostname for deployment when projectName is absent
     template: drupal-ingress.yaml
     set:
       environmentName: 'foo'
-      clusterDomain: 'baz' 
+      clusterDomain: 'baz'
     asserts:
       - equal:
           path: spec.rules[0].host
@@ -81,7 +81,7 @@ tests:
       - equal:
           path: spec.rules[0].http.paths[0].backend.service.name
           value: 'RELEASE-NAME-drupal'
-  
+
   - it: directs traefik requests to varnish service when varnish is enabled (cm 0.8)
     template: drupal-ingress.yaml
     set:
@@ -206,7 +206,7 @@ tests:
     asserts:
       - documentIndex: 1
         equal:
-          path: 'metadata.annotations.kubernetes\.io/ingress\.class'
+          path: metadata.annotations['kubernetes.io/ingress.class']
           value: 'foo'
 
   - it: exposeDomains - uses default ingress type and has correct hostname (1.18+)
@@ -255,12 +255,11 @@ tests:
     asserts:
       - documentIndex: 1
         equal:
-          path: 'metadata.annotations.traefik\.ingress\.kubernetes\.io\/frontend-entry-points'
+          path: metadata.annotations['traefik.ingress.kubernetes.io/frontend-entry-points']
           value: 'http'
       - documentIndex: 1
-        equal:
-          path: 'ingress\.kubernetes\.io\/ssl-redirect'
-          value: null
+        notExists:
+          path: metadata.annotations['ingress.kubernetes.io/ssl-redirect']
 
   - it: exposeDomains - can disable ssl redirect
     template: drupal-ingress.yaml
@@ -274,11 +273,10 @@ tests:
           ingress: nossl
     asserts:
       - documentIndex: 1
-        equal:
-          path: 'metadata.annotations.ingress\.kubernetes\.io\/ssl-redirect'
-          value: null
+        notExists:
+          path: metadata.annotations['ingress.kubernetes.io/ssl-redirect']
 
-  - it: exposeDomains - multiple hostnames can use the same ingress 
+  - it: exposeDomains - multiple hostnames can use the same ingress
     template: drupal-ingress.yaml
     set:
       exposeDomains:
@@ -286,7 +284,7 @@ tests:
           hostname: foo.baz
         bar:
           hostname: bar.baz
-        
+
     asserts:
       - documentIndex: 1
         equal:
@@ -310,7 +308,7 @@ tests:
     asserts:
       - documentIndex: 1
         equal:
-          path: 'metadata.annotations.kubernetes\.io\/ingress\.global-static-ip-name'
+          path: metadata.annotations['kubernetes.io/ingress.global-static-ip-name']
           value: 'baz'
 
   - it: exposeDomains - non-gce ingress path wildcard for kubernetes <1.19

--- a/charts/drupal/tests/drupal_ingress_test.yaml
+++ b/charts/drupal/tests/drupal_ingress_test.yaml
@@ -241,6 +241,18 @@ tests:
           path: spec.rules[0].host
           value: 'foo.bar'
 
+  - it: exposeDomains - ssl redirect is enabled by default
+    template: drupal-ingress.yaml
+    set:
+      exposeDomains:
+        foo:
+          hostname: foo.bar
+    asserts:
+      - documentIndex: 1
+        equal:
+          path: metadata.annotations['ingress.kubernetes.io/ssl-redirect']
+          value: 'true'
+
   - it: exposeDomains - can disable ssl for a certain ingress
     template: drupal-ingress.yaml
     set:

--- a/charts/drupal/tests/drupal_node_selector_test.yaml
+++ b/charts/drupal/tests/drupal_node_selector_test.yaml
@@ -1,9 +1,11 @@
 suite: node selector test
 templates:
-  - drupal-deployment.yaml
-  - drupal-cron.yaml
-  - shell-deployment.yaml
   - drupal-configmap.yaml
+  - drupal-cron.yaml
+  - drupal-deployment.yaml
+  - drupal-secret.yaml
+  - shell-configmap.yaml
+  - shell-deployment.yaml
 capabilities:
   apiVersions:
     - pxc.percona.com/v1

--- a/charts/drupal/tests/drupal_php_env_test.yaml
+++ b/charts/drupal/tests/drupal_php_env_test.yaml
@@ -1,5 +1,9 @@
 suite: drupal php env
 templates:
+  - drupal-configmap.yaml
+  - drupal-deployment.yaml
+  - drupal-secret.yaml
+  - shell-configmap.yaml
   - shell-deployment.yaml
 capabilities:
   apiVersions:

--- a/charts/drupal/tests/elasticsearch_test.yaml
+++ b/charts/drupal/tests/elasticsearch_test.yaml
@@ -1,7 +1,8 @@
 suite: drupal elasticsearch
 templates:
-  - drupal-deployment.yaml
   - drupal-configmap.yaml
+  - drupal-deployment.yaml
+  - drupal-secret.yaml
 capabilities:
   apiVersions:
     - pxc.percona.com/v1

--- a/charts/drupal/tests/memcached_test.yaml
+++ b/charts/drupal/tests/memcached_test.yaml
@@ -1,7 +1,8 @@
 suite: drupal memcached
 templates:
-  - drupal-deployment.yaml
   - drupal-configmap.yaml
+  - drupal-deployment.yaml
+  - drupal-secret.yaml
 capabilities:
   apiVersions:
     - pxc.percona.com/v1

--- a/charts/drupal/tests/nginx-extra-config_test.yaml
+++ b/charts/drupal/tests/nginx-extra-config_test.yaml
@@ -1,7 +1,8 @@
 suite: additional nginx configuration file
 templates:
-  - drupal-deployment.yaml
   - drupal-configmap.yaml
+  - drupal-deployment.yaml
+  - drupal-secret.yaml
 capabilities:
   apiVersions:
     - pxc.percona.com/v1
@@ -10,7 +11,7 @@ tests:
     template: drupal-configmap.yaml
     set:
       nginx.extraConfig: |
-        add_header X-Release-Name extraconfig-{{ .Release.Name }};  
+        add_header X-Release-Name extraconfig-{{ .Release.Name }};
     asserts:
     - matchRegex:
         path: data.extraConfig
@@ -19,7 +20,7 @@ tests:
     template: drupal-configmap.yaml
     set:
       nginx.serverExtraConfig: |
-        # serverextraconfig test {{ .Release.Name }}  
+        # serverextraconfig test {{ .Release.Name }}
     asserts:
     - matchRegex:
         path: data.drupal_conf
@@ -28,7 +29,7 @@ tests:
     template: drupal-configmap.yaml
     set:
       nginx.locationExtraConfig: |
-        # locationextraconfig test {{ .Release.Name }}  
+        # locationextraconfig test {{ .Release.Name }}
     asserts:
     - matchRegex:
         path: data.drupal_conf
@@ -39,7 +40,7 @@ tests:
       nginx.extraConfig: |
         server {
           server_name exists.test;
-        }  
+        }
     asserts:
       - contains:
           path: spec.template.spec.containers[1].volumeMounts

--- a/charts/drupal/tests/private_docker_image_test.yaml
+++ b/charts/drupal/tests/private_docker_image_test.yaml
@@ -1,9 +1,10 @@
 suite: private docker image
 templates:
-  - drupal-deployment.yaml
-  - drupal-cron.yaml
-  - post-release.yaml
   - drupal-configmap.yaml
+  - drupal-cron.yaml
+  - drupal-deployment.yaml
+  - drupal-secret.yaml
+  - post-release.yaml
 capabilities:
   apiVersions:
     - pxc.percona.com/v1

--- a/charts/drupal/tests/private_files_test.yaml
+++ b/charts/drupal/tests/private_files_test.yaml
@@ -1,10 +1,11 @@
 suite: drupal private files
 templates:
+  - drupal-configmap.yaml
+  - drupal-cron.yaml
   - drupal-deployment.yaml
+  - drupal-secret.yaml
   - drupal-volumes.yaml
   - post-release.yaml
-  - drupal-cron.yaml
-  - drupal-configmap.yaml
 capabilities:
   apiVersions:
     - pxc.percona.com/v1

--- a/charts/drupal/tests/redis_test.yaml
+++ b/charts/drupal/tests/redis_test.yaml
@@ -1,7 +1,8 @@
 suite: drupal redis
 templates:
-  - drupal-deployment.yaml
   - drupal-configmap.yaml
+  - drupal-deployment.yaml
+  - drupal-secret.yaml
 capabilities:
   apiVersions:
     - pxc.percona.com/v1

--- a/charts/drupal/tests/reference_data_test.yaml
+++ b/charts/drupal/tests/reference_data_test.yaml
@@ -1,10 +1,11 @@
 suite: reference data
 templates:
+  - drupal-configmap.yaml
+  - drupal-deployment.yaml
+  - drupal-secret.yaml
+  - drupal-volumes.yaml
   - post-release.yaml
   - reference-data-cron.yaml
-  - drupal-deployment.yaml
-  - drupal-volumes.yaml
-  - drupal-configmap.yaml
 capabilities:
   apiVersions:
     - pxc.percona.com/v1
@@ -38,7 +39,7 @@ tests:
           readOnly: true
 
   - it: is not mounted on the main deployment
-    template: post-release.yaml    
+    template: post-release.yaml
     asserts:
     - template: drupal-deployment.yaml
       notContains:
@@ -53,7 +54,7 @@ tests:
         content:
           name: "reference-data-volume"
           mountPath: "/app/reference-data"
-            
+
   - it: takes reference data information
     template: post-release.yaml
     set:
@@ -130,7 +131,7 @@ tests:
         content:
           name: "reference-data-volume"
           persistentVolumeClaim:
-            claimName: foo-reference-data  
+            claimName: foo-reference-data
     - notContains:
         path: spec.template.spec.containers[0].volumeMounts
         content:

--- a/charts/drupal/tests/shell_configmap_test.yaml
+++ b/charts/drupal/tests/shell_configmap_test.yaml
@@ -1,12 +1,14 @@
 suite: shell configmap
 templates:
+  - drupal-configmap.yaml
+  - drupal-secret.yaml
   - shell-configmap.yaml
   - shell-deployment.yaml
 capabilities:
   apiVersions:
     - pxc.percona.com/v1
 tests:
-  
+
   - it: Secret ConfigMap is created
     template: shell-configmap.yaml
     set:
@@ -17,7 +19,7 @@ tests:
       - equal:
           path: metadata.labels.app
           value: drupal
-  
+
   - it: Authorized keys addition is reflected into shell configmap
     template: shell-configmap.yaml
     set:
@@ -26,25 +28,25 @@ tests:
         - foo
         - bar
     asserts:
-      - template: shell-configmap.yaml 
+      - template: shell-configmap.yaml
         equal:
           path: data.authorizedKeys
           value: |-
             foo
             bar
-  
+
   - it: No extra authorized keys are present in template
     template: shell-configmap.yaml
     set:
       shell.enabled: true
       shell.authorizedKeys: []
     asserts:
-      - template: shell-configmap.yaml 
+      - template: shell-configmap.yaml
         equal:
           path: data.authorizedKeys
           value: ""
 
-  - it: Adds keyserver environment variables when shell is enabled 
+  - it: Adds keyserver environment variables when shell is enabled
     template: shell-deployment.yaml
     set:
       shell.enabled: true
@@ -58,14 +60,14 @@ tests:
             value: foo.bar
       - contains:
           path: spec.template.spec.containers[0].env
-          content: 
+          content:
             name: GITAUTH_USERNAME
             valueFrom:
               secretKeyRef:
                 key: keyserver.username
                 name: RELEASE-NAME-secrets-shell
 
-  - it: Keyserver environment variables not present when shell is disabled 
+  - it: Keyserver environment variables not present when shell is disabled
     template: shell-deployment.yaml
     set:
       shell.enabled: true

--- a/charts/drupal/tests/shell_deployment_test.yaml
+++ b/charts/drupal/tests/shell_deployment_test.yaml
@@ -1,5 +1,8 @@
 suite: shell deployment
 templates:
+  - drupal-configmap.yaml
+  - drupal-secret.yaml
+  - shell-configmap.yaml
   - shell-deployment.yaml
 capabilities:
   apiVersions:

--- a/charts/drupal/tests/varnish_test.yaml
+++ b/charts/drupal/tests/varnish_test.yaml
@@ -1,7 +1,7 @@
 suite: varnish deployment
 templates:
-  - varnish-deployment.yaml
   - varnish-configmap-vcl.yaml
+  - varnish-deployment.yaml
 capabilities:
   apiVersions:
     - pxc.percona.com/v1
@@ -11,7 +11,7 @@ tests:
     set:
       varnish.enabled: true
       varnish.storageBackend: 'type,/storage/location,size'
-    asserts: 
+    asserts:
       - documentIndex: 0
         contains:
           path: 'spec.template.spec.containers[0].env'
@@ -23,7 +23,7 @@ tests:
     set:
       varnish.enabled: true
       varnish.extraParams: '-foo -bar'
-    asserts: 
+    asserts:
       - documentIndex: 0
         contains:
           path: 'spec.template.spec.containers[0].env'


### PR DESCRIPTION
### Blocked by https://github.com/wunderio/silta-images/pull/216

Proposed changes:
- Update helm unit tests to work with latest version of the helm-unittest plugin
- Fix two bugs with duplicate keys in drupal-cron.yaml and varnish-deployment.yaml, reported by the updated tests