### PR TITLE
SLT-1103: Drupal chart: Add support for mailpit, deprecate mailhog

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,6 +142,7 @@ workflows:
                 name: Add helm repositories and build local chart
                 command: |
                   helm repo add elastic https://helm.elastic.co
+                  helm repo add jouve https://jouve.github.io/charts/
                   helm repo add codecentric https://codecentric.github.io/helm-charts
                   helm repo add percona https://percona.github.io/percona-helm-charts/
                   helm dependency build ./charts/drupal

--- a/charts/drupal/Chart.lock
+++ b/charts/drupal/Chart.lock
@@ -16,12 +16,12 @@ dependencies:
   version: 5.1.0
 - name: mailpit
   repository: https://jouve.github.io/charts/
-  version: 0.23.1
+  version: 0.24.0
 - name: elasticsearch
   repository: file://../elasticsearch
   version: 8.5.1
 - name: silta-release
   repository: file://../silta-release
   version: 1.0.1
-digest: sha256:38e74b72e50d324a82d8adf1e1f75203074fa997b72c8df03892ceb36424bc40
-generated: "2025-04-01T17:31:34.709323+03:00"
+digest: sha256:e3ea21b74deadb01861e37b2296391e1f0a25f62dc6b3da226d28cb95245342d
+generated: "2025-04-08T22:42:49.491746+03:00"

--- a/charts/drupal/Chart.lock
+++ b/charts/drupal/Chart.lock
@@ -14,11 +14,14 @@ dependencies:
 - name: mailhog
   repository: https://storage.googleapis.com/charts.wdr.io
   version: 5.1.0
+- name: mailpit
+  repository: https://jouve.github.io/charts/
+  version: 0.23.1
 - name: elasticsearch
   repository: file://../elasticsearch
   version: 8.5.1
 - name: silta-release
   repository: file://../silta-release
   version: 1.0.1
-digest: sha256:9941fba8da73d8d7c9024c8c53dda085f0fba6ae50ef63d884dfe994d08a7641
-generated: "2025-03-18T10:31:05.247476421+02:00"
+digest: sha256:e3bc6118a514b2bcaa01173a93bb88c5e28ec3c71138d57385b744bb3c34378f
+generated: "2025-03-27T15:34:52.476543+02:00"

--- a/charts/drupal/Chart.lock
+++ b/charts/drupal/Chart.lock
@@ -23,5 +23,5 @@ dependencies:
 - name: silta-release
   repository: file://../silta-release
   version: 1.0.1
-digest: sha256:e3bc6118a514b2bcaa01173a93bb88c5e28ec3c71138d57385b744bb3c34378f
-generated: "2025-03-27T15:34:52.476543+02:00"
+digest: sha256:38e74b72e50d324a82d8adf1e1f75203074fa997b72c8df03892ceb36424bc40
+generated: "2025-04-01T17:31:34.709323+03:00"

--- a/charts/drupal/Chart.yaml
+++ b/charts/drupal/Chart.yaml
@@ -23,7 +23,7 @@ dependencies:
   repository: https://storage.googleapis.com/charts.wdr.io
   condition: mailhog.enabled
 - name: mailpit
-  version: 0.23.x
+  version: 0.24.x
   repository: https://jouve.github.io/charts/
   condition: mailpit.enabled
 - name: elasticsearch

--- a/charts/drupal/Chart.yaml
+++ b/charts/drupal/Chart.yaml
@@ -22,6 +22,10 @@ dependencies:
   version: 5.1.x
   repository: https://storage.googleapis.com/charts.wdr.io
   condition: mailhog.enabled
+- name: mailpit
+  version: 0.23.1
+  repository: https://jouve.github.io/charts/
+  condition: mailpit.enabled
 - name: elasticsearch
   version: 8.5.x
   # repository: https://helm.elastic.co

--- a/charts/drupal/Chart.yaml
+++ b/charts/drupal/Chart.yaml
@@ -23,7 +23,7 @@ dependencies:
   repository: https://storage.googleapis.com/charts.wdr.io
   condition: mailhog.enabled
 - name: mailpit
