### PR TITLE
Add nodeSelector support for backup jobs

### DIFF
--- a/charts/drupal/templates/backup-cron.yaml
+++ b/charts/drupal/templates/backup-cron.yaml
@@ -63,6 +63,10 @@ spec:
             resources:
               {{- .Values.backup.resources | toYaml | nindent 14 }}
           restartPolicy: Never
+          nodeSelector:
+            {{- .Values.backup.nodeSelector | toYaml | nindent 12 }}
+          tolerations:
+            {{- include "drupal.tolerations" .Values.backup.nodeSelector | nindent 12 }}
           volumes:
             {{- include "drupal.volumes" . | nindent 12 }}
             - name: {{ .Release.Name }}-backup

--- a/charts/drupal/values.schema.json
+++ b/charts/drupal/values.schema.json
@@ -471,10 +471,10 @@
         }
       }
     },
-    "silta-hub": { 
+    "silta-hub": {
       "type": "object",
       "properties": {
-        "sync": { 
+        "sync": {
           "type": "object",
           "properties": {
             "resources": {
@@ -519,6 +519,7 @@
         "csiDriverName": { "type": "string" },
         "ignoreTableContent": { "type": "string" },
         "skipFiles": { "type": "boolean" },
+        "nodeSelector": { "type": "object" },
         "resources": {
           "type": "object",
           "additionalProperties": false,

--- a/charts/drupal/values.yaml
+++ b/charts/drupal/values.yaml
@@ -24,7 +24,7 @@ environmentName: ""
 # See https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
 imagePullSecrets: []
 
-# Custom imagePullSecret for the containers. Base64 encoded. This will create a secret and append it to the imagePullSecrets. 
+# Custom imagePullSecret for the containers. Base64 encoded. This will create a secret and append it to the imagePullSecrets.
 imagePullSecret: ""
 
 # The app label added to our Kubernetes resources.
@@ -540,6 +540,9 @@ backup:
 
   #  Do not backup files
   #skipFiles: true
+
+  # Set a nodeSelector specifically for backup jobs.
+  nodeSelector: {}
 
   # Resources for the backup cron job.
   resources:


### PR DESCRIPTION
Changes proposed:
- Add nodeSelector support for backup jobs
- Set the default value to an empty object

Here are screenshots from test:

**Backups enabled, using default value for nodeSelector:**

![Monosnap k9s 2024-11-22 11-20-06](https://github.com/user-attachments/assets/69bc5a30-a560-496d-9823-e5eede69726f)
![Monosnap k9s 2024-11-22 11-20-33](https://github.com/user-attachments/assets/6c657342-e903-4df5-9e18-7607ff23114e)

**Backups enabled, using overridden value for nodeSelector:**

![Monosnap k9s 2024-11-22 11-19-28](https://github.com/user-attachments/assets/9a1c3f77-8370-46dc-ac7f-b6f18d2d0b74)
![Monosnap k9s 2024-11-22 11-16-18](https://github.com/user-attachments/assets/15699a3f-6adb-48a5-abad-f5400ed677e0)
