### PR TITLE
Custom clusterissuer support; Old cert-manager api deprecation

### DIFF
--- a/charts/drupal/templates/drupal-certificate.yaml
+++ b/charts/drupal/templates/drupal-certificate.yaml
@@ -30,7 +30,7 @@ spec:
     rotationPolicy: "Always"
 ---
 {{- range $index, $prefix := .Values.domainPrefixes }}
-{{- $params := dict "prefix" $prefix  -}}
+{{- $params := dict "prefix" $prefix  }}
 apiVersion: {{ include "cert-manager.api-version" $ | trim }}
 kind: Certificate
 metadata:
@@ -81,7 +81,7 @@ spec:
     rotationPolicy: "Always"
 ---
 {{- range $index, $prefix := .Values.domainPrefixes }}
-{{- $params := dict "prefix" $prefix  -}}
+{{- $params := dict "prefix" $prefix  }}
 apiVersion: {{ include "cert-manager.api-version" $ | trim }}
 kind: Certificate
 metadata:
@@ -132,6 +132,42 @@ data:
 ---
 {{- end }}
 
+{{- else }}
+apiVersion: {{ include "cert-manager.api-version" . | trim }}
+kind: Certificate
+metadata:
+  name: {{ .Release.Name }}-crt
+  labels:
+    {{- include "drupal.release_labels" . | nindent 4 }}
+spec:
+  secretName: {{ .Release.Name }}-tls
+  dnsNames:
+  - {{ include "drupal.domain" . | quote }}
+  issuerRef:
+    name: {{ $context_ssl.issuer }}
+    kind: ClusterIssuer
+  privateKey:
+    rotationPolicy: "Always"
+---
+{{- range $index, $prefix := .Values.domainPrefixes }}
+{{- $params := dict "prefix" $prefix  }}
+apiVersion: {{ include "cert-manager.api-version" $ | trim }}
+kind: Certificate
+metadata:
+  name: {{ $.Release.Name }}-crt-p{{ $index }}
+  labels:
+    {{- include "drupal.release_labels" $ | nindent 4 }}
+spec:
+  secretName: {{ $.Release.Name }}-tls-p{{ $index }}
+  dnsNames:
+  - '{{ include "drupal.domain" (merge $params $ ) }}'
+  issuerRef:
+    name: {{ $context_ssl.issuer }}
+    kind: ClusterIssuer
+  privateKey:
+    rotationPolicy: "Always"
+---
+{{- end }}
 {{- end }}
 {{- end }}
 
@@ -205,6 +241,24 @@ data:
   {{- end }}
   tls.crt: {{ $domain.ssl.crt | default "" | b64enc }}
   tls.key: {{ $domain.ssl.key | default "" | b64enc }}
+---
+{{- end }}
+{{- else }}
+apiVersion: {{ include "cert-manager.api-version" $ | trim }}
+kind: Certificate
+metadata:
+  name: {{ $.Release.Name }}-crt-{{ $index }}
+  labels:
+    {{- include "drupal.release_labels" $ | nindent 4 }}
+spec:
+  secretName: {{ $.Release.Name }}-tls-{{ $index }}
+  dnsNames:
+  - {{ $domain.hostname | quote }}
+  issuerRef:
+    name: {{ $domain.ssl.issuer }}
+    kind: ClusterIssuer
+  privateKey:
+    rotationPolicy: "Always"
 ---
 {{- end }}
 {{- end }}

--- a/charts/drupal/templates/drupal-certificate.yaml
+++ b/charts/drupal/templates/drupal-certificate.yaml
@@ -1,109 +1,7 @@
 {{- $context_ingress := .Values.ingress.default }}
 {{- $context_ssl := .Values.ssl }}
 {{- if $context_ingress.tls }}
