### PR TITLE
always use new pvc when current environment is reference environment

### DIFF
--- a/charts/drupal/templates/post-release.yaml
+++ b/charts/drupal/templates/post-release.yaml
@@ -47,7 +47,7 @@ spec:
         {{- if or (eq .Values.referenceData.referenceEnvironment .Values.environmentName) (not .Values.referenceData.skipMount) }}
         - name: reference-data-volume
           persistentVolumeClaim:
-            {{- if (lookup "v1" "PersistentVolumeClaim" .Release.Namespace (printf "%s-reference" (include "drupal.referenceEnvironment" $ ))) }}
+            {{- if or (eq .Values.referenceData.referenceEnvironment .Values.environmentName) (lookup "v1" "PersistentVolumeClaim" .Release.Namespace (printf "%s-reference" (include "drupal.referenceEnvironment" $ ))) }}
             claimName: {{ include "drupal.referenceEnvironment" . }}-reference
             {{- else }}
             claimName: {{ include "drupal.referenceEnvironment" . }}-reference-data

--- a/charts/drupal/tests/reference_data_test.yaml
+++ b/charts/drupal/tests/reference_data_test.yaml
@@ -240,7 +240,7 @@ tests:
         content:
           name: "reference-data-volume"
           persistentVolumeClaim:
-            claimName: foo-reference-data
+            claimName: foo-reference
     - contains:
         path: spec.template.spec.containers[0].volumeMounts
         content:


### PR DESCRIPTION
Always use new reference data pvc name when current environment is the reference environment