### PR TITLE
SLT-1034: ClamAV

### DIFF
--- a/charts/drupal/files/settings.silta.php
+++ b/charts/drupal/files/settings.silta.php
@@ -93,6 +93,15 @@ if (getenv('VARNISH_ADMIN_HOST')) {
 }
 
 /**
+ * Override clamav config when clamav environment variables are defined.
+ */
+if (getenv('CLAMAV_HOST')) {
+  $config['clamav.settings']['scan_mode'] = 0;
+  $config['clamav.settings']['mode_daemon_tcpip']['hostname'] = getenv('CLAMAV_HOST');
+  $config['clamav.settings']['mode_daemon_tcpip']['port'] = getenv('CLAMAV_PORT');
+}
+
+/**
  * Use our own services override.
  *
  * Add monolog config

--- a/charts/drupal/templates/_helpers.tpl
+++ b/charts/drupal/templates/_helpers.tpl
@@ -256,6 +256,12 @@ imagePullSecrets:
 - name: SOLR_HOST
   value: {{ .Release.Name }}-solr
 {{- end }}
+{{- if .Values.clamav.enabled }}
+- name: CLAMAV_HOST
+  value: {{ .Release.Name }}-clamav
+- name: CLAMAV_PORT
+  value: "3310"
+{{- end }}
 # Environment overrides via values file
 {{- range $key, $val := .Values.php.env }}
 - name: {{ $key }}
@@ -285,9 +291,9 @@ imagePullSecrets:
 - name: HTTPS_PROXY
   value: "{{ $proxy.url }}:{{ $proxy.port }}"
 - name: no_proxy
-  value: 127.0.0.1,localhost,.svc.cluster.local,{{ .Release.Name }}-memcached,{{ .Release.Name }}-redis,{{ .Release.Name }}-es,{{ .Release.Name }}-varnish,{{ .Release.Name }}-solr{{ if $proxy.no_proxy }},{{$proxy.no_proxy}}{{ end }}
+  value: 127.0.0.1,localhost,.svc.cluster.local,{{ .Release.Name }}-memcached,{{ .Release.Name }}-redis,{{ .Release.Name }}-es,{{ .Release.Name }}-clamav,{{ .Release.Name }}-varnish,{{ .Release.Name }}-solr{{ if $proxy.no_proxy }},{{$proxy.no_proxy}}{{ end }}
 - name: NO_PROXY
-  value: 127.0.0.1,localhost,.svc.cluster.local,{{ .Release.Name }}-memcached,{{ .Release.Name }}-redis,{{ .Release.Name }}-es,{{ .Release.Name }}-varnish,{{ .Release.Name }}-solr{{ if $proxy.no_proxy }},{{$proxy.no_proxy}}{{ end }}
+  value: 127.0.0.1,localhost,.svc.cluster.local,{{ .Release.Name }}-memcached,{{ .Release.Name }}-redis,{{ .Release.Name }}-es,{{ .Release.Name }}-clamav,{{ .Release.Name }}-varnish,{{ .Release.Name }}-solr{{ if $proxy.no_proxy }},{{$proxy.no_proxy}}{{ end }}
 {{- end }}
 {{- end }}
 

--- a/charts/drupal/templates/clamav-configmap.yaml
+++ b/charts/drupal/templates/clamav-configmap.yaml
@@ -1,0 +1,50 @@
+{{- if .Values.clamav.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-clamav
+  labels:
+    {{- include "drupal.release_labels" . | nindent 4 }}
+data:
+  freshclam.conf: |
+    # https://docs.clamav.net/manual/Usage/Configuration.html#freshclamconf
+    {{- if .Values.clamav.freshclamExtraConfig }}
+    {{ .Values.clamav.freshclamExtraConfig | nindent 4 }}
+    {{- end }}
+    PidFile /tmp/freshclam.pid
+    DatabaseOwner clamav
+    DatabaseMirror database.clamav.net
+    Checks 2
+    ScriptedUpdates yes
+    NotifyClamd /etc/clamav/clamd.conf
+    UpdateLogFile /var/log/clamav/freshclam.log
+    # DatabaseDirectory /var/lib/clamav
+    # LogFileMaxSize 1M
+    # LogTime no
+    # LogVerbose no
+    # LogSyslog no
+    # LogFacility LOG_LOCAL6
+    # LogRotate no
+    # DNSDatabaseInfo current.cvd.clamav.net
+    # MaxAttempts 3
+    # CompressLocalDatabase no
+    # DatabaseCustomURL http://myserver.example.com/mysigs.ndb
+    # PrivateMirror mirror1.example.com
+    # HTTPProxyServer https://proxy.example.com
+    # HTTPProxyPort 1234
+    # HTTPProxyUsername myusername
+    # HTTPProxyPassword mypass
+    # HTTPUserAgent SomeUserAgentIdString
+    # LocalIPAddress aaa.bbb.ccc.ddd
+    # OnUpdateExecute command
+    # OnErrorExecute command
+    # OnOutdatedExecute command
+    # Foreground no
+    # Debug no
+    # ConnectTimeout 30
+    # ReceiveTimeout 60
+    # TestDatabases yes
+    # Bytecode yes
+    # ExtraDatabase dbname1
+    # ExcludeDatabase dbname1
+{{- end }}

--- a/charts/drupal/templates/clamav-deployment.yaml
+++ b/charts/drupal/templates/clamav-deployment.yaml
@@ -1,0 +1,71 @@
+{{- if .Values.clamav.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-clamav
+  labels:
+    {{- include "drupal.release_labels" . | nindent 4 }}
+    service: clamav
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "drupal.release_selector_labels" . | nindent 6 }}
+      service: clamav
+  template:
+    metadata:
+      labels:
+        {{- include "drupal.release_labels" . | nindent 8 }}
+        service: clamav
+      annotations:
+        # We use a checksum to redeploy the pods when the configMap changes.
+        configMap-checksum: {{ include (print $.Template.BasePath "/clamav-configmap.yaml") . | sha256sum }}
+    spec:
+      enableServiceLinks: false
+      containers:
+      - name: clamd
+        image: {{ .Values.clamav.image }}:{{ .Values.clamav.imageTag }}
+        env:
+        - name: UPDATE
+          value: "false"
+        livenessProbe:
+          tcpSocket:
+            port: 3310
+          initialDelaySeconds: 20
+          timeoutSeconds: 2
+        readinessProbe:
+          tcpSocket:
+            port: 3310
+          initialDelaySeconds: 20
+          timeoutSeconds: 2
+        ports:
+        - containerPort: 3310
+          name: clamd
+          protocol: TCP
+        resources:
+          {{ .Values.clamav.resources | toYaml | nindent 10 }}
+        volumeMounts:
+        - name: avdata
+          mountPath: /var/lib/clamav  
+      - name: freshclam
+        image: {{ .Values.clamav.image }}:{{ .Values.clamav.imageTag }}
+        env:
+        - name: UPDATE_ONLY
+          value: "true"
+        resources:
+          {{ .Values.clamav.resources | toYaml | nindent 10 }}
+        volumeMounts:
+        - name: freshclam-config
+          mountPath: /etc/clamav/freshclam.conf
+          subPath: freshclam.conf
+          readOnly: true
+        - name: avdata
+          mountPath: /var/lib/clamav
+      volumes:
+      - name: freshclam-config
+        configMap:
+          name: {{ .Release.Name }}-clamav
+      - name: avdata
+        source:
+          emptyDir: {}
+{{- end }}

--- a/charts/drupal/templates/clamav-service.yaml
+++ b/charts/drupal/templates/clamav-service.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.clamav.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-clamav
+  annotations:
+    {{- if (index .Values "silta-release").downscaler.enabled }}
+    auto-downscale/down: "false"
+    {{- end }}
+  labels:
+    {{- include "drupal.release_labels" . | nindent 4 }}
+    service: clamav
+spec:
+  type: ClusterIP
+  ports:
+  - name: web
+    protocol: TCP
+    port: 3310
+    targetPort: 3310
+  selector:
+    {{- include "drupal.release_selector_labels" . | nindent 4 }}
+    service: clamav
+{{- end }}

--- a/charts/drupal/values.schema.json
+++ b/charts/drupal/values.schema.json
@@ -659,6 +659,36 @@
         }
       }
     },
+    "clamav": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "image": { "type": "string" },
+        "imageTag": { "type": ["string", "integer"] },
+        "freshclamExtraConfig": { "type": "string" },
+        "resources": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "requests": {
+              "type": "object",
+              "properties": {
+                "cpu": { "type": ["integer", "string"] },
+                "memory": { "type": "string" }
+              }
+            },
+            "limits": {
+              "type": "object",
+              "properties": {
+                "cpu": { "type": ["integer", "string"] },
+                "memory": { "type": "string" }
+              }
+            }
+          }
+        }
+      }
+    },
     "signalsciences": {
       "type": "object",
       "additionalProperties": false,

--- a/charts/drupal/values.yaml
+++ b/charts/drupal/values.yaml
@@ -768,6 +768,20 @@ solr:
       accessModes:
         - ReadWriteOnce
 
+# ClamAV daemon for virus scanning.
+clamav:
+  enabled: false
+  # Available image tags: https://hub.docker.com/r/clamav/clamav/
+  image: clamav/clamav
+  imageTag: stable
+  freshclamExtraConfig: ""
+  resources:
+    requests:
+      cpu: 1
+      memory: 2Gi
+    limits:
+      cpu: 1500m
+      memory: 3Gi
 db:
   # Available options: mariadb, pxc-db
   primary: mariadb

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         "php": ">=7.3",
         "composer/installers": "^2.0",
         "cweagans/composer-patches": "^1.6",
+        "drupal/clamav": "^2.0",
         "drupal/core-composer-scaffold": "^10.0",
         "drupal/core-dev": "^9.1",
         "drupal/core-recommended": "^9.1",
@@ -52,7 +53,8 @@
             "zaporylie/composer-drupal-optimizations": true,
             "dealerdirect/phpcodesniffer-composer-installer": true,
             "phpro/grumphp": true,
-            "phpstan/extension-installer": true
+            "phpstan/extension-installer": true,
+            "php-http/discovery": true
         }
     },
     "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0f2c5777e0c72f81f903a60d5d60cf61",
+    "content-hash": "fe9265cdbc5b0497c982e9914b5b6478",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -2030,6 +2030,62 @@
             },
             "abandoned": "roave/better-reflection",
             "time": "2023-07-27T18:11:59+00:00"
+        },
+        {
+            "name": "drupal/clamav",
+            "version": "2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/clamav.git",
+                "reference": "2.0.2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/clamav-2.0.2.zip",
+                "reference": "2.0.2",
+                "shasum": "298f63201af7a4b25760f574e5561c6c4696324d"
+            },
+            "require": {
+                "drupal/core": "^8 || ^9 || ^10"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "2.0.2",
+                    "datestamp": "1692700952",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "adammalone",
+                    "homepage": "https://www.drupal.org/user/1295980"
+                },
+                {
+                    "name": "James Andres",
+                    "homepage": "https://www.drupal.org/user/33827"
+                },
+                {
+                    "name": "manarth",
+                    "homepage": "https://www.drupal.org/user/321496"
+                },
+                {
+                    "name": "mcdruid",
+                    "homepage": "https://www.drupal.org/user/255969"
+                }
+            ],
+            "description": "Integration with the ClamAV anti-virus scanner.",
+            "homepage": "https://www.drupal.org/project/clamav",
+            "support": {
+                "source": "https://git.drupalcode.org/project/clamav"
+            }
         },
         {
             "name": "drupal/coder",
@@ -13332,5 +13388,5 @@
         "php": ">=7.3"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -55,3 +55,18 @@ php:
       # The ~ symbol will be replaced by a random digit from 0 to 9.
       # This will avoid running all cron jobs at the same time.
       schedule: '~ 0 31 2 *'
+
+clamav:
+  enabled: true
+  image: clamav/clamav
+  imageTag: latest
+  freshclamExtraConfig:
+    Checks 2
+    
+  resources:
+    requests:
+      memory: 2Gi
+      cpu: 1200m
+    limits:
+      memory: 4Gi
+      cpu: 2400m

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -55,18 +55,3 @@ php:
       # The ~ symbol will be replaced by a random digit from 0 to 9.
       # This will avoid running all cron jobs at the same time.
       schedule: '~ 0 31 2 *'
-
-clamav:
-  enabled: true
-  image: clamav/clamav
-  imageTag: latest
-  freshclamExtraConfig:
-    Checks 2
-    
-  resources:
-    requests:
-      memory: 2Gi
-      cpu: 1200m
-    limits:
-      memory: 4Gi
-      cpu: 2400m


### PR DESCRIPTION
- Implements deployment (pod) with two containers - clamd and freshclam
- Freshclam runs in daemon mode that updates virus signatures 2 times per day (`Checks` configuration parameter). Freshclam is run in daemon mode instead of cronjob so that virus signatures are shared with clamd.
- Adds clamd connection parameters (`CLAMAV_HOST`, `CLAMAV_PORT`) to drupal/php and shell containers.
- Injects clamav module configuration in settings.silta.php when clamav is enabled in silta settings.
- Allows image and resource and freshclam configuration overrides

**Testing / Usage:**
1. Enable clamav in silta settings: `clamav.enabled: true`
2. Install clamav drupal module (`composer require 'drupal/clamav:^2.0'`) and enable it.
3. Clamav status should be available in drupal status page.
4. Download virus test file from https://www.eicar.org/download-anti-malware-testfile/, add `.jpg` extension.
5. Upload file, drupal should deny upload with error message `A virus has been detected in the file. The file will be deleted.`- 
![Screenshot from 2024-07-26 15-39-48](https://github.com/user-attachments/assets/852eb797-210f-4cfc-9b7a-648975b3a130)