-{{- if has $context_ssl.issuer (list "letsencrypt" "letsencrypt-staging") }}
-apiVersion: {{ include "cert-manager.api-version" . | trim }}
-kind: Certificate
-metadata:
-  name: {{ .Release.Name }}-crt
-  annotations:
-    cert-manager.io/issue-temporary-certificate: "true"
-    acme.cert-manager.io/http01-override-ingress-name: "{{ $.Release.Name }}-drupal"
-  labels:
-    {{- include "drupal.release_labels" . | nindent 4 }}
-spec:
-  secretName: {{ .Release.Name }}-tls
-  dnsNames:
-  - {{ include "drupal.domain" . | quote }}
-  issuerRef:
-    name: {{ $context_ssl.issuer }}
-    kind: ClusterIssuer
-{{- if eq ( include "cert-manager.api-version" . | trim ) "certmanager.k8s.io/v1alpha1" }}
-  acme:
-    config:
-      - http01:
-          ingress: {{ .Release.Name }}-drupal
-        domains:
-          - {{ template "drupal.domain" . }}
-{{- end }}
-  privateKey:
-    rotationPolicy: "Always"
----
-{{- range $index, $prefix := .Values.domainPrefixes }}
-{{- $params := dict "prefix" $prefix  }}
-apiVersion: {{ include "cert-manager.api-version" $ | trim }}
-kind: Certificate
-metadata:
-  name: {{ $.Release.Name }}-crt-p{{ $index }}
-  annotations:
-    cert-manager.io/issue-temporary-certificate: "true"
-    acme.cert-manager.io/http01-override-ingress-name: "{{ $.Release.Name }}-drupal"
-  labels:
-    {{- include "drupal.release_labels" $ | nindent 4 }}
-spec:
-  secretName: {{ $.Release.Name }}-tls-p{{ $index }}
-  dnsNames:
-  - '{{ include "drupal.domain" (merge $params $ ) }}'
-  issuerRef:
-    name: {{ $context_ssl.issuer }}
-    kind: ClusterIssuer
-{{- if eq ( include "cert-manager.api-version" $ | trim ) "certmanager.k8s.io/v1alpha1" }}
-  acme:
-    config:
-      - http01:
-          ingress: {{ $.Release.Name }}-drupal
-        domains:
-          - '{{ include "drupal.domain" (merge $params $ ) }}'
-{{- end }}
-  privateKey:
-    rotationPolicy: "Always"
----
-{{- end }}
-
-{{- else if eq $context_ssl.issuer "selfsigned" }}
-apiVersion: {{ include "cert-manager.api-version" . | trim }}
-kind: Certificate
-metadata:
-  name: {{ .Release.Name }}-crt
-  labels:
-    {{- include "drupal.release_labels" . | nindent 4 }}
-spec:
-  secretName: {{ .Release.Name }}-tls
-  duration: 2160h
-  renewBefore: 150h
-  commonName: {{ template "drupal.domain" . }}
-  dnsNames:
-  - {{ template "drupal.domain" . }}
-  issuerRef:
-    name: {{ $context_ssl.issuer }}
-    kind: ClusterIssuer
-  privateKey:
-    rotationPolicy: "Always"
----
-{{- range $index, $prefix := .Values.domainPrefixes }}
-{{- $params := dict "prefix" $prefix  }}
-apiVersion: {{ include "cert-manager.api-version" $ | trim }}
-kind: Certificate
-metadata:
-  name: {{ $.Release.Name }}-crt-p{{ $index }}
-  labels:
-    {{- include "drupal.release_labels" $ | nindent 4 }}
-spec:
-  secretName: {{ $.Release.Name }}-tls-p{{ $index }}
-  duration: 2160h
-  renewBefore: 150h
-  commonName: {{ include "drupal.domain" (merge $params $ ) }}
-  dnsNames:
-    - '{{ include "drupal.domain" (merge $params $ ) }}'
-  issuerRef:
-    name: {{ $context_ssl.issuer }}
-    kind: ClusterIssuer
-  privateKey:
-    rotationPolicy: "Always"
----
-{{- end }}
-
-{{- else if eq $context_ssl.issuer "custom" }}
+{{- if eq $context_ssl.issuer "custom" }}
 {{- if not $context_ssl.existingTLSSecret }}
 apiVersion: v1
 kind: Secret
@@ -117,7 +15,8 @@ data:
   tls.crt: {{ $context_ssl.crt | b64enc }}
   tls.key: {{ $context_ssl.key | b64enc }}
 ---
