### PR TITLE
mariadb backup validation image

### DIFF
--- a/charts/drupal/templates/backup-cron.yaml
+++ b/charts/drupal/templates/backup-cron.yaml
@@ -50,7 +50,7 @@ spec:
                 {{ include "drupal.backup-command" (merge $params . ) | nindent 16 }}
                 {{ include "mariadb.db-validation" (merge $params . ) | nindent 16 }}
           - name: mariadb
-            image: docker.io/bitnami/mariadb:10.3.24-debian-10-r49
+            image: {{ printf "%s/%s:%s" $.Values.mariadb.image.registry $.Values.mariadb.image.repository $.Values.mariadb.image.tag }}
             imagePullPolicy: IfNotPresent
             env:
             - name: MARIADB_ROOT_PASSWORD


### PR DESCRIPTION
Uses same mariadb image for backup validation task as the actual service