### PR TITLE
Force run as solr root

### DIFF
--- a/charts/drupal/templates/solr-statefulset.yaml
+++ b/charts/drupal/templates/solr-statefulset.yaml
@@ -84,6 +84,9 @@ spec:
       volumes:
       - name: {{ .Release.Name }}-core-dir
         emptyDir: {}
+      securityContext:
+        runAsUser: 0
+        runAsGroup: 0
       serviceAccountName: {{ include "drupal.serviceAccountName" . }}
   volumeClaimTemplates:
   - metadata:

--- a/charts/drupal/values.yaml
+++ b/charts/drupal/values.yaml
@@ -887,7 +887,8 @@ smtp:
 # Solr.
 solr:
   enabled: false
-  # Available image tags: https://hub.docker.com/r/geerlingguy/solr/tags
+  # Official image tags: https://hub.docker.com/_/solr/tags
+  # Versions before 9.x: https://hub.docker.com/r/geerlingguy/solr/tags
   image: wunderio/silta-solr
   imageTag: 8-v1
 


### PR DESCRIPTION
Currently, our solr images run as root (because of dockerfile) and solr user in geerlingguy images is uid 1000 while solr images is 8983 so migration would requires permission change.
So we just force this to run as root because of write access to data in older mounts, but also because solr uid varies between images. 
This can be removed when everyone has migrated to 9.x images that use "solr" uid 8983 by default. Then the `fsGroup` can be set to `8983`.