### PR TITLE
Make reference database import method configurable.

### DIFF
--- a/charts/drupal/templates/_helpers.tpl
+++ b/charts/drupal/templates/_helpers.tpl
@@ -565,7 +565,7 @@ if [ "${REF_DATA_COPY_DB:-}" == "true" ]; then
         echo "Parallel import command finished."
 
       elif [[ "$import_method" == "sequential" ]]; then
-        echo "Importing SQL files in sequentially. This setting can be changed in silta.yml using the referenceData.databaseImportMethod key."
+        echo "Importing SQL files sequentially. This setting can be changed in silta.yml using the referenceData.databaseImportMethod key."
         find "${tmp_ref_data}/" -type f -name "*.sql" | sort | while IFS= read -r sql_file; do
           echo "Importing ${sql_file}"
           if ! mysql -A --user="${DB_USER}" --password="${DB_PASS}" --host="${DB_HOST}" "${DB_NAME}" < "${sql_file}"; then

--- a/charts/drupal/templates/_helpers.tpl
+++ b/charts/drupal/templates/_helpers.tpl
@@ -535,7 +535,7 @@ else
 fi
 {{- end }}
 
-{{- define "drupal.import-reference-db" -}}
+{{- define  "drupal.import-reference-db" -}}
 if [ "${REF_DATA_COPY_DB:-}" == "true" ]; then
   if [[ -f /app/reference-data/db.tar.gz || -f /app/reference-data/db.sql.gz ]]; then
     echo "Dropping old database"
@@ -543,13 +543,43 @@ if [ "${REF_DATA_COPY_DB:-}" == "true" ]; then
 
     app_ref_data=/app/reference-data
     tmp_ref_data=/tmp/reference-data
+    import_method={{ .Values.referenceData.databaseImportMethod }}
 
     # New way of importing.
     if [[ -f "${app_ref_data}/db.tar.gz" ]]; then
       echo "Importing reference database dump from db.tar.gz"
       mkdir "${tmp_ref_data}"
       tar -xzf "${app_ref_data}/db.tar.gz" -C "${tmp_ref_data}/"
-      find "${tmp_ref_data}/" -type f -name "*.sql" | xargs -P10 -I{} sh -c 'echo "Importing {}" && mysql -A --user="${DB_USER}" --password="${DB_PASS}" --host="${DB_HOST}" "${DB_NAME}" < {}'
+
+      if [[ "$import_method" == "parallel" ]]; then
+        echo "Importing SQL files in parallel. This setting can be changed in silta.yml using the referenceData.databaseImportMethod key."
+        find "${tmp_ref_data}/" -type f -name "*.sql" | xargs -P10 -I{} sh -c 'echo "Importing {}" && mysql -A --user="${DB_USER}" --password="${DB_PASS}" --host="${DB_HOST}" "${DB_NAME}" < {}'
+        pipeline_exit_code=$? # Capture exit code of the pipeline (most likely influenced by xargs)
+
+        # Check if xargs reported an error (any non-zero exit status)
+        if [ "$pipeline_exit_code" -ne 0 ]; then
+          echo "ERROR: One or more parallel imports failed. Check the logs above for specific mysql errors."
+          exit 1
+        fi
+
+        echo "Parallel import command finished."
+
+      elif [[ "$import_method" == "sequential" ]]; then
+        echo "Importing SQL files in sequentially. This setting can be changed in silta.yml using the referenceData.databaseImportMethod key."
+        find "${tmp_ref_data}/" -type f -name "*.sql" | sort | while IFS= read -r sql_file; do
+          echo "Importing ${sql_file}"
+          if ! mysql -A --user="${DB_USER}" --password="${DB_PASS}" --host="${DB_HOST}" "${DB_NAME}" < "${sql_file}"; then
+            echo "ERROR: Failed to import ${sql_file}. Check the logs above for specific mysql errors."
+            exit 1
+          fi
+        done
+
+        echo "Sequential import command finished."
+
+      else
+        echo "Incompatible import method. Please use either 'parallel' or 'sequential' in referenceData.databaseImportMethod."
+        exit 1
+      fi
 
     # Backwards compatibility for old way of importing.
     elif [[ -f "${app_ref_data}/db.sql.gz" ]]; then

--- a/charts/drupal/values.schema.json
+++ b/charts/drupal/values.schema.json
@@ -8,7 +8,7 @@
     "branchName": { "type": "string" },
     "imagePullSecrets": { "type": "array" },
     "imagePullSecret": { "type": "string" },
-    "serviceAccount": { 
+    "serviceAccount": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
@@ -450,6 +450,7 @@
         "enabled": { "type": "boolean" },
         "referenceEnvironment": { "type": "string" },
         "schedule": { "type": "string" },
+        "databaseImportMethod": { "type": "string" },
         "copyDatabase": { "type": "boolean" },
         "copyFiles": { "type": "boolean" },
         "updateAfterDeployment": { "type": "boolean" },
@@ -551,7 +552,7 @@
           }
         }
       }
-     },
+    },
     "mariadb": {
       "type": "object",
       "properties": {

--- a/charts/drupal/values.yaml
+++ b/charts/drupal/values.yaml
@@ -448,6 +448,10 @@ referenceData:
   # When to automatically update the reference data.
   schedule: '~ 3 * * *'
 
+  # The method used to import the database tables. Can be either 'parallel' or 'sequential'.
+  # Parallel is faster but might in some cases be unstable. In that case, use sequential instead.
+  databaseImportMethod: 'parallel'
+
   # Whether to copy the database, only used programmatically.
   copyDatabase: true
 


### PR DESCRIPTION
This pull request introduces a new feature to configure the database import method for reference data in the Drupal Helm chart. It allows users to choose between parallel and sequential import methods, enhancing flexibility and performance. The changes also include validation for the new configuration and error handling during the import process.

### New Feature: Configurable Database Import Method

* **Import Method Implementation in `_helpers.tpl`:** Added logic to support two database import methods (`parallel` and `sequential`) based on the `referenceData.databaseImportMethod` configuration. Includes error handling to ensure failed imports are reported and logged.
* **Schema Update in `values.schema.json`:** Added a new property, `databaseImportMethod`, to the schema definition to validate the configuration.
* **Default Configuration in `values.yaml`:** Introduced a default value for `databaseImportMethod` set to `parallel`, with comments explaining the options and their trade-offs.

### Tests
* Test deployment with [sequential import](https://app.circleci.com/pipelines/github/wunderio/drupal-project-k8s/6935/workflows/8c91026d-0e0b-4ab1-aee4-46c8ac0cc98e/jobs/22963?invite=true#step-116-731_118)
* Test deployment with [parallel import](https://app.circleci.com/pipelines/github/wunderio/drupal-project-k8s/6934/workflows/b9a3940e-610f-47ee-9d7b-225f2dff620f/jobs/22966?invite=true#step-116-729_118)