-  version: 0.23.1
+  version: 0.23.x
   repository: https://jouve.github.io/charts/
   condition: mailpit.enabled
 - name: elasticsearch

--- a/charts/drupal/templates/NOTES.txt
+++ b/charts/drupal/templates/NOTES.txt
@@ -26,6 +26,16 @@ Mailhog available at:
   {{- end }}
 {{- end }}
 
+{{- if .Values.mailpit.enabled }}
+
+Mailpit available at:
+
+  http://{{- template "drupal.domain" . }}/mailpit
+  {{- range $index, $domain := .Values.exposeDomains }}
+  http://{{ $domain.hostname }}/mailpit
+  {{- end }}
+{{- end }}
+
 {{- if .Values.nginx.basicauth.enabled }}
 
 Basic access authentication credentials:

--- a/charts/drupal/templates/_helpers.tpl
+++ b/charts/drupal/templates/_helpers.tpl
@@ -98,6 +98,8 @@ imagePullSecrets:
 - name: SMTP_ADDRESS
   {{- if .Values.mailpit.enabled }}
   value: "{{ .Release.Name }}-mailpit-smtp:25"
+  {{ else if .Values.mailhog.enabled }}
+  value: "{{ .Release.Name }}-mailhog:1025"
   {{ else }}
   value: {{ .Values.smtp.address | quote }}
   {{- end }}
@@ -116,6 +118,8 @@ imagePullSecrets:
 - name: SSMTP_MAILHUB
   {{- if .Values.mailpit.enabled }}
   value: "{{ .Release.Name }}-mailpit-smtp:25"
+  {{ else if .Values.mailhog.enabled }}
+  value: "{{ .Release.Name }}-mailhog:1025"
   {{ else }}
   value: {{ .Values.smtp.address | quote }}
   {{- end }}

--- a/charts/drupal/templates/_helpers.tpl
+++ b/charts/drupal/templates/_helpers.tpl
@@ -96,8 +96,8 @@ imagePullSecrets:
 
 {{- define "smtp.env" }}
 - name: SMTP_ADDRESS
-  {{- if .Values.mailhog.enabled }}
-  value: "{{ .Release.Name }}-mailhog:1025"
+  {{- if .Values.mailpit.enabled }}
+  value: "{{ .Release.Name }}-mailpit-smtp:25"
   {{ else }}
   value: {{ .Values.smtp.address | quote }}
   {{- end }}
@@ -114,8 +114,8 @@ imagePullSecrets:
       key: password
 # Duplicate SMTP env variables for ssmtp bundled with amazee php image
 - name: SSMTP_MAILHUB
-  {{- if .Values.mailhog.enabled }}
-  value: "{{ .Release.Name }}-mailhog:1025"
+  {{- if .Values.mailpit.enabled }}
+  value: "{{ .Release.Name }}-mailpit-smtp:25"
   {{ else }}
   value: {{ .Values.smtp.address | quote }}
   {{- end }}

--- a/charts/drupal/templates/_helpers.tpl
+++ b/charts/drupal/templates/_helpers.tpl
@@ -233,10 +233,15 @@ imagePullSecrets:
 - name: ELASTICSEARCH_HOST
   value: {{ .Release.Name }}-es
 {{- end }}
-{{- if or .Values.mailhog.enabled .Values.smtp.enabled }}
+{{- if or .Values.mailhog.enabled .Values.mailpit.enabled .Values.smtp.enabled }}
 {{- if .Values.mailhog.enabled }}
 {{- if contains "mailhog" .Release.Name -}}
 {{- fail "Do not use 'mailhog' in release name or deployment will fail" -}}
+{{- end }}
+{{- end }}
+{{- if .Values.mailpit.enabled }}
+{{- if contains "mailpit" .Release.Name -}}
+{{- fail "Do not use 'mailpit' in release name or deployment will fail" -}}
 {{- end }}
 {{- end }}
 {{ include "smtp.env" . }}

