### PR TITLE
SLT-1037: Drupal chart: Change default names in helm release notes

### DIFF
--- a/charts/drupal/templates/NOTES.txt
+++ b/charts/drupal/templates/NOTES.txt
@@ -59,7 +59,7 @@ Downloading data from server
 
   {{ range $index, $mount := .Values.mounts -}}
   {{ if eq $mount.enabled true -}}
-  {{/*  Ensure that the printed path is suffixed with a slash.*/}}
+  {{/*  Ensure that the mount path is suffixed with a slash when printed. */}}
   {{- $mountPath := ternary $mount.mountPath (printf "%s/" $mount.mountPath) (hasSuffix "/" $mount.mountPath) -}}
   Downloading files from {{ $index }}:
   rsync -azv -e 'ssh -A -J {{ include "drupal.jumphost" $ }}' {{ include "drupal.shellHost" $ }}:{{ $mountPath }} {{ $.Release.Namespace }}-mounts/{{ $index }}
@@ -76,10 +76,8 @@ Importing data into server (use this with caution!)
 
   {{ range $index, $mount := .Values.mounts -}}
   {{ if eq $mount.enabled true -}}
-  {{/*  Ensure that the printed path is suffixed with a slash.*/}}
-  {{- $mountPath := ternary $mount.mountPath (printf "%s/" $mount.mountPath) (hasSuffix "/" $mount.mountPath) -}}
   Uploading files to {{ $index }}:
-  rsync -azv --temp-dir=/tmp/ -e 'ssh -A -J {{ include "drupal.jumphost" $ }}' {{ $.Release.Namespace }}-mounts/{{ $index }} {{ include "drupal.shellHost" $ }}:{{ $mountPath }}
+  rsync -azv --temp-dir=/tmp/ -e 'ssh -A -J {{ include "drupal.jumphost" $ }}' {{ $.Release.Namespace }}-mounts/{{ $index }}/ {{ include "drupal.shellHost" $ }}:{{ $mount.mountPath }}
   {{ end }}
   {{ end -}}
   {{- end -}}

--- a/charts/drupal/templates/NOTES.txt
+++ b/charts/drupal/templates/NOTES.txt
@@ -59,8 +59,10 @@ Downloading data from server
 
   {{ range $index, $mount := .Values.mounts -}}
   {{ if eq $mount.enabled true -}}
+  {{/*  Ensure that the printed path is suffixed with a slash.*/}}
+  {{- $mountPath := ternary $mount.mountPath (printf "%s/" $mount.mountPath) (hasSuffix "/" $mount.mountPath) -}}
   Downloading files from {{ $index }}:
-  rsync -azv -e 'ssh -A -J {{ include "drupal.jumphost" $ }}' {{ include "drupal.shellHost" $ }}:{{ $mount.mountPath }} {{ $.Release.Namespace }}-mounts/{{ $index }}
+  rsync -azv -e 'ssh -A -J {{ include "drupal.jumphost" $ }}' {{ include "drupal.shellHost" $ }}:{{ $mountPath }} {{ $.Release.Namespace }}-mounts/{{ $index }}
   {{ end }}
   {{ end -}}
 
@@ -74,8 +76,10 @@ Importing data into server (use this with caution!)
 
   {{ range $index, $mount := .Values.mounts -}}
   {{ if eq $mount.enabled true -}}
+  {{/*  Ensure that the printed path is suffixed with a slash.*/}}
+  {{- $mountPath := ternary $mount.mountPath (printf "%s/" $mount.mountPath) (hasSuffix "/" $mount.mountPath) -}}
   Uploading files to {{ $index }}:
-  rsync -azv --temp-dir=/tmp/ -e 'ssh -A -J {{ include "drupal.jumphost" $ }}' {{ $.Release.Namespace }}-mounts/{{ $index }} {{ include "drupal.shellHost" $ }}:{{ $mount.mountPath }}
+  rsync -azv --temp-dir=/tmp/ -e 'ssh -A -J {{ include "drupal.jumphost" $ }}' {{ $.Release.Namespace }}-mounts/{{ $index }} {{ include "drupal.shellHost" $ }}:{{ $mountPath }}
   {{ end }}
   {{ end -}}
   {{- end -}}

--- a/charts/drupal/templates/NOTES.txt
+++ b/charts/drupal/templates/NOTES.txt
@@ -53,9 +53,9 @@ SSH connection (limited access through VPN):
   ssh {{ include "drupal.shellHost" . }} -J {{ include "drupal.jumphost" . }}
 
 Downloading data from server
