### PR TITLE
Update .dockerignore files

### DIFF
--- a/silta/php.Dockerfile.dockerignore
+++ b/silta/php.Dockerfile.dockerignore
@@ -16,8 +16,6 @@ vendor/**/Tests
 web/sites/**/files
 web/.dockerignore
 Dockerfile
-silta/*.Dockerfile
-silta/*.Dockerfile.dockerignore
 composer.lock
 silta/silta*.yml
 charts

--- a/silta/shell.Dockerfile.dockerignore
+++ b/silta/shell.Dockerfile.dockerignore
@@ -16,8 +16,6 @@ vendor/**/Tests
 web/sites/**/files
 web/.dockerignore
 Dockerfile
-silta/*.Dockerfile
-silta/*.Dockerfile.dockerignore
 composer.lock
 silta/silta*.yml
 charts


### PR DESCRIPTION
This pull request makes a minor update to the `.dockerignore` files for the Silta project. The change removes the exclusion of Silta Dockerfile and Dockerfile.dockerignore patterns, which may affect which files are ignored during Docker builds.

- Removed the lines ignoring `silta/*.Dockerfile` and `silta/*.Dockerfile.dockerignore` from both `silta/php.Dockerfile.dockerignore` and `silta/shell.Dockerfile.dockerignore` files.