### PR TITLE
silta-shared PV adjustments for new csi-rclone provisioner

### DIFF
--- a/charts/drupal/templates/_helpers.tpl
+++ b/charts/drupal/templates/_helpers.tpl
@@ -68,7 +68,7 @@ ports:
     name: {{ $mount.configMapName }}
 {{- else }}
   persistentVolumeClaim:
-    {{- if eq ( include "silta-cluster.rclone.has-provisioner" $ ) "true" }}
+    {{- if and ( eq $mount.storageClassName "silta-shared" ) ( eq ( include "silta-cluster.rclone.has-provisioner" $ ) "true" ) }}
     claimName: {{ $.Release.Name }}-{{ $index }}2
     {{- else }}
     claimName: {{ $.Release.Name }}-{{ $index }}

--- a/charts/drupal/templates/_helpers.tpl
+++ b/charts/drupal/templates/_helpers.tpl
@@ -68,7 +68,11 @@ ports:
     name: {{ $mount.configMapName }}
 {{- else }}
   persistentVolumeClaim:
+    {{- if eq ( include "silta-cluster.rclone.has-provisioner" $ ) "true" }}
+    claimName: {{ $.Release.Name }}-{{ $index }}2
+    {{- else }}
     claimName: {{ $.Release.Name }}-{{ $index }}
+    {{- end }}
 {{- end }}
 {{- end }}
 {{- end }}
@@ -687,3 +691,9 @@ autoscaling/v2beta1
 {{ fail "Cannot use domain prefixes together with domain masking"}}
 {{- end -}}
 {{- end -}}
+
+{{- define "silta-cluster.rclone.has-provisioner" }}
+{{- if ( $.Capabilities.APIVersions.Has "silta.wdr.io/v1" ) }}true
+{{- else }}false
+{{- end }}
+{{- end }}

--- a/charts/drupal/templates/backup-cron.yaml
+++ b/charts/drupal/templates/backup-cron.yaml
@@ -67,7 +67,7 @@ spec:
             {{- include "drupal.volumes" . | nindent 12 }}
             - name: {{ .Release.Name }}-backup
               persistentVolumeClaim:
-                {{- if eq ( include "silta-cluster.rclone.has-provisioner" $ ) "true" }}
+                {{- if and ( eq $.Values.backup.storageClassName "silta-shared" ) ( eq ( include "silta-cluster.rclone.has-provisioner" $ ) "true" ) }}
                 claimName: {{ .Release.Name }}-backup2
                 {{- else }}
                 claimName: {{ .Release.Name }}-backup

--- a/charts/drupal/templates/backup-cron.yaml
+++ b/charts/drupal/templates/backup-cron.yaml
@@ -67,7 +67,11 @@ spec:
             {{- include "drupal.volumes" . | nindent 12 }}
             - name: {{ .Release.Name }}-backup
               persistentVolumeClaim:
+                {{- if eq ( include "silta-cluster.rclone.has-provisioner" $ ) "true" }}
+                claimName: {{ .Release.Name }}-backup2
+                {{- else }}
                 claimName: {{ .Release.Name }}-backup
+                {{- end }}
           {{- include "drupal.imagePullSecrets" . | nindent 10 }}
 {{- end }}
 

--- a/charts/drupal/templates/backup-volume.yaml
+++ b/charts/drupal/templates/backup-volume.yaml
@@ -28,7 +28,7 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  {{- if eq ( include "silta-cluster.rclone.has-provisioner" $ ) "true" }}
+  {{- if and ( eq $.Values.backup.storageClassName "silta-shared" ) ( eq ( include "silta-cluster.rclone.has-provisioner" $ ) "true" ) }}
   name: {{ .Release.Name }}-backup2
   {{- else }}
   name: {{ .Release.Name }}-backup

--- a/charts/drupal/templates/backup-volume.yaml
+++ b/charts/drupal/templates/backup-volume.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.backup.enabled }}
 {{- if eq .Values.backup.storageClassName "silta-shared" }}
