### PR TITLE
SLT-1193: Add deprecation warning for mailhog in release notes

### DIFF
--- a/charts/drupal/templates/NOTES.txt
+++ b/charts/drupal/templates/NOTES.txt
@@ -17,13 +17,15 @@ Your site is available at:
   {{- end }}
 
 {{- if .Values.mailhog.enabled }}
-  
+
 Mailhog available at:
 
   http://{{- template "drupal.domain" . }}/mailhog
   {{- range $index, $domain := .Values.exposeDomains }}
   http://{{ $domain.hostname }}/mailhog
   {{- end }}
+  ⚠️ **DEPRECATED** mailhog is deprecated and will be removed in the future, use mailpit instead
+  See: https://wunderio.github.io/silta/docs/silta-examples#sending-e-mail
 {{- end }}
 
 {{- if .Values.mailpit.enabled }}


### PR DESCRIPTION
How to test:
 - See that there is a deprecation warning in release notes:
   - **option 1**: https://app.circleci.com/pipelines/github/wunderio/drupal-project-k8s/6964/workflows/09ab23f5-9ee9-47f0-a9f7-96e28aef6c20/jobs/23096?invite=true#step-117-98_21
   - **option 2**: Checkout this branch and run `helm install --dry-run test-drupal ./charts/drupal --set mailhog.enabled=true`