### PR TITLE
SLT-1164: Make sure gdprDump generates unique usernames in user_field_data

### DIFF
--- a/charts/drupal/values.yaml
+++ b/charts/drupal/values.yaml
@@ -507,6 +507,7 @@ gdprDump:
             key: 'processed_data.mail'
         name:
           converter: 'faker'
+          unique: true
           parameters:
             formatter: 'name'
         pass:


### PR DESCRIPTION
Motivation
--
- Current gdprDump config for user_field_data.name field doesn't check the uniques of the generated value, thus it can lead to entries with duplicate "names". That is against Drupal user_field_data DB table/index rules (see below) and would lead to errors in reference DB import, thus missing data.
<img width="1320" alt="image" src="https://github.com/user-attachments/assets/52d9dab8-3111-4401-9cad-079eaa425c7b" />

This issue can present itself on large sites with thousands of users (i.e., 35k) as there is a hight change of gdprDump generating entries with duplicate usernames as I believe those are not completely randomized but rather generated from a given set of "names", "surnames", "titles" etc.
 
Changes proposed:
 - Make sure unique usernames are generated by gdprDump by explicitly setting `unique: true` property