+{{- if eq ( include "silta-cluster.rclone.has-provisioner" $ ) "false" }}
 apiVersion: v1
 kind: PersistentVolume
 metadata:
@@ -23,10 +24,15 @@ spec:
   {{- end }}
 ---
 {{- end }}
+{{- end }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
+  {{- if eq ( include "silta-cluster.rclone.has-provisioner" $ ) "true" }}
+  name: {{ .Release.Name }}-backup2
+  {{- else }}
   name: {{ .Release.Name }}-backup
+  {{- end }}
   labels:
     {{- include "drupal.release_labels" . | nindent 4 }}
   annotations:
@@ -39,8 +45,10 @@ spec:
     requests:
       storage: {{ .Values.backup.storage }}
 {{- if eq .Values.backup.storageClassName "silta-shared" }}
+{{- if eq ( include "silta-cluster.rclone.has-provisioner" $ ) "false" }}
   selector:
     matchLabels:
       name: {{ .Release.Name }}-{{ $.Release.Namespace | sha256sum | trunc 7 }}-backup
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/drupal/templates/drupal-volumes.yaml
+++ b/charts/drupal/templates/drupal-volumes.yaml
@@ -4,6 +4,7 @@
 {{- if eq $mount.enabled true }}
 {{- if and (not (hasKey $mount "configMapName")) (not (hasKey $mount "secretName")) -}}
 {{- if eq $mount.storageClassName "silta-shared" }}
+{{- if eq ( include "silta-cluster.rclone.has-provisioner" $ ) "false" }}
 # Mount-enabled: {{ $mount.enabled  }}
 apiVersion: v1
 kind: PersistentVolume
@@ -27,10 +28,15 @@ spec:
   {{- end }}
 ---
 {{- end }}
+{{- end }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
+  {{- if eq ( include "silta-cluster.rclone.has-provisioner" $ ) "true" }}
+  name: {{ $.Release.Name }}-{{ $index }}2
+  {{- else }}
   name: {{ $.Release.Name }}-{{ $index }}
+  {{- end }}
   labels:
     {{- include "drupal.release_labels" $ | nindent 4 }}
   annotations:
@@ -43,9 +49,11 @@ spec:
     requests:
       storage: {{ $mount.storage }}
 {{- if eq $mount.storageClassName "silta-shared" }}
+{{- if eq ( include "silta-cluster.rclone.has-provisioner" $ ) "false" }}
   selector:
     matchLabels:
       name: {{ $releaseNameTrimmed }}-{{ $.Release.Namespace | sha256sum | trunc 7 }}-{{ $index }}
+{{- end }}
 {{- end }}
 ---
 {{- end -}}
@@ -55,6 +63,7 @@ spec:
 {{- if .Values.referenceData.enabled }}
 {{- if eq .Values.referenceData.referenceEnvironment .Values.environmentName }}
 {{- if eq .Values.referenceData.storageClassName "silta-shared" }}
+{{- if eq ( include "silta-cluster.rclone.has-provisioner" $ ) "false" }}
 apiVersion: v1
 kind: PersistentVolume
 metadata:
@@ -77,10 +86,15 @@ spec:
   {{- end }}
 ---
 {{- end }}
+{{- end }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
+  {{- if eq ( include "silta-cluster.rclone.has-provisioner" $ ) "true" }}
+  name: {{ include "drupal.referenceEnvironment" . }}-reference
+  {{- else }}
   name: {{ include "drupal.referenceEnvironment" . }}-reference-data
+  {{- end }}
   labels:
     {{- include "drupal.release_labels" . | nindent 4 }}
   annotations:
@@ -93,9 +107,11 @@ spec:
     requests:
       storage: {{ .Values.referenceData.storage }}
 {{- if eq .Values.referenceData.storageClassName "silta-shared" }}
+{{- if eq ( include "silta-cluster.rclone.has-provisioner" $ ) "false" }}
   selector:
     matchLabels:
       name: {{ .Release.Name }}-{{ .Release.Namespace | sha256sum | trunc 7 }}-reference-data
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/drupal/templates/drupal-volumes.yaml
+++ b/charts/drupal/templates/drupal-volumes.yaml
@@ -32,7 +32,7 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  {{- if eq ( include "silta-cluster.rclone.has-provisioner" $ ) "true" }}
+  {{- if and ( eq $mount.storageClassName "silta-shared" ) ( eq ( include "silta-cluster.rclone.has-provisioner" $ ) "true" ) }}
   name: {{ $.Release.Name }}-{{ $index }}2
   {{- else }}
   name: {{ $.Release.Name }}-{{ $index }}
@@ -90,7 +90,7 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  {{- if eq ( include "silta-cluster.rclone.has-provisioner" $ ) "true" }}
+  {{- if and ( eq $.Values.referenceData.storageClassName "silta-shared" ) ( eq ( include "silta-cluster.rclone.has-provisioner" $ ) "true" ) }}
   name: {{ include "drupal.referenceEnvironment" . }}-reference
   {{- else }}
   name: {{ include "drupal.referenceEnvironment" . }}-reference-data

--- a/charts/drupal/templates/post-release.yaml
+++ b/charts/drupal/templates/post-release.yaml
@@ -47,6 +47,10 @@ spec:
         {{- if or (eq .Values.referenceData.referenceEnvironment .Values.environmentName) (not .Values.referenceData.skipMount) }}
         - name: reference-data-volume
           persistentVolumeClaim:
+            {{- if (lookup "v1" "PersistentVolumeClaim" .Release.Namespace (printf "%s-reference" (include "drupal.referenceEnvironment" $ ))) }}
+            claimName: {{ include "drupal.referenceEnvironment" . }}-reference
+            {{- else }}
             claimName: {{ include "drupal.referenceEnvironment" . }}-reference-data
+            {{- end }}
         {{- end -}}
         {{- end }}

--- a/charts/drupal/templates/reference-data-cron.yaml
+++ b/charts/drupal/templates/reference-data-cron.yaml
@@ -48,8 +48,11 @@ spec:
             {{- include "drupal.volumes" . | nindent 12 }}
             - name: reference-data-volume
               persistentVolumeClaim:
+                {{- if eq ( include "silta-cluster.rclone.has-provisioner" $ ) "true" }}
+                claimName: {{ include "drupal.referenceEnvironment" . }}-reference
+                {{- else }}
                 claimName: {{ include "drupal.referenceEnvironment" . }}-reference-data
-
+                {{- end }}
           {{- include "drupal.imagePullSecrets" . | nindent 10 }}
 {{- end }}
 {{- end }}

--- a/charts/drupal/templates/reference-data-cron.yaml
+++ b/charts/drupal/templates/reference-data-cron.yaml
@@ -48,7 +48,7 @@ spec:
             {{- include "drupal.volumes" . | nindent 12 }}
             - name: reference-data-volume
               persistentVolumeClaim:
-                {{- if eq ( include "silta-cluster.rclone.has-provisioner" $ ) "true" }}
+                {{- if and ( eq $.Values.referenceData.storageClassName "silta-shared" ) ( eq ( include "silta-cluster.rclone.has-provisioner" $ ) "true" ) }}
                 claimName: {{ include "drupal.referenceEnvironment" . }}-reference
                 {{- else }}
                 claimName: {{ include "drupal.referenceEnvironment" . }}-reference-data

--- a/charts/drupal/templates/shell-deployment.yaml
+++ b/charts/drupal/templates/shell-deployment.yaml
@@ -83,14 +83,22 @@ spec:
       {{- include "drupal.volumes" . | nindent 6 }}
       - name: ssh-keys
         persistentVolumeClaim:
+          {{- if eq ( include "silta-cluster.rclone.has-provisioner" $ ) "true" }}
+          claimName: {{ .Release.Name }}-ssh-keys2
+          {{- else }}
           claimName: {{ .Release.Name }}-ssh-keys
+          {{- end }}
       - name: shell-configmap
         configMap:
           name: {{ .Release.Name }}-shell
       {{- if .Values.backup.enabled }}
       - name: {{ .Release.Name }}-backup
         persistentVolumeClaim:
+          {{- if eq ( include "silta-cluster.rclone.has-provisioner" $ ) "true" }}
+          claimName: {{ .Release.Name }}-backup2
+          {{- else }}
           claimName: {{ .Release.Name }}-backup
+          {{- end }}
       {{- end }}
       {{- include "drupal.imagePullSecrets" . | nindent 6 }}
 {{- end }}

--- a/charts/drupal/templates/shell-deployment.yaml
+++ b/charts/drupal/templates/shell-deployment.yaml
@@ -83,7 +83,7 @@ spec:
       {{- include "drupal.volumes" . | nindent 6 }}
       - name: ssh-keys
         persistentVolumeClaim:
-          {{- if eq ( include "silta-cluster.rclone.has-provisioner" $ ) "true" }}
+          {{- if and ( eq $.Values.shell.mount.storageClassName "silta-shared" ) ( eq ( include "silta-cluster.rclone.has-provisioner" $ ) "true" ) }}
           claimName: {{ .Release.Name }}-ssh-keys2
           {{- else }}
           claimName: {{ .Release.Name }}-ssh-keys
@@ -94,7 +94,7 @@ spec:
       {{- if .Values.backup.enabled }}
       - name: {{ .Release.Name }}-backup
         persistentVolumeClaim:
-          {{- if eq ( include "silta-cluster.rclone.has-provisioner" $ ) "true" }}
+          {{- if and ( eq $.Values.backup.storageClassName "silta-shared" ) ( eq ( include "silta-cluster.rclone.has-provisioner" $ ) "true" ) }}
           claimName: {{ .Release.Name }}-backup2
           {{- else }}
           claimName: {{ .Release.Name }}-backup

--- a/charts/drupal/templates/shell-volume.yaml
+++ b/charts/drupal/templates/shell-volume.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.shell.enabled }}
 {{- $releaseNameTrimmed := substr 0 (int (sub 54 (len "ssh-keys"))) $.Release.Name }}
 {{- if eq .Values.shell.mount.storageClassName "silta-shared" }}
+{{- if eq ( include "silta-cluster.rclone.has-provisioner" $ ) "false" }}
 apiVersion: v1
 kind: PersistentVolume
 metadata:
@@ -24,15 +25,21 @@ spec:
   {{- end }}
 ---
 {{- end }}
+{{- end }}
 
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
+  {{- if eq ( include "silta-cluster.rclone.has-provisioner" $ ) "true" }}
+  name: {{ .Release.Name }}-ssh-keys2
+  {{- else }}
   name: {{ .Release.Name }}-ssh-keys
+  {{- end }}
   labels:
     {{- include "drupal.release_labels" . | nindent 4 }}
   annotations:
     storage.silta/storage-path: {{ .Values.environmentName | default .Release.Name }}/ssh-keys    
+    csi-rclone/umask: "077"
 spec:
   accessModes:
     - ReadWriteMany
@@ -41,8 +48,10 @@ spec:
     requests:
       storage: {{ .Values.shell.mount.storage }}
 {{- if eq .Values.shell.mount.storageClassName "silta-shared" }}
+{{- if eq ( include "silta-cluster.rclone.has-provisioner" $ ) "false" }}
   selector:
     matchLabels:
       name: {{ $releaseNameTrimmed }}-{{ .Release.Namespace | sha256sum | trunc 7 }}-ssh-keys
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/drupal/templates/shell-volume.yaml
+++ b/charts/drupal/templates/shell-volume.yaml
@@ -30,7 +30,7 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  {{- if eq ( include "silta-cluster.rclone.has-provisioner" $ ) "true" }}
+  {{- if and ( eq $.Values.shell.mount.storageClassName "silta-shared" ) ( eq ( include "silta-cluster.rclone.has-provisioner" $ ) "true" ) }}
   name: {{ .Release.Name }}-ssh-keys2
   {{- else }}
   name: {{ .Release.Name }}-ssh-keys

--- a/charts/drupal/tests/drupal_cron_test.yaml
+++ b/charts/drupal/tests/drupal_cron_test.yaml
@@ -74,11 +74,13 @@ tests:
             persistentVolumeClaim:
               claimName: RELEASE-NAME-public-files
 
-  - it: has public files mounted (with provisioner)
+  - it: has public files mounted (silta-shared storageclass, with provisioner)
     template: drupal-cron.yaml
     capabilities:
       apiVersions:
         - silta.wdr.io/v1
+    set:
+      mounts.public-files.storageClassName: silta-shared
     asserts:
       - contains:
           path: spec.jobTemplate.spec.template.spec.volumes
@@ -86,6 +88,21 @@ tests:
             name: "drupal-public-files"
             persistentVolumeClaim:
               claimName: RELEASE-NAME-public-files2
+
+  - it: has public files mounted (non-silta-shared storageclass, with provisioner)
+    template: drupal-cron.yaml
+    capabilities:
+      apiVersions:
+        - silta.wdr.io/v1
+    set:
+      mounts.public-files.storageClassName: foo
+    asserts:
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.volumes
+          content:
+            name: "drupal-public-files"
+            persistentVolumeClaim:
+              claimName: RELEASE-NAME-public-files
 
   - it: runs multiple jobs
     template: drupal-cron.yaml

--- a/charts/drupal/tests/drupal_cron_test.yaml
+++ b/charts/drupal/tests/drupal_cron_test.yaml
@@ -64,7 +64,7 @@ tests:
             name: foo
             value: bar
 
-  - it: has public files mounted
+  - it: has public files mounted (without provisioner)
     template: drupal-cron.yaml
     asserts:
       - contains:
@@ -73,6 +73,19 @@ tests:
             name: "drupal-public-files"
             persistentVolumeClaim:
               claimName: RELEASE-NAME-public-files
+
+  - it: has public files mounted (with provisioner)
+    template: drupal-cron.yaml
+    capabilities:
+      apiVersions:
+        - silta.wdr.io/v1
+    asserts:
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.volumes
+          content:
+            name: "drupal-public-files"
+            persistentVolumeClaim:
+              claimName: RELEASE-NAME-public-files2
 
   - it: runs multiple jobs
     template: drupal-cron.yaml

--- a/charts/drupal/tests/drupal_postinstall_test.yaml
+++ b/charts/drupal/tests/drupal_postinstall_test.yaml
@@ -81,7 +81,7 @@ tests:
             persistentVolumeClaim:
               claimName: RELEASE-NAME-public-files
               
-  - it: has public files mounted (with provisioner)
+  - it: has public files mounted (silta-shared storageclass, with provisioner)
     template: post-release.yaml
     capabilities:
       apiVersions:
@@ -95,6 +95,21 @@ tests:
             name: "drupal-public-files"
             persistentVolumeClaim:
               claimName: RELEASE-NAME-public-files2
+              
+  - it: has public files mounted (non-silta-shared storageclass, with provisioner)
+    template: post-release.yaml
+    capabilities:
+      apiVersions:
+        - silta.wdr.io/v1
+    set:
+      mounts.public-files.storageClassName: foo
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: "drupal-public-files"
+            persistentVolumeClaim:
+              claimName: RELEASE-NAME-public-files
 
   - it: can override default php resource requests and limits
     template: post-release.yaml

--- a/charts/drupal/tests/drupal_postinstall_test.yaml
+++ b/charts/drupal/tests/drupal_postinstall_test.yaml
@@ -71,7 +71,7 @@ tests:
             name: foo
             value: bar
 
-  - it: has public files mounted
+  - it: has public files mounted (without provisioner)
     template: post-release.yaml
     asserts:
       - contains:
@@ -80,6 +80,21 @@ tests:
             name: "drupal-public-files"
             persistentVolumeClaim:
               claimName: RELEASE-NAME-public-files
+              
+  - it: has public files mounted (with provisioner)
+    template: post-release.yaml
+    capabilities:
+      apiVersions:
+        - silta.wdr.io/v1
+    set:
+      mounts.public-files.storageClassName: silta-shared
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: "drupal-public-files"
+            persistentVolumeClaim:
+              claimName: RELEASE-NAME-public-files2
 
   - it: can override default php resource requests and limits
     template: post-release.yaml

--- a/charts/drupal/tests/private_files_test.yaml
+++ b/charts/drupal/tests/private_files_test.yaml
@@ -10,7 +10,7 @@ capabilities:
   apiVersions:
     - pxc.percona.com/v1
 tests:
-  - it: private files should be disabled by default
+  - it: private files should be disabled by default (without provisioner)
     template: drupal-deployment.yaml
     asserts:
       # No private files volume is mounted.
@@ -25,7 +25,27 @@ tests:
           count: 2
         template: drupal-volumes.yaml
 
-  - it: private files should work when enabled
+  - it: private files should be disabled by default (with provisioner)
+    template: drupal-deployment.yaml
+    capabilities:
+      apiVersions:
+        - silta.wdr.io/v1
+    set:
+      mounts.private-files.storageClassName: silta-shared
+    asserts:
+      # No private files volume is mounted.
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: "drupal-private-files"
+            persistentVolumeClaim:
+              claimName: RELEASE-NAME-private-files2
+      # Only one volume is defined.
+      - hasDocuments:
+          count: 1
+        template: drupal-volumes.yaml
+
+  - it: private files should work when enabled (without provisioner)
     template: drupal-deployment.yaml
     set:
       mounts:
@@ -55,6 +75,39 @@ tests:
         hasDocuments:
           count: 4
 
+  - it: private files should work when enabled (with provisioner)
+    template: drupal-deployment.yaml
+    capabilities:
+      apiVersions:
+        - silta.wdr.io/v1
+    set:
+      mounts:
+        private-files:
+          enabled: true
+          storage: 123Gi
+          storageClassName: silta-shared
+          mountPath: /foo/bar/private
+    asserts:
+      # A private files volume is mounted
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: "drupal-private-files"
+            persistentVolumeClaim:
+              claimName: RELEASE-NAME-private-files2
+
+      # The environment variable is set
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PRIVATE_FILES_PATH
+            value: '/foo/bar/private'
+
+      # There are two volumes defined.
+      - template: drupal-volumes.yaml
+        hasDocuments:
+          count: 2
+
       # Private files are available for cron jobs.
       - template: drupal-cron.yaml
         contains:
@@ -62,7 +115,7 @@ tests:
           content:
             name: "drupal-private-files"
             persistentVolumeClaim:
-              claimName: RELEASE-NAME-private-files
+              claimName: RELEASE-NAME-private-files2
 
       # Private files are available for in the post-install hooks.
       - template: post-release.yaml
@@ -71,17 +124,23 @@ tests:
           content:
             name: "drupal-private-files"
             persistentVolumeClaim:
-              claimName: RELEASE-NAME-private-files
+              claimName: RELEASE-NAME-private-files2
 
       - template: drupal-volumes.yaml
-        documentIndex: 3
+        documentIndex: 1
         equal:
           path: spec.storageClassName
           value: silta-shared
       - template: drupal-volumes.yaml
+        documentIndex: 0
+        equal:
+          path: metadata.name
+          value: RELEASE-NAME-private-files2
+      - template: drupal-volumes.yaml
         # Note that object attributes are iterated alphabetically, so "private-files" comes before "public-files"
-        documentIndex: 1
+        documentIndex: 0
         equal:
           path: spec.resources.requests.storage
           value: 123Gi
+
 

--- a/charts/drupal/tests/private_files_test.yaml
+++ b/charts/drupal/tests/private_files_test.yaml
@@ -25,7 +25,7 @@ tests:
           count: 2
         template: drupal-volumes.yaml
 
-  - it: private files should be disabled by default (with provisioner)
+  - it: private files should be disabled by default (silta-shared storageclass, with provisioner)
     template: drupal-deployment.yaml
     capabilities:
       apiVersions:
@@ -40,6 +40,26 @@ tests:
             name: "drupal-private-files"
             persistentVolumeClaim:
               claimName: RELEASE-NAME-private-files2
+      # Only one volume is defined.
+      - hasDocuments:
+          count: 1
+        template: drupal-volumes.yaml
+
+  - it: private files should be disabled by default (non-silta-shared storageclass, with provisioner)
+    template: drupal-deployment.yaml
+    capabilities:
+      apiVersions:
+        - silta.wdr.io/v1
+    set:
+      mounts.private-files.storageClassName: foo
+    asserts:
+      # No private files volume is mounted.
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: "drupal-private-files"
+            persistentVolumeClaim:
+              claimName: RELEASE-NAME-private-files
       # Only one volume is defined.
       - hasDocuments:
           count: 1

--- a/charts/drupal/tests/reference_data_test.yaml
+++ b/charts/drupal/tests/reference_data_test.yaml
@@ -10,7 +10,7 @@ capabilities:
   apiVersions:
     - pxc.percona.com/v1
 tests:
-  - it: By default no reference data PVC or CronJob is created, but the reference volume is mounted for the post-release job
+  - it: By default no reference data PVC or CronJob is created, but the reference volume is mounted for the post-release job (without provisioner)
     template: post-release.yaml
     set:
       referenceData:
@@ -37,6 +37,66 @@ tests:
           name: "reference-data-volume"
           mountPath: "/app/reference-data"
           readOnly: true
+
+  - it: By default no reference data PVC or CronJob is created, but the reference volume is mounted for the post-release job (with provisioner)
+    template: post-release.yaml
+    capabilities:
+      apiVersions:
+        - silta.wdr.io/v1
+    set:
+      referenceData:
+        referenceEnvironment: 'FOO'
+    asserts:
+    # Only public files PVC is defined.
+    - hasDocuments:
+        count: 1
+      template: drupal-volumes.yaml
+    - hasDocuments:
+        count: 0
+      template: reference-data-cron.yaml
+
+    # Reference data volume is mounted in post-release job
+    - contains:
+        path: spec.template.spec.volumes
+        content:
+          name: "reference-data-volume"
+          persistentVolumeClaim:
+            claimName: foo-reference-data
+    - contains:
+        path: spec.template.spec.containers[0].volumeMounts
+        content:
+          name: "reference-data-volume"
+          mountPath: "/app/reference-data"
+          readOnly: true
+  
+  - it: Uses new reference data PVC when found via lookup
+    template: post-release.yaml
+    capabilities:
+      apiVersions:
+        - silta.wdr.io/v1
+    kubernetesProvider:
+      scheme:
+        "v1/PersistentVolumeClaim":
+          gvr:
+            version:  "v1"
+            resource: "persistentvolumeclaims"
+          namespaced: true
+      objects:
+        - kind: PersistentVolumeClaim
+          apiVersion: v1
+          metadata:
+            name: foo-reference
+            namespace: NAMESPACE
+    set:
+      referenceData:
+        referenceEnvironment: 'FOO'
+    asserts:
+    - contains:
+        path: spec.template.spec.volumes
+        content:
+          name: "reference-data-volume"
+          persistentVolumeClaim:
+            claimName: foo-reference
 
   - it: is not mounted on the main deployment
     template: post-release.yaml


### PR DESCRIPTION
Changes:
- Skips silta-shared PV creation when provisioner is available, removes selector field from silta-shared PVC's
- PVC name change for silta-shared storageclass PVC's to avoid immutable field update errors
- Reference data PVC lookup (lookup and use the new PVC when found)

Testing:
a1: Make a new branch off master, deploy it to cluster with updated storage driver.
a2: Store some files
a3: Merge this branch into it, deploy, see if files are still present. PVC name should end with "2"

b1: Make a new branch off master, change storageclass to something else, deploy it to cluster with updated storage driver.
b2: Store some files
b3: Merge this branch into it, see if files are still present. Validate PVC name, it should not end with "2"

Do the same on a cluster without csi rclone update, PVC names in both cases should be without "2" at the end.
