### PR TITLE
connection limit annotation validation

### DIFF
--- a/charts/drupal/templates/checks.yaml
+++ b/charts/drupal/templates/checks.yaml
@@ -19,4 +19,13 @@
 {{- end }}
 {{- if .Values.referenceData.ignoreTableContent }}
 {{- fail "referenceData.ignoreTableContent is deprecated. See gdprDump.tables.[cache_*].truncate` key for table data removal." -}}
-{{- end}}
+{{- end }}
+{{- /* Ingress checks */ -}}
+{{- range $ingress_index, $ingress := $.Values.ingress }}
+{{- if and $ingress.extraAnnotations (hasKey $ingress.extraAnnotations "nginx.ingress.kubernetes.io/limit-connections") }}
+{{- $limit := int (get $ingress.extraAnnotations "nginx.ingress.kubernetes.io/limit-connections") }}
+{{- if gt $limit 65536 }}
+{{- fail "nginx.ingress.kubernetes.io/limit-connections cannot be greater than 65536" }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/drupal/tests/drupal_ingress_test.yaml
+++ b/charts/drupal/tests/drupal_ingress_test.yaml
@@ -1,6 +1,7 @@
 suite: drupal ingress
 templates:
   - drupal-ingress.yaml
+  - checks.yaml
 capabilities:
   apiVersions:
     - pxc.percona.com/v1
@@ -402,3 +403,40 @@ tests:
         equal:
           path: spec.rules[0].http.paths[0].path
           value: '/'
+
+  - it: prevents limit connections above 65536 for default ingress
+    template: checks.yaml
+    set:
+      ingress:
+        default:
+          extraAnnotations:
+            'nginx.ingress.kubernetes.io/limit-connections': '65537'
+    asserts:
+      - failedTemplate:
+          errorMessage: "nginx.ingress.kubernetes.io/limit-connections cannot be greater than 65536"
+
+  - it: allows limit connections above 65536 for default ingress
+    template: checks.yaml
+    set:
+      ingress:
+        default:
+          extraAnnotations:
+            'nginx.ingress.kubernetes.io/limit-connections': '65536'
+    asserts:
+      - notFailedTemplate:
+          errorMessage: "nginx.ingress.kubernetes.io/limit-connections cannot be greater than 65536"
+
+  - it: prevents limit connections above 65536 for enabled exposeDomains ingress
+    template: checks.yaml
+    set:
+      exposeDomains:
+        bar:
+          hostname: foo.bar
+          ingress: baz
+      ingress:
+        baz:
+          extraAnnotations:
+            'nginx.ingress.kubernetes.io/limit-connections': '65537'
+    asserts:
+      - failedTemplate:
+          errorMessage: "nginx.ingress.kubernetes.io/limit-connections cannot be greater than 65536"


### PR DESCRIPTION
Prevents nginx configuration emergency failure when setting connection limit above 65536

Testing:
```yaml
ingress:
  default:
    extraAnnotations:
      nginx.ingress.kubernetes.io/limit-connections: "65537"
```