--- a/charts/drupal/templates/checks.yaml
+++ b/charts/drupal/templates/checks.yaml
@@ -1,5 +1,11 @@
+{{- if and .Values.mailhog.enabled .Values.mailpit.enabled }}
+{{- fail "Mailhog and mailpit can't be enabled at the same time as those are overlapping services. Use mailpit only as mailhog is deprecated." -}}
+{{- end }}
 {{- if index (index .Values "silta-release") "branchName" }}
 {{- if eq (index (index .Values "silta-release") "branchName") "production" }}
+{{- if .Values.mailhog.enabled }}
+{{- fail "Mailhog should not be enabled in production" -}}
+{{- end }}
 {{- if .Values.mailpit.enabled }}
 {{- fail "Mailpit should not be enabled in production" -}}
 {{- end }}

--- a/charts/drupal/templates/checks.yaml
+++ b/charts/drupal/templates/checks.yaml
@@ -1,7 +1,7 @@
 {{- if index (index .Values "silta-release") "branchName" }}
 {{- if eq (index (index .Values "silta-release") "branchName") "production" }}
-{{- if .Values.mailhog.enabled }}
-{{- fail "Mailhog should not be enabled in production" -}}
+{{- if .Values.mailpit.enabled }}
+{{- fail "Mailpit should not be enabled in production" -}}
 {{- end }}
 {{- if eq .Values.nginx.resources.requests.cpu "1m" }}
 {{- fail "Raise nginx.resources.requests.cpu for production environment" -}}

--- a/charts/drupal/templates/drupal-configmap.yaml
+++ b/charts/drupal/templates/drupal-configmap.yaml
@@ -396,7 +396,7 @@ data:
       {{- end }}
 
       {{- if .Values.mailpit.enabled }}
-      location /mailpit {
+      location /mailpit/ {
 
         # Auth / whitelist always enabled
         satisfy any;
@@ -413,15 +413,18 @@ data:
         {{- end}}
 
         # Proxy to mailpit container
-        proxy_pass http://{{ .Release.Name }}-mailpit-http:80/;
+        proxy_pass http://{{ .Release.Name }}-mailpit-http:80/mailpit/;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_http_version 1.1;
+        # Websock connection
+        chunked_transfer_encoding on;
+        proxy_set_header X-NginX-Proxy true;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
-        proxy_redirect default;
+        proxy_http_version 1.1;
+        proxy_redirect off;
         proxy_buffering off;
       }
       {{- end}}

--- a/charts/drupal/templates/drupal-configmap.yaml
+++ b/charts/drupal/templates/drupal-configmap.yaml
@@ -395,8 +395,8 @@ data:
       }
       {{- end }}
 
-      {{- if .Values.mailhog.enabled }}
-      location /mailhog {
+      {{- if .Values.mailpit.enabled }}
+      location /mailpit {
 
         # Auth / whitelist always enabled
         satisfy any;
@@ -412,11 +412,11 @@ data:
         auth_basic_user_file /etc/nginx/.htaccess;
         {{- end}}
 
-        rewrite ^/mailhog$ /mailhog/ permanent;
+        rewrite ^/mailpit /mailpit/ permanent;
 
-        # Proxy to mailhog container
-        rewrite /mailhog(.*) $1 break;
-        proxy_pass http://{{ .Release.Name }}-mailhog:8025/;
+        # Proxy to mailpit container
+        rewrite /mailpit(.*) $1 break;
+        proxy_pass http://{{ .Release.Name }}-mailpit-http:80/;
 
         # Websock connection
         chunked_transfer_encoding on;

--- a/charts/drupal/templates/drupal-configmap.yaml
+++ b/charts/drupal/templates/drupal-configmap.yaml
@@ -412,19 +412,16 @@ data:
         auth_basic_user_file /etc/nginx/.htaccess;
         {{- end}}
 
-        rewrite ^/mailpit /mailpit/ permanent;
-
         # Proxy to mailpit container
-        rewrite /mailpit(.*) $1 break;
         proxy_pass http://{{ .Release.Name }}-mailpit-http:80/;
-
-        # Websock connection
-        chunked_transfer_encoding on;
-        proxy_set_header X-NginX-Proxy true;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
-        proxy_http_version 1.1;
-        proxy_redirect off;
+        proxy_redirect default;
         proxy_buffering off;
       }
       {{- end}}

--- a/charts/drupal/templates/drupal-configmap.yaml
+++ b/charts/drupal/templates/drupal-configmap.yaml
@@ -395,6 +395,40 @@ data:
       }
       {{- end }}
 