-{{- range $index, $prefix := .Values.domainPrefixes }}
+{{ range $index, $prefix := .Values.domainPrefixes }}
+{{- $params := dict "prefix" $prefix }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -131,16 +30,26 @@ data:
   tls.key: {{ $context_ssl.key | b64enc }}
 ---
 {{- end }}
-
+{{- end }}
 {{- else }}
-apiVersion: {{ include "cert-manager.api-version" . | trim }}
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: {{ .Release.Name }}-crt
+  {{- if has $context_ssl.issuer (list "letsencrypt" "letsencrypt-staging") }}
+  annotations:
+    cert-manager.io/issue-temporary-certificate: "true"
+    acme.cert-manager.io/http01-override-ingress-name: "{{ $.Release.Name }}-drupal"
+  {{- end }}
   labels:
     {{- include "drupal.release_labels" . | nindent 4 }}
 spec:
   secretName: {{ .Release.Name }}-tls
+  {{- if eq $context_ssl.issuer "selfsigned" }}
+  duration: 2160h
+  renewBefore: 150h
+  commonName: {{ template "drupal.domain" . }}
+  {{- end }}
   dnsNames:
   - {{ include "drupal.domain" . | quote }}
   issuerRef:
@@ -149,16 +58,26 @@ spec:
   privateKey:
     rotationPolicy: "Always"
 ---
-{{- range $index, $prefix := .Values.domainPrefixes }}
-{{- $params := dict "prefix" $prefix  }}
-apiVersion: {{ include "cert-manager.api-version" $ | trim }}
+{{ range $index, $prefix := .Values.domainPrefixes }}
+{{- $params := dict "prefix" $prefix }}
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: {{ $.Release.Name }}-crt-p{{ $index }}
+  {{- if has $context_ssl.issuer (list "letsencrypt" "letsencrypt-staging") }}
+  annotations:
+    cert-manager.io/issue-temporary-certificate: "true"
+    acme.cert-manager.io/http01-override-ingress-name: "{{ $.Release.Name }}-drupal"
+  {{- end }}
   labels:
     {{- include "drupal.release_labels" $ | nindent 4 }}
 spec:
   secretName: {{ $.Release.Name }}-tls-p{{ $index }}
+  {{- if eq $context_ssl.issuer "selfsigned" }}
+  duration: 2160h
+  renewBefore: 150h
+  commonName: {{ include "drupal.domain" (merge $params $ ) }}
+  {{- end }}
   dnsNames:
   - '{{ include "drupal.domain" (merge $params $ ) }}'
   issuerRef:
@@ -173,60 +92,10 @@ spec:
 
 # Certificates for exposeDomains
 {{- range $index, $domain := .Values.exposeDomains }}
-{{ $domain := merge $domain $.Values.exposeDomainsDefaults}}
+{{- $domain := mergeOverwrite ($.Values.exposeDomainsDefaults | toYaml | fromYaml) $domain }}
 {{- if $domain.ssl }}
 {{- if $domain.ssl.enabled }}
-{{- if has $domain.ssl.issuer (list "letsencrypt" "letsencrypt-staging") }}
-apiVersion: {{ include "cert-manager.api-version" $ | trim }}
-kind: Certificate
-metadata:
-  name: {{ $.Release.Name }}-crt-{{ $index }}
-  annotations:
-    cert-manager.io/issue-temporary-certificate: "true"
-    acme.cert-manager.io/http01-override-ingress-name: "{{ $.Release.Name }}-drupal-{{ $domain.ingress }}"
-  labels:
-    {{- include "drupal.release_labels" $ | nindent 4 }}
-spec:
-  secretName: {{ $.Release.Name }}-tls-{{ $index }}
-  dnsNames:
-  - {{ $domain.hostname | quote }}
-  issuerRef:
-    name: {{ $domain.ssl.issuer }}
-    kind: ClusterIssuer
-{{- if eq ( include "cert-manager.api-version" $ | trim ) "certmanager.k8s.io/v1alpha1" }}
-  acme:
-    config:
-      - http01:
-          ingress: {{ $.Release.Name }}-drupal-{{ $domain.ingress }}
-        domains:
-          - {{ $domain.hostname | quote }}
-{{- end }}
-  privateKey:
-    rotationPolicy: "Always"
----
-
-{{- else if eq $domain.ssl.issuer "selfsigned" }}
-apiVersion: {{ include "cert-manager.api-version" $ | trim }}
-kind: Certificate
-metadata:
-  name: {{ $.Release.Name }}-crt-{{ $index }}
-  labels:
-    {{- include "drupal.release_labels" $ | nindent 4 }}
-spec:
-  secretName: {{ $.Release.Name }}-tls-{{ $index }}
-  duration: 2160h
-  renewBefore: 150h
-  commonName: {{ $domain.hostname | quote }}
-  dnsNames:
-  - {{ $domain.hostname | quote }}
-  issuerRef:
-    name: {{ $domain.ssl.issuer }}
-    kind: ClusterIssuer
-  privateKey:
-    rotationPolicy: "Always"
----
-
-{{- else if eq $domain.ssl.issuer "custom" }}
+{{- if eq $domain.ssl.issuer "custom" }}
 {{- if not $domain.ssl.existingTLSSecret }}
 apiVersion: v1
 kind: Secret
@@ -244,14 +113,24 @@ data:
 ---
 {{- end }}
 {{- else }}
-apiVersion: {{ include "cert-manager.api-version" $ | trim }}
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: {{ $.Release.Name }}-crt-{{ $index }}
+  {{- if has $domain.ssl.issuer (list "letsencrypt" "letsencrypt-staging") }}
+  annotations:
+    cert-manager.io/issue-temporary-certificate: "true"
+    acme.cert-manager.io/http01-override-ingress-name: "{{ $.Release.Name }}-drupal-{{ $domain.ingress }}"
+  {{- end }}
   labels:
     {{- include "drupal.release_labels" $ | nindent 4 }}
 spec:
   secretName: {{ $.Release.Name }}-tls-{{ $index }}
+  {{- if eq $domain.ssl.issuer "selfsigned" }}
+  duration: 2160h
+  renewBefore: 150h
+  commonName: {{ $domain.hostname | quote }}
+  {{- end }}
   dnsNames:
   - {{ $domain.hostname | quote }}
   issuerRef:
@@ -260,8 +139,6 @@ spec:
   privateKey:
     rotationPolicy: "Always"
 ---
-{{- end }}
-{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/drupal/templates/drupal-ingress.yaml
+++ b/charts/drupal/templates/drupal-ingress.yaml
@@ -1,9 +1,9 @@
 {{- $ingress := .Values.ingress.default }}
 {{- $context_ssl := .Values.ssl }}
-{{- $letsencrypt_in_use := false }}
+{{- $cluster_issuer := "" }}
 {{- if $ingress.tls }}
-{{- if has $context_ssl.issuer (list "letsencrypt" "letsencrypt-staging") }}
-{{- $letsencrypt_in_use = true }}
+{{- if and (ne $context_ssl.issuer "selfsigned") (ne $context_ssl.issuer "custom") }}
+{{- $cluster_issuer = $context_ssl.issuer }}
 {{- end }}
 {{- end }}
 apiVersion: {{ include "ingress.api-version" . | trim }}
@@ -52,8 +52,8 @@ metadata:
     {{- end }}
 
     {{- if eq $ingress.type "gce" }}
-    {{- if $letsencrypt_in_use }}
-    cert-manager.io/cluster-issuer: letsencrypt
+    {{- if $cluster_issuer }}
+    cert-manager.io/cluster-issuer: {{ $cluster_issuer }}
     {{- end }}
     {{- end }}
     {{- if $ingress.staticIpAddressName }}
@@ -61,8 +61,8 @@ metadata:
     {{- end }}
 
     {{- if or (eq $ingress.type "azure/application-gateway") (eq $ingress.type "azure-application-gateway") }}
-    {{- if $letsencrypt_in_use }}
-    cert-manager.io/cluster-issuer: letsencrypt
+    {{- if $cluster_issuer }}
+    cert-manager.io/cluster-issuer: {{ $cluster_issuer }}
     {{- end }}
     appgw.ingress.kubernetes.io/health-probe-status-codes: "200-399, 401-404"
     {{- end }}
@@ -163,14 +163,14 @@ spec:
   {{- end }}
 {{- end }}
 
-{{- $letsencrypt_in_use := false }}
+{{- $cluster_issuer := "" }}
 {{- range $index, $domain := $.Values.exposeDomains }}
 {{ $domain := merge $domain $.Values.exposeDomainsDefaults}}
 {{- if eq $domain.ingress $ingress_index }}
 {{- if $domain.ssl }}
 {{- if $domain.ssl.enabled }}
-{{- if has $domain.ssl.issuer (list "letsencrypt" "letsencrypt-staging") }}
-{{- $letsencrypt_in_use = true }}
+{{- if and (ne $domain.ssl.issuer "selfsigned") (ne $domain.ssl.issuer "custom") }}
+{{- $cluster_issuer = $domain.ssl.issuer }}
 {{- end }}
 {{- end }}
 {{- end }}
@@ -224,8 +224,8 @@ metadata:
     {{- end }}
 
     {{- if eq $ingress.type "gce" }}
-    {{- if $letsencrypt_in_use }}
-    cert-manager.io/cluster-issuer: letsencrypt
+    {{- if $cluster_issuer }}
+    cert-manager.io/cluster-issuer: {{ $cluster_issuer }}
     {{- end }}
     {{- end }}
     {{- if $ingress.staticIpAddressName }}
@@ -233,8 +233,8 @@ metadata:
     {{- end }}
 
     {{- if or (eq $ingress.type "azure/application-gateway") (eq $ingress.type "azure-application-gateway") }}
-    {{- if $letsencrypt_in_use }}
-    cert-manager.io/cluster-issuer: letsencrypt
+    {{- if $cluster_issuer }}
+    cert-manager.io/cluster-issuer: {{ $cluster_issuer }}
     {{- end }}
     appgw.ingress.kubernetes.io/health-probe-status-codes: "200-399, 401-404"
     {{- end }}

--- a/charts/drupal/templates/drupal-ingress.yaml
+++ b/charts/drupal/templates/drupal-ingress.yaml
@@ -165,7 +165,7 @@ spec:
 
 {{- $cluster_issuer := "" }}
 {{- range $index, $domain := $.Values.exposeDomains }}
-{{ $domain := merge $domain $.Values.exposeDomainsDefaults}}
+{{- $domain := mergeOverwrite (deepCopy $.Values.exposeDomainsDefaults) $domain }}
 {{- if eq $domain.ingress $ingress_index }}
 {{- if $domain.ssl }}
 {{- if $domain.ssl.enabled }}

--- a/charts/drupal/templates/drupal-ingress.yaml
+++ b/charts/drupal/templates/drupal-ingress.yaml
@@ -15,11 +15,7 @@ metadata:
     kubernetes.io/ingress.class: {{ $ingress.type | quote }}
     {{- end }}
     {{- if $ingress.tls }}
-    {{- if eq ( include "cert-manager.api-version" $ | trim ) "cert-manager.io/v1" }}
     acme.cert-manager.io/http01-edit-in-place: "true"
-    {{- else }}
-    certmanager.k8s.io/acme-http01-edit-in-place: "true"
-    {{- end }}
     {{- if eq $ingress.type "traefik" }}
     traefik.ingress.kubernetes.io/frontend-entry-points: "http,https"
     {{- end }}
@@ -187,11 +183,7 @@ metadata:
     kubernetes.io/ingress.class: {{ $ingress.type | quote }}
     {{- end }}
     {{- if $ingress.tls }}
-    {{- if eq ( include "cert-manager.api-version" $ | trim ) "cert-manager.io/v1" }}
     acme.cert-manager.io/http01-edit-in-place: "true"
-    {{- else }}
-    certmanager.k8s.io/acme-http01-edit-in-place: "true"
-    {{- end }}
     {{- if eq $ingress.type "traefik" }}
     traefik.ingress.kubernetes.io/frontend-entry-points: "http,https"
     {{- end }}

--- a/charts/drupal/tests/drupal_certificate_test.yaml
+++ b/charts/drupal/tests/drupal_certificate_test.yaml
@@ -1,0 +1,429 @@
+suite: drupal certificate
+templates:
+  - drupal-certificate.yaml
+  - checks.yaml
+capabilities:
+  apiVersions:
+    - pxc.percona.com/v1
+tests:
+  - it: letsencrypt - creates a Certificate resource
+    template: drupal-certificate.yaml
+    asserts:
+      - documentIndex: 0
+        isKind:
+          of: Certificate
+
+  - it: letsencrypt - uses cert-manager.io/v1 apiVersion
+    template: drupal-certificate.yaml
+    asserts:
+      - documentIndex: 0
+        equal:
+          path: apiVersion
+          value: 'cert-manager.io/v1'
+
+  - it: letsencrypt - certificate has correct name
+    template: drupal-certificate.yaml
+    asserts:
+      - documentIndex: 0
+        equal:
+          path: metadata.name
+          value: 'RELEASE-NAME-crt'
+
+  - it: letsencrypt - certificate has ACME temporary certificate annotation
+    template: drupal-certificate.yaml
+    asserts:
+      - documentIndex: 0
+        equal:
+          path: metadata.annotations['cert-manager.io/issue-temporary-certificate']
+          value: 'true'
+
+  - it: letsencrypt - certificate has ACME http01 override ingress annotation
+    template: drupal-certificate.yaml
+    asserts:
+      - documentIndex: 0
+        equal:
+          path: metadata.annotations['acme.cert-manager.io/http01-override-ingress-name']
+          value: 'RELEASE-NAME-drupal'
+
+  - it: letsencrypt - certificate secretName is correct
+    template: drupal-certificate.yaml
+    asserts:
+      - documentIndex: 0
+        equal:
+          path: spec.secretName
+          value: 'RELEASE-NAME-tls'
+
+  - it: letsencrypt - certificate issuerRef is correct
+    template: drupal-certificate.yaml
+    asserts:
+      - documentIndex: 0
+        equal:
+          path: spec.issuerRef.name
+          value: 'letsencrypt'
+      - documentIndex: 0
+        equal:
+          path: spec.issuerRef.kind
+          value: 'ClusterIssuer'
+
+  - it: letsencrypt - certificate has no duration or renewBefore fields
+    template: drupal-certificate.yaml
+    asserts:
+      - documentIndex: 0
+        notExists:
+          path: spec.duration
+      - documentIndex: 0
+        notExists:
+          path: spec.renewBefore
+
+  - it: letsencrypt-staging - creates Certificate with staging issuerRef
+    template: drupal-certificate.yaml
+    set:
+      ssl.issuer: letsencrypt-staging
+    asserts:
+      - documentIndex: 0
+        isKind:
+          of: Certificate
+      - documentIndex: 0
+        equal:
+          path: spec.issuerRef.name
+          value: 'letsencrypt-staging'
+
+  - it: letsencrypt-staging - certificate has ACME annotations
+    template: drupal-certificate.yaml
+    set:
+      ssl.issuer: letsencrypt-staging
+    asserts:
+      - documentIndex: 0
+        equal:
+          path: metadata.annotations['cert-manager.io/issue-temporary-certificate']
+          value: 'true'
+      - documentIndex: 0
+        equal:
+          path: metadata.annotations['acme.cert-manager.io/http01-override-ingress-name']
+          value: 'RELEASE-NAME-drupal'
+
+  - it: selfsigned - creates Certificate resource
+    template: drupal-certificate.yaml
+    set:
+      ssl.issuer: selfsigned
+    asserts:
+      - documentIndex: 0
+        isKind:
+          of: Certificate
+
+  - it: selfsigned - certificate has duration and renewBefore fields
+    template: drupal-certificate.yaml
+    set:
+      ssl.issuer: selfsigned
+    asserts:
+      - documentIndex: 0
+        equal:
+          path: spec.duration
+          value: '2160h'
+      - documentIndex: 0
+        equal:
+          path: spec.renewBefore
+          value: '150h'
+
+  - it: selfsigned - certificate has no ACME annotations
+    template: drupal-certificate.yaml
+    set:
+      ssl.issuer: selfsigned
+    asserts:
+      - documentIndex: 0
+        notExists:
+          path: metadata.annotations
+
+  - it: selfsigned - certificate issuerRef is correct
+    template: drupal-certificate.yaml
+    set:
+      ssl.issuer: selfsigned
+    asserts:
+      - documentIndex: 0
+        equal:
+          path: spec.issuerRef.name
+          value: 'selfsigned'
+      - documentIndex: 0
+        equal:
+          path: spec.issuerRef.kind
+          value: 'ClusterIssuer'
+
+  - it: custom - creates a kubernetes.io/tls Secret
+    template: drupal-certificate.yaml
+    set:
+      ssl.issuer: custom
+      ssl.ca: myca
+      ssl.crt: mycrt
+      ssl.key: mykey
+    asserts:
+      - documentIndex: 0
+        isKind:
+          of: Secret
+      - documentIndex: 0
+        equal:
+          path: type
+          value: 'kubernetes.io/tls'
+
+  - it: custom - secret has correct name
+    template: drupal-certificate.yaml
+    set:
+      ssl.issuer: custom
+      ssl.ca: myca
+      ssl.crt: mycrt
+      ssl.key: mykey
+    asserts:
+      - documentIndex: 0
+        equal:
+          path: metadata.name
+          value: 'RELEASE-NAME-tls-custom'
+
+  - it: custom - existingTLSSecret skips resource creation
+    template: drupal-certificate.yaml
+    set:
+      ssl.issuer: custom
+      ssl.existingTLSSecret: my-existing-secret
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: generic issuer - creates Certificate resource
+    template: drupal-certificate.yaml
+    set:
+      ssl.issuer: my-cluster-issuer
+    asserts:
+      - documentIndex: 0
+        isKind:
+          of: Certificate
+
+  - it: generic issuer - certificate has correct issuerRef
+    template: drupal-certificate.yaml
+    set:
+      ssl.issuer: my-cluster-issuer
+    asserts:
+      - documentIndex: 0
+        equal:
+          path: spec.issuerRef.name
+          value: 'my-cluster-issuer'
+      - documentIndex: 0
+        equal:
+          path: spec.issuerRef.kind
+          value: 'ClusterIssuer'
+
+  - it: generic issuer - certificate has no ACME annotations
+    template: drupal-certificate.yaml
+    set:
+      ssl.issuer: my-cluster-issuer
+    asserts:
+      - documentIndex: 0
+        notExists:
+          path: metadata.annotations
+
+  - it: generic issuer - certificate has no duration or renewBefore fields
+    template: drupal-certificate.yaml
+    set:
+      ssl.issuer: my-cluster-issuer
+    asserts:
+      - documentIndex: 0
+        notExists:
+          path: spec.duration
+      - documentIndex: 0
+        notExists:
+          path: spec.renewBefore
+
+  - it: tls disabled - no certificate resources are rendered
+    template: drupal-certificate.yaml
+    set:
+      ingress.default.tls: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: domainPrefixes - creates additional Certificate per prefix
+    template: drupal-certificate.yaml
+    set:
+      domainPrefixes: ['en', 'fi']
+    asserts:
+      - hasDocuments:
+          count: 3
+      - documentIndex: 0
+        equal:
+          path: metadata.name
+          value: 'RELEASE-NAME-crt'
+      - documentIndex: 1
+        isKind:
+          of: Certificate
+      - documentIndex: 1
+        equal:
+          path: metadata.name
+          value: 'RELEASE-NAME-crt-p0'
+      - documentIndex: 1
+        equal:
+          path: spec.secretName
+          value: 'RELEASE-NAME-tls-p0'
+
+  - it: domainPrefixes letsencrypt - prefix certificates have ACME annotations
+    template: drupal-certificate.yaml
+    set:
+      domainPrefixes: ['en']
+    asserts:
+      - documentIndex: 1
+        equal:
+          path: metadata.annotations['cert-manager.io/issue-temporary-certificate']
+          value: 'true'
+
+  - it: domainPrefixes selfsigned - prefix certificates have duration fields
+    template: drupal-certificate.yaml
+    set:
+      ssl.issuer: selfsigned
+      domainPrefixes: ['en']
+    asserts:
+      - documentIndex: 1
+        equal:
+          path: spec.duration
+          value: '2160h'
+      - documentIndex: 1
+        equal:
+          path: spec.renewBefore
+          value: '150h'
+
+  - it: domainPrefixes custom - prefix certificates are Secrets
+    template: drupal-certificate.yaml
+    set:
+      ssl.issuer: custom
+      ssl.ca: myca
+      ssl.crt: mycrt
+      ssl.key: mykey
+      domainPrefixes: ['en']
+    asserts:
+      - documentIndex: 1
+        isKind:
+          of: Secret
+      - documentIndex: 1
+        equal:
+          path: metadata.name
+          value: 'RELEASE-NAME-tls-p0-custom'
+
+  - it: exposeDomains - letsencrypt creates Certificate with ACME annotations
+    template: drupal-certificate.yaml
+    set:
+      exposeDomains:
+        example:
+          hostname: example.com
+    asserts:
+      - documentIndex: 1
+        isKind:
+          of: Certificate
+      - documentIndex: 1
+        equal:
+          path: metadata.name
+          value: 'RELEASE-NAME-crt-example'
+      - documentIndex: 1
+        equal:
+          path: spec.secretName
+          value: 'RELEASE-NAME-tls-example'
+      - documentIndex: 1
+        equal:
+          path: metadata.annotations['cert-manager.io/issue-temporary-certificate']
+          value: 'true'
+
+  - it: exposeDomains - letsencrypt annotation references correct ingress name
+    template: drupal-certificate.yaml
+    set:
+      exposeDomains:
+        example:
+          hostname: example.com
+    asserts:
+      - documentIndex: 1
+        equal:
+          path: metadata.annotations['acme.cert-manager.io/http01-override-ingress-name']
+          value: 'RELEASE-NAME-drupal-default'
+
+  - it: exposeDomains - letsencrypt certificate has correct issuerRef
+    template: drupal-certificate.yaml
+    set:
+      exposeDomains:
+        example:
+          hostname: example.com
+    asserts:
+      - documentIndex: 1
+        equal:
+          path: spec.issuerRef.name
+          value: 'letsencrypt'
+
+  - it: exposeDomains - selfsigned creates Certificate with duration fields
+    template: drupal-certificate.yaml
+    set:
+      exposeDomains:
+        example:
+          hostname: example.com
+          ssl:
+            issuer: selfsigned
+    asserts:
+      - documentIndex: 1
+        isKind:
+          of: Certificate
+      - documentIndex: 1
+        equal:
+          path: spec.duration
+          value: '2160h'
+      - documentIndex: 1
+        equal:
+          path: spec.renewBefore
+          value: '150h'
+      - documentIndex: 1
+        notExists:
+          path: metadata.annotations
+
+  - it: exposeDomains - custom creates a kubernetes.io/tls Secret
+    template: drupal-certificate.yaml
+    set:
+      exposeDomains:
+        example:
+          hostname: example.com
+          ssl:
+            issuer: custom
+            crt: mycrt
+            key: mykey
+    asserts:
+      - documentIndex: 1
+        isKind:
+          of: Secret
+      - documentIndex: 1
+        equal:
+          path: metadata.name
+          value: 'RELEASE-NAME-tls-example-custom'
+      - documentIndex: 1
+        equal:
+          path: type
+          value: 'kubernetes.io/tls'
+
+  - it: exposeDomains - generic issuer creates Certificate without ACME annotations
+    template: drupal-certificate.yaml
+    set:
+      exposeDomains:
+        example:
+          hostname: example.com
+          ssl:
+            issuer: my-cluster-issuer
+    asserts:
+      - documentIndex: 1
+        isKind:
+          of: Certificate
+      - documentIndex: 1
+        equal:
+          path: spec.issuerRef.name
+          value: 'my-cluster-issuer'
+      - documentIndex: 1
+        notExists:
+          path: metadata.annotations
+
+  - it: exposeDomains - ssl disabled in exposeDomainsDefaults prevents certificate creation
+    template: drupal-certificate.yaml
+    set:
+      exposeDomainsDefaults.ssl.enabled: false
+      exposeDomains:
+        example:
+          hostname: example.com
+    asserts:
+      - hasDocuments:
+          count: 1


### PR DESCRIPTION
- Custom clusterIssuer support, certificate template refactor
- Old cert-manager api depreciation (`certmanager.k8s.io/v1alpha1`, [depreciated in v0.11](https://cert-manager.io/docs/releases/release-notes/release-notes-0.11/).
- Fixes `ssl.enabled:false` cases with mergeOverwrite