### PR TITLE
When extracting reference data files, ignoredFolders do not get deleted

### DIFF
--- a/charts/drupal/templates/_helpers.tpl
+++ b/charts/drupal/templates/_helpers.tpl
@@ -464,7 +464,7 @@ if [[ "$(drush status --fields=bootstrap)" = *'Successful'* ]] ; then
     {{ range $folderIndex, $folderPattern := $.Values.referenceData.ignoreFolders -}}
     --exclude="{{ $folderPattern }}" \
     {{ end -}}
-    --delete \
+    --delete --delete-excluded \
     /app/reference-data/{{ $index }}
   {{ end -}}
   {{- end }}


### PR DESCRIPTION
Proposed changes:
- Add flag --delete-excluded to the rsync command when extracting reference data files

How to test:
- In a projects main env, create a test file at web/sites/default/files/ref-test/foobar
- Trigger the cronjob for generating reference data
- Verify that the test file exists in the reference data
- Add "ref-test" to referenceData.ignoreFolders
- Trigger the cronjob for generating reference data
- Verify that the test file no longer exists in the reference data