-  
-  Downloading database: 
-  ssh {{ include "drupal.shellHost" . }} -J {{ include "drupal.jumphost" . }} "drush sql-dump" > my_database_dump.sql
+
+  Downloading database:
+  ssh {{ include "drupal.shellHost" . }} -J {{ include "drupal.jumphost" . }} "drush sql-dump" > {{ .Release.Namespace }}-{{ .Release.Name }}.sql
 
   {{ range $index, $mount := .Values.mounts -}}
   {{ if eq $mount.enabled true -}}
@@ -68,9 +68,9 @@ Downloading data from server
   rsync -chavzP -e "ssh -A -J {{ include "drupal.jumphost" . }}" {{ include "drupal.shellHost" . }}:/app/remote-filename ./
 
 Importing data into server (use this with caution!)
-  
+
   Importing database:
-  ssh {{ include "drupal.shellHost" . }} -J {{ include "drupal.jumphost" . }} "drush sql-cli" < my_database_dump.sql
+  ssh {{ include "drupal.shellHost" . }} -J {{ include "drupal.jumphost" . }} "drush sql-cli" < {{ .Release.Namespace }}-{{ .Release.Name }}.sql
 
   {{ range $index, $mount := .Values.mounts -}}
   {{ if eq $mount.enabled true -}}

--- a/charts/drupal/templates/NOTES.txt
+++ b/charts/drupal/templates/NOTES.txt
@@ -60,7 +60,7 @@ Downloading data from server
   {{ range $index, $mount := .Values.mounts -}}
   {{ if eq $mount.enabled true -}}
   Downloading files from {{ $index }}:
-  rsync -azv -e 'ssh -A -J {{ include "drupal.jumphost" $ }}' {{ include "drupal.shellHost" $ }}:{{ $mount.mountPath }} local_folder/ 
+  rsync -azv -e 'ssh -A -J {{ include "drupal.jumphost" $ }}' {{ include "drupal.shellHost" $ }}:{{ $mount.mountPath }} {{ $.Release.Namespace }}-mounts/{{ $index }}
   {{ end }}
   {{ end -}}
 
@@ -75,7 +75,7 @@ Importing data into server (use this with caution!)
   {{ range $index, $mount := .Values.mounts -}}
   {{ if eq $mount.enabled true -}}
   Uploading files to {{ $index }}:
-  rsync -azv --temp-dir=/tmp/ -e 'ssh -A -J {{ include "drupal.jumphost" $ }}' local_folder/ {{ include "drupal.shellHost" $ }}:{{ $mount.mountPath }}
+  rsync -azv --temp-dir=/tmp/ -e 'ssh -A -J {{ include "drupal.jumphost" $ }}' {{ $.Release.Namespace }}-mounts/{{ $index }} {{ include "drupal.shellHost" $ }}:{{ $mount.mountPath }}
   {{ end }}
   {{ end -}}
   {{- end -}}

--- a/charts/drupal/templates/NOTES.txt
+++ b/charts/drupal/templates/NOTES.txt
@@ -59,7 +59,7 @@ Downloading data from server
 
   {{ range $index, $mount := .Values.mounts -}}
   {{ if eq $mount.enabled true -}}
-  {{/*  Ensure that the mount path is suffixed with a slash when printed. */}}
+  {{/*  Ensure that the mount path is suffixed with a slash to download contents of the mount not the folder itself. */}}
   {{- $mountPath := ternary $mount.mountPath (printf "%s/" $mount.mountPath) (hasSuffix "/" $mount.mountPath) -}}
   Downloading files from {{ $index }}:
   rsync -azv -e 'ssh -A -J {{ include "drupal.jumphost" $ }}' {{ include "drupal.shellHost" $ }}:{{ $mountPath }} {{ $.Release.Namespace }}-mounts/{{ $index }}


### PR DESCRIPTION
Changes proposed:

Drupal chart: 
- Generate sql dump-file name as well as the local file mount folder names in release notes using `namespace` and `release-name`. This can prevent accidental cross-namespace or cross-environment imports.
- Ensure that the mount path in **download** command is suffixed with a slash to download contents of the mount not the folder itself, this retains the right folder structure when uploading files with **upload/import** command (i.e, doesn't create an extra sub-directory).

How to test:
1. Can be tested by using commands from release notes here: https://app.circleci.com/pipelines/github/wunderio/drupal-project-k8s?branch=feature%2FSLT-1037-sql-dump-name (or you can preview the release notes locally by running `helm install --dry-run test-release ./charts/drupal -n drupal-project-k8s --values silta/silta.yml`)
2. For file mounts:
  2.1. Run the ssh commands for file mount downloading 
  2.2. Add new file in each of the downloaded mounts locally, i.e., run:
    ```
    touch drupal-project-k8s-mounts/private-files/test-file.txt
    touch drupal-project-k8s-mounts/public-files/test-file.txt
    ```
    2.3. Run the ssh commands for file mount importing, make sure you do it from the same folder as in 2.1. See that only the new files got uploaded and in the correct location.