### PR TITLE
Update silta-nginx to version 1.30

### DIFF
--- a/silta/nginx.Dockerfile
+++ b/silta/nginx.Dockerfile
@@ -1,4 +1,4 @@
 # Dockerfile for building nginx.
-FROM wunderio/silta-nginx:1.30-v1
+FROM wunderio/silta-nginx:latest
 
 COPY . /app/web


### PR DESCRIPTION
This PR aims to replace the usage of deprecated silta-nginx versions with the latest stable version 1.30.\nPlease review adjusted image tags and make sure this PR only changes relevant configuration files.\nTo use pinned version (1.30 tag) instead of latest change line to "FROM wunderio/silta-nginx:1.30-v1".\n\nTest that any custom nginx configurations are still working as expected, as there might be breaking changes between versions.\n\nThis is automated pull request. Ask OPS team for guidance if you have any questions or concerns regarding this update.\n