### PR TITLE
Add cronjob name as label

### DIFF
--- a/charts/drupal/templates/drupal-cron.yaml
+++ b/charts/drupal/templates/drupal-cron.yaml
@@ -10,6 +10,7 @@ metadata:
   labels:
     {{- include "drupal.release_labels" $ | nindent 4 }}
     cronjob: "true"
+    cronjob-name: {{ $index | quote }}
 spec:
   {{- if $.Values.timezone }}
   {{- if eq ( include "drupal.cron.timezone-support" $ ) "true" }}

--- a/charts/drupal/templates/drupal-cron.yaml
+++ b/charts/drupal/templates/drupal-cron.yaml
@@ -31,6 +31,7 @@ spec:
           labels:
             {{- include "drupal.release_labels" $ | nindent 12 }}
             cronjob: "true"
+            cronjob-name: {{ $index | quote }}
         spec:
           enableServiceLinks: false
           containers:


### PR DESCRIPTION
Changes proposed:
- Add the name (key) of the cronjob as a label. This is helpful when dealing with multiple cronjobs that have shortened/hashed names

![Monosnap k9s 2024-11-12 12-00-09](https://github.com/user-attachments/assets/b98463a0-01ae-4e79-bf17-498d0dbae1e8)