+      {{- if .Values.mailhog.enabled }}
+      location /mailhog {
+
+        # Auth / whitelist always enabled
+        satisfy any;
+        allow 127.0.0.1;
+        {{- range .Values.nginx.noauthips }}
+        allow {{ . }};
+        {{- end }}
+        deny all;
+
+        {{- if gt (len .Values.nginx.noauthips) 1 -}}
+        # Basic auth only offered when at least one extra ip is whitelisted. Prevents using default credentials.
+        auth_basic "Restricted";
+        auth_basic_user_file /etc/nginx/.htaccess;
+        {{- end}}
+
+        rewrite ^/mailhog$ /mailhog/ permanent;
+
+        # Proxy to mailhog container
+        rewrite /mailhog(.*) $1 break;
+        proxy_pass http://{{ .Release.Name }}-mailhog:8025/;
+
+        # Websock connection
+        chunked_transfer_encoding on;
+        proxy_set_header X-NginX-Proxy true;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_http_version 1.1;
+        proxy_redirect off;
+        proxy_buffering off;
+      }
+      {{- end}}
+
       {{- if .Values.mailpit.enabled }}
       location /mailpit/ {
 

--- a/charts/drupal/templates/drupal-configmap.yaml
+++ b/charts/drupal/templates/drupal-configmap.yaml
@@ -430,6 +430,11 @@ data:
       {{- end}}
 
       {{- if .Values.mailpit.enabled }}
+      # Redirect the legacy mailhog service to mailpit.
+      location /mailhog {
+        return 301 /mailpit/;
+      }
+
       location /mailpit/ {
 
         # Auth / whitelist always enabled

--- a/charts/drupal/templates/smtp-secret.yaml
+++ b/charts/drupal/templates/smtp-secret.yaml
@@ -1,4 +1,4 @@
-{{- if or .Values.mailhog.enabled .Values.smtp.enabled }}
+{{- if or .Values.mailpit.enabled .Values.smtp.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/drupal/templates/smtp-secret.yaml
+++ b/charts/drupal/templates/smtp-secret.yaml
@@ -1,4 +1,4 @@
-{{- if or .Values.mailpit.enabled .Values.smtp.enabled }}
+{{- if or .Values.mailpit.enabled .Values.mailhog.enabled .Values.smtp.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/drupal/templates/varnish-configmap-vcl.yaml
+++ b/charts/drupal/templates/varnish-configmap-vcl.yaml
@@ -399,7 +399,7 @@ data:
 
       {{- if .Values.mailpit.enabled }}
       // No varnish for mailpit
-      if (req.url ~ "^/mailpit$") {
+      if (req.url ~ "^/mailpit(/|$)") {
         return (pass);
       }
       {{- end }}

--- a/charts/drupal/templates/varnish-configmap-vcl.yaml
+++ b/charts/drupal/templates/varnish-configmap-vcl.yaml
@@ -397,9 +397,9 @@ data:
       }
       {{- end }}
 
-      {{- if .Values.mailhog.enabled }}
-      // No varnish for mailhog
-      if (req.url ~ "^/mailhog$") {
+      {{- if .Values.mailpit.enabled }}
+      // No varnish for mailpit
+      if (req.url ~ "^/mailpit$") {
         return (pass);
       }
       {{- end }}

--- a/charts/drupal/templates/varnish-configmap-vcl.yaml
+++ b/charts/drupal/templates/varnish-configmap-vcl.yaml
@@ -397,6 +397,13 @@ data:
       }
       {{- end }}
 
+      {{- if .Values.mailhog.enabled }}
+      // No varnish for mailhog
+      if (req.url ~ "^/mailhog$") {
+        return (pass);
+      }
+      {{- end }}
+
       {{- if .Values.mailpit.enabled }}
       // No varnish for mailpit
       if (req.url ~ "^/mailpit(/|$)") {

--- a/charts/drupal/test.values.yaml
+++ b/charts/drupal/test.values.yaml
@@ -28,7 +28,7 @@ redis:
 elasticsearch:
   enabled: true
 
-mailhog:
+mailpit:
   enabled: true
 
 backup:

--- a/charts/drupal/tests/drupal_deployment_test.yaml
+++ b/charts/drupal/tests/drupal_deployment_test.yaml
@@ -182,7 +182,7 @@ tests:
   - it: sets smtp environment variables correctly
     template: drupal-deployment.yaml
     set:
-      mailhog:
+      mailpit:
         enabled: false
       smtp:
         enabled: true
@@ -199,10 +199,10 @@ tests:
           content:
             name: SMTP_USERNAME
             value: foo
-  - it: sets mailhog smtp environment variables correctly
+  - it: sets mailpit smtp environment variables correctly
     template: drupal-deployment.yaml
     set:
-      mailhog:
+      mailpit:
         enabled: true
       smtp:
         enabled: true
@@ -211,11 +211,11 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: SMTP_ADDRESS
-            value: RELEASE-NAME-mailhog:1025
+            value: RELEASE-NAME-mailpit-smtp:25
   - it: sets ssmtp environment variables correctly
     template: drupal-deployment.yaml
     set:
-      mailhog:
+      mailpit:
         enabled: false
       smtp:
         enabled: true

--- a/charts/drupal/values.schema.json
+++ b/charts/drupal/values.schema.json
@@ -625,6 +625,12 @@
         "enabled": { "type": "boolean" }
       }
     },
+    "mailpit": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" }
+      }
+    },
     "mailhog": {
       "type": "object",
       "properties": {

--- a/charts/drupal/values.yaml
+++ b/charts/drupal/values.yaml
@@ -738,6 +738,11 @@ redis:
   serviceAccount:
     automountServiceAccountToken: false
 
+# Mailpit service overrides
+mailpit:
+  enabled: false
+
+
 # Mailhog service overrides
 # see: https://github.com/codecentric/helm-charts/blob/master/charts/mailhog/values.yaml
 mailhog:

--- a/charts/drupal/values.yaml
+++ b/charts/drupal/values.yaml
@@ -757,6 +757,7 @@ mailpit:
   mailpit:
     # This is for easier proxying from Drupal's nginx
     webroot: /mailpit
+  enableServiceLinks: false
 
 # Important! This service is deprecated and will be removed from future releases. Please use "mailpit" instead.
 # Mailhog service overrides

--- a/charts/drupal/values.yaml
+++ b/charts/drupal/values.yaml
@@ -741,6 +741,11 @@ redis:
 # Mailpit service overrides
 mailpit:
   enabled: false
+  extraEnvVars:
+    - name: MP_SMTP_AUTH_ACCEPT_ANY
+      value: "true"
+    - name: MP_SMTP_AUTH_ALLOW_INSECURE
+      value: "true"
   resources:
     requests:
       cpu: 1m

--- a/charts/drupal/values.yaml
+++ b/charts/drupal/values.yaml
@@ -742,7 +742,6 @@ redis:
 mailpit:
   enabled: false
 
-
 # Mailhog service overrides
 # see: https://github.com/codecentric/helm-charts/blob/master/charts/mailhog/values.yaml
 mailhog:

--- a/charts/drupal/values.yaml
+++ b/charts/drupal/values.yaml
@@ -741,6 +741,13 @@ redis:
 # Mailpit service overrides
 mailpit:
   enabled: false
+  resources:
+    requests:
+      cpu: 1m
+      memory: 10M
+    limits:
+      cpu: 50m
+      memory: 100M
 
 # Mailhog service overrides
 # see: https://github.com/codecentric/helm-charts/blob/master/charts/mailhog/values.yaml

--- a/charts/drupal/values.yaml
+++ b/charts/drupal/values.yaml
@@ -739,6 +739,7 @@ redis:
     automountServiceAccountToken: false
 
 # Mailpit service overrides
+# see: https://github.com/jouve/charts/blob/main/charts/mailpit/values.yaml
 mailpit:
   enabled: false
   extraEnvVars:
@@ -757,6 +758,7 @@ mailpit:
     # This is for easier proxying from Drupal's nginx
     webroot: /mailpit
 
+# Important! This service is deprecated and will be removed from future releases. Please use "mailpit" instead.
 # Mailhog service overrides
 # see: https://github.com/codecentric/helm-charts/blob/master/charts/mailhog/values.yaml
 mailhog:

--- a/charts/drupal/values.yaml
+++ b/charts/drupal/values.yaml
@@ -753,6 +753,9 @@ mailpit:
     limits:
       cpu: 50m
       memory: 100M
+  mailpit:
+    # This is for easier proxying from Drupal's nginx
+    webroot: /mailpit
 
 # Mailhog service overrides
 # see: https://github.com/codecentric/helm-charts/blob/master/charts/mailhog/values.yaml

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -10,6 +10,9 @@ varnish:
 mailpit:
   enabled: true
 
+mailhog:
+  enabled: true
+
 elasticsearch:
   enabled: true
 

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -10,9 +10,6 @@ varnish:
 mailpit:
   enabled: true
 
-mailhog:
-  enabled: false
-
 elasticsearch:
   enabled: true
 

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -7,6 +7,9 @@
 varnish:
   enabled: true
 
+mailpit:
+  enabled: true
+
 elasticsearch:
   enabled: true
 

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -11,7 +11,7 @@ mailpit:
   enabled: true
 
 mailhog:
-  enabled: true
+  enabled: false
 
 elasticsearch:
   enabled: true


### PR DESCRIPTION
**Motivation:**
[Mailhog](https://github.com/mailhog/MailHog) is an email service we’re using in our development environments (local & Silta non-production) to test out if email functionalities are working properly. Mailhog [is not maintained anymore](https://github.com/mailhog/MailHog/issues/442#issuecomment-1493415258) and is causing issues for developers. Therefore, we need to replace it with some alternative. Our current pick is [Mailpit](https://mailpit.axllent.org/).

Changes proposed:
- Add mailpit dependency, enable it, add default value overrides
- Update chart templates with needed changes for mailpit to work
- Update unit tests to run against mailpit instead of mailhog
- Keep mailhog in chart but add deprecation notices

How to test:
1. Install the updated chart and see that mailpit works (`helm install drupal-release charts/drupal --set mailpit.enabled=true` or test here: https://app.circleci.com/pipelines/github/wunderio/drupal-project-k8s/6873/workflows/20d2da53-257e-4bc2-8d2e-85bbb7c3eae2/jobs/22713). Test the following:
    - validation goes through (i.e., unit tests pass: `helm unittest ./charts/drupal`)
    - mailpit URL is listed in the release notes and it works
    - the legacy `/mailhog` path redirects to `/mailpit`
    - emails sent from Drupal (i.e., after password reset or new account creation) end up in mailpit, mailpit's UI works, i.e, you can mark emails as read, delete them, download etc.
2. See that updated installation checks work, i.e., try to install chart with both `mailpit` and `mailhog` enabled, see that the installation fails (or see screenshot below)
![image](https://github.com/user-attachments/assets/f86f7664-19dc-48c7-a606-2d18d0e9793